### PR TITLE
Log LLM judge prompt and response token counts

### DIFF
--- a/cicd/tests/src/judge/llm-judge.ts
+++ b/cicd/tests/src/judge/llm-judge.ts
@@ -138,6 +138,9 @@ export class LLMJudge {
     );
 
     const responseText = response.data.response;
+    const promptTokens = response.data.prompt_eval_count ?? '?';
+    const responseTokens = response.data.eval_count ?? '?';
+    process.stderr.write(`  [LLM] Tokens for ${testId}: prompt=${promptTokens}, response=${responseTokens}\n`);
 
     // Log raw response
     if (!responseText) {


### PR DESCRIPTION
## Summary
- Extract `prompt_eval_count` and `eval_count` from Ollama API response
- Log actual token usage per test case for monitoring against 8K context limit
- Example output: `[LLM] Tokens for TC-BUILD-001: prompt=1557, response=68`

## Test plan
- [x] Verified with TC-BUILD-001: 4,501 chars → 1,557 prompt tokens, 68 response tokens
- [x] Token counts logged correctly alongside existing char-based logging

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)