### PR TITLE
Formalize test management flow: User Story → TestLink → YAML

### DIFF
--- a/.claude/commands/add-test.md
+++ b/.claude/commands/add-test.md
@@ -4,15 +4,32 @@ The user will provide: **$ARGUMENTS** (suite name and description of what to tes
 
 ## Steps
 
-1. **Determine the suite** — build, runtime, inference, or models.
+1. **Identify user story** — Ask the user for the GitHub issue number, or create one if needed.
 
-2. **Find next ID** — Check existing test cases to auto-increment:
+2. **Determine the suite** — build, runtime, inference, or models.
+
+3. **Find next ID** — Check existing test cases to auto-increment:
 
 ```bash
 ls cicd/tests/testcases/<suite>/
 ```
 
-3. **Create the YAML test case** at `cicd/tests/testcases/<suite>/TC-<SUITE>-<NNN>.yml`:
+4. **Create TestLink test case** — Use MCP tool to create the test case in TestLink:
+
+```
+mcp__testlink__create_test_case:
+  project_id: "1"
+  suite_id: "<suite ID>"  # Build=2, Inference=3, Runtime=39, Models=122
+  name: "TC-<SUITE>-<NNN>: <Descriptive Name>"
+  summary: "Related to #<issue>. <What this test validates.>"
+  steps: [{ actions: "<command>", expected_results: "<expected>" }]
+  importance: 2
+  execution_type: 2
+```
+
+Record the returned `tc_external_id` as the `testlink_id`.
+
+5. **Create the YAML test case** at `cicd/tests/testcases/<suite>/TC-<SUITE>-<NNN>.yml`:
 
 ```yaml
 id: TC-<SUITE>-<NNN>
@@ -21,6 +38,8 @@ suite: <suite>
 priority: <1-3>
 timeout: <milliseconds>
 dependencies: []
+testlink_id: ollama37-<N>
+issue: <github-issue-number>
 
 steps:
   - name: <step description>
@@ -38,28 +57,7 @@ criteria: |
   - <condition 2>
 ```
 
-4. **Add spec entry** — Append the test specification to `cicd/specs/<suite>.md` following the existing format:
-
-```markdown
----
-
-## TC-<SUITE>-<NNN>: <Name>
-
-**Importance:** <High/Medium/Low>
-**Execution Type:** Automated
-**Timeout:** <seconds> seconds
-
-**Summary:**
-<What this test verifies>
-
-### Steps
-
-| # | Action | Expected Result |
-|---|--------|-----------------|
-| 1 | <command> | <expected output> |
-```
-
-5. **Verify** — Run the new test:
+6. **Verify** — Run the new test:
 
 ```bash
 cd cicd/tests && npm run test -- --suite <suite>

--- a/.claude/skills/add-test.md
+++ b/.claude/skills/add-test.md
@@ -6,14 +6,45 @@ argument-hint: <suite> <test-name>
 
 # Add Test
 
-Create a new YAML test case and its spec entry for the ollama37 test framework. Use `/add-test` to create.
+Create a new test case following the **Test Management Flow**: User Story → TestLink → YAML.
 
 ## When to use
 - After implementing a feature that needs test coverage
 - When adding regression tests for a bug fix
 - When expanding test coverage for an existing suite
 
-## Test suites
+## Flow
+
+### 1. Identify the User Story
+- Every test must trace to a GitHub Issue
+- If no issue exists, create one first (or ask the user)
+
+### 2. Create TestLink Test Case
+- Use MCP tools to create the test case in TestLink
+- TestLink is the **design authority** — define steps and expected results here first
+- Include the GitHub issue reference in the summary field
+
+**TestLink reference:**
+| Suite | TestLink Suite ID |
+|-------|------------------|
+| Build | 2 |
+| Inference | 3 |
+| Runtime | 39 |
+| Models | 122 |
+
+**MCP tool:** `mcp__testlink__create_test_case`
+- `project_id`: "1"
+- `suite_id`: suite ID from table above
+- `name`: "TC-<SUITE>-<NNN>: <Descriptive Name>"
+- `summary`: include "Related to #N" for GitHub issue link
+- `steps`: array of `{ actions, expected_results }`
+- `importance`: 1 (low), 2 (medium), 3 (high)
+- `execution_type`: 2 (automated)
+
+### 3. Create YAML Test Script
+YAML is the **execution authority** — what actually runs in CI.
+
+**Test suites:**
 | Suite | Directory | ID prefix |
 |-------|-----------|-----------|
 | build | `cicd/tests/testcases/build/` | TC-BUILD |
@@ -21,7 +52,8 @@ Create a new YAML test case and its spec entry for the ollama37 test framework. 
 | inference | `cicd/tests/testcases/inference/` | TC-INFERENCE |
 | models | `cicd/tests/testcases/models/` | TC-MODELS |
 
-## Test case format (YAML)
+**Test case format (YAML):**
+
 Required fields:
 - `id` — Unique ID (e.g. `TC-BUILD-004`)
 - `name` — Descriptive name
@@ -29,10 +61,12 @@ Required fields:
 - `priority` — Integer (1 = highest)
 - `timeout` — Milliseconds
 - `dependencies` — List of prerequisite test IDs
+- `testlink_id` — TestLink external ID (e.g. `ollama37-21`)
+- `issue` — GitHub issue number (e.g. `28`)
 - `steps` — List of step objects
 - `criteria` — LLM judge criteria string
 
-## Step fields
+**Step fields:**
 - `name` — Step description
 - `command` — Bash command to run
 - `expectPatterns` — List of regex patterns that must match output
@@ -41,5 +75,5 @@ Required fields:
 
 ## Related files
 - Test cases: `cicd/tests/testcases/<suite>/`
-- Specs: `cicd/specs/<suite>.md`
 - Framework docs: `cicd/README.md`
+- TestLink MCP tools: `mcp__testlink__*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,41 @@ This is the end-to-end flow for working on any project, issue, or story. **Alway
 
 **Key principle**: The issue is the single source of truth. Anyone reading it should see the full history — start, failures, fixes, and resolution.
 
+## Test Management Flow
+
+Test cases follow a **requirements-driven** flow: every test traces back to a user story.
+
+```
+GitHub Issue (User Story)  →  TestLink Test Case  →  YAML Test Script
+(what to validate)            (how to validate)      (automated execution)
+```
+
+### 1. User Story (GitHub Issue)
+- Created via `/plan` or manually
+- Describes WHAT needs testing and WHY
+- Has type + priority + component labels
+
+### 2. Test Case Design (TestLink)
+- Create test case in the appropriate suite via MCP tools (`mcp__testlink__create_test_case`)
+- Define steps, expected results, preconditions
+- Include GitHub issue reference in the summary field (e.g., "Related to #N")
+- Record the TestLink external ID (e.g., `ollama37-21`)
+
+### 3. Test Script (YAML)
+- Create executable YAML via `/add-test` skill
+- Must include `testlink_id` and `issue` fields linking back to TestLink and GitHub
+- PR includes the new YAML file
+
+### TestLink Reference
+- Project: ollama37 (ID: 1)
+- Test plan: "CI/CD Pipeline v1.0" (ID: 87)
+- Suites: Build (ID: 2), Inference (ID: 3), Runtime (ID: 39), Models (ID: 122)
+
+### Authorities
+- **TestLink** = design authority (what should be tested, how)
+- **YAML** = execution authority (what actually runs in CI)
+- If they conflict, update YAML to match TestLink
+
 ## Skill Quick Reference
 
 Extracted triggers and key rules from each skill. Use these to recognize when to load a skill, and as a fallback if the Skill tool is unavailable.
@@ -125,7 +160,7 @@ Extracted triggers and key rules from each skill. Use these to recognize when to
 
 ### add-test
 - **Trigger**: New feature or fix needs test coverage
-- **Key info**: YAML test cases in `cicd/tests/testcases/<suite>/`. ID format: `TC-<SUITE>-<NNN>`. Required fields: id, name, suite, priority, timeout, dependencies, steps, criteria.
+- **Key info**: Follows Test Management Flow: User Story → TestLink → YAML. YAML test cases in `cicd/tests/testcases/<suite>/`. ID format: `TC-<SUITE>-<NNN>`. Required fields: id, name, suite, priority, timeout, dependencies, testlink_id, issue, steps, criteria.
 
 ### trace
 - **Trigger**: Investigating unfamiliar code, understanding execution flow, before modifying unknown code

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -225,6 +225,8 @@ export class TestLoader {
       priority: typeof raw.priority === 'number' ? raw.priority : 1,
       timeout: typeof raw.timeout === 'number' ? raw.timeout : 60000,
       dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
+      testlinkId: typeof raw.testlink_id === 'string' ? raw.testlink_id : undefined,
+      issue: typeof raw.issue === 'number' ? raw.issue : undefined,
       steps,
       criteria: typeof raw.criteria === 'string' ? raw.criteria : '',
     };

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -38,6 +38,10 @@ export interface TestCase {
   timeout: number;
   /** Test IDs that must pass before this test runs */
   dependencies: string[];
+  /** TestLink external ID (e.g., ollama37-21) */
+  testlinkId?: string;
+  /** GitHub issue number this test traces to */
+  issue?: number;
   /** Test steps to execute */
   steps: TestStep[];
   /** Human-readable criteria for LLM judge evaluation */


### PR DESCRIPTION
## Summary
- Document requirements-driven test flow: GitHub Issue → TestLink → YAML
- Update `/add-test` skill and command to enforce the flow (TestLink before YAML)
- Add `testlink_id` and `issue` fields to YAML test case format and TypeScript types
- Remove stale `cicd/specs/` step from add-test command (TestLink replaces it)

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify `/add-test` flow works end-to-end with a real test case (e.g., qwen3.5 model test)

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)