### PR TITLE
Add FunctionGemma support

### DIFF
--- a/model/parsers/functiongemma.go
+++ b/model/parsers/functiongemma.go
@@ -1,0 +1,38 @@
+package parsers
+
+import (
+	"strings"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/tools"
+)
+
+type FunctionGemmaParser struct {
+	tools  []api.Tool
+	parser *tools.Parser
+}
+
+func (p *FunctionGemmaParser) Init(t []api.Tool, _ *api.Message) []api.Tool {
+	p.tools = t
+	p.parser = tools.NewParserWithTag(t, "<start_function_call>call:")
+	return t
+}
+
+func (p *FunctionGemmaParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
+	// Strip end tags from the content before parsing
+	s = strings.ReplaceAll(s, "<end_function_call>", "")
+
+	toolCalls, content := p.parser.Add(s)
+	if done && len(toolCalls) == 0 {
+		content += p.parser.Content()
+	}
+	return content, "", toolCalls, nil
+}
+
+func (p *FunctionGemmaParser) HasToolSupport() bool {
+	return true
+}
+
+func (p *FunctionGemmaParser) HasThinkingSupport() bool {
+	return false
+}

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -51,6 +51,8 @@ func ParserForName(name string) Parser {
 	case "qwen3.5":
 		parser := &Qwen3VLParser{hasThinkingSupport: true}
 		return parser
+	case "functiongemma":
+		return &FunctionGemmaParser{}
 	case "passthrough":
 		return &PassthroughParser{}
 	case "harmony":

--- a/model/renderers/functiongemma.go
+++ b/model/renderers/functiongemma.go
@@ -1,0 +1,120 @@
+package renderers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+func jsonString(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+type FunctionGemmaRenderer struct{}
+
+func (r *FunctionGemmaRenderer) Render(messages []api.Message, tools []api.Tool, _ *api.ThinkValue) (string, error) {
+	var sb strings.Builder
+
+	// Collect system messages
+	var system string
+	for _, m := range messages {
+		if m.Role == "system" {
+			if system == "" {
+				system = m.Content
+			} else {
+				system = system + "\n\n" + m.Content
+			}
+		}
+	}
+
+	// Developer turn: system message + tool declarations
+	if len(tools) > 0 || system != "" {
+		sb.WriteString("<start_of_turn>developer\n")
+		if system != "" {
+			sb.WriteString(system)
+		}
+		for _, tool := range tools {
+			sb.WriteString("<start_function_declaration>declaration:")
+			sb.WriteString(tool.Function.Name)
+			sb.WriteString("{description:<escape>")
+			sb.WriteString(tool.Function.Description)
+			sb.WriteString("<escape>,parameters:{properties:{")
+
+			first := true
+			for name, prop := range tool.Function.Parameters.Properties {
+				if !first {
+					sb.WriteString(",")
+				}
+				first = false
+				sb.WriteString(name)
+				sb.WriteString(":{description:<escape>")
+				sb.WriteString(prop.Description)
+				sb.WriteString("<escape>,type:<escape>")
+				if len(prop.Type) > 0 {
+					sb.WriteString(strings.ToUpper(prop.Type[0]))
+				}
+				sb.WriteString("<escape>")
+				if len(prop.Enum) > 0 {
+					sb.WriteString(",enum:[")
+					for i, e := range prop.Enum {
+						if i > 0 {
+							sb.WriteString(",")
+						}
+						sb.WriteString("<escape>")
+						sb.WriteString(fmt.Sprintf("%v", e))
+						sb.WriteString("<escape>")
+					}
+					sb.WriteString("]")
+				}
+				sb.WriteString("}")
+			}
+			sb.WriteString("},required:[")
+			for i, req := range tool.Function.Parameters.Required {
+				if i > 0 {
+					sb.WriteString(",")
+				}
+				sb.WriteString("<escape>")
+				sb.WriteString(req)
+				sb.WriteString("<escape>")
+			}
+			sb.WriteString("],type:<escape>OBJECT<escape>}}<end_function_declaration>")
+		}
+		sb.WriteString("\n<end_of_turn>\n")
+	}
+
+	// Render messages
+	for _, m := range messages {
+		switch m.Role {
+		case "system":
+			continue
+		case "user":
+			sb.WriteString("<start_of_turn>user\n")
+			sb.WriteString(m.Content)
+			sb.WriteString("<end_of_turn>\n")
+		case "assistant":
+			sb.WriteString("<start_of_turn>model\n")
+			if len(m.ToolCalls) > 0 {
+				for _, tc := range m.ToolCalls {
+					sb.WriteString("<start_function_call>call:")
+					sb.WriteString(tc.Function.Name)
+					sb.WriteString(jsonString(tc.Function.Arguments))
+					sb.WriteString("<end_function_call>")
+				}
+			} else {
+				sb.WriteString(m.Content)
+			}
+			sb.WriteString("<end_of_turn>\n")
+		case "tool":
+			sb.WriteString("<start_function_response>response:")
+			sb.WriteString(m.ToolName)
+			sb.WriteString(jsonString(m.Content))
+			sb.WriteString("<end_function_response>")
+		}
+	}
+
+	sb.WriteString("<start_of_turn>model\n")
+	return sb.String(), nil
+}

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -59,6 +59,8 @@ func rendererForName(name string) Renderer {
 	case "qwen3.5":
 		renderer := &Qwen3VLRenderer{isThinking: true, useImgTags: RenderImgTags}
 		return renderer
+	case "functiongemma":
+		return &FunctionGemmaRenderer{}
 	default:
 		return nil
 	}

--- a/template/functiongemma.gotmpl
+++ b/template/functiongemma.gotmpl
@@ -1,0 +1,46 @@
+{{- $system := "" }}
+{{- range .Messages }}
+{{- if eq .Role "system" }}
+{{- if not $system }}{{ $system = .Content }}
+{{- else }}{{ $system = printf "%s\n\n%s" $system .Content }}
+{{- end }}
+{{- continue }}
+{{- end }}
+{{- end }}
+{{- /* Developer turn: system message + tool declarations */ -}}
+{{- if or .Tools $system }}<start_of_turn>developer
+{{- if $system }}
+{{ $system }}
+{{- end }}
+{{- range .Tools }}
+<start_function_declaration>declaration:{{ .Function.Name }}{description:<escape>{{ .Function.Description }}<escape>,parameters:{properties:{
+{{- $first := true }}
+{{- range $name, $prop := .Function.Parameters.Properties }}
+{{- if not $first }},{{ end }}{{ $first = false }}{{ $name }}:{description:<escape>{{ $prop.Description }}<escape>,type:<escape>{{ index $prop.Type 0 | upper }}<escape>
+{{- if $prop.Enum }},enum:[{{ range $i, $e := $prop.Enum }}{{ if $i }},{{ end }}<escape>{{ $e }}<escape>{{ end }}]{{ end }}
+}
+{{- end }}},required:[
+{{- range $i, $r := .Function.Parameters.Required }}{{ if $i }},{{ end }}<escape>{{ $r }}<escape>{{ end }}],type:<escape>OBJECT<escape>}}<end_function_declaration>
+{{- end }}
+<end_of_turn>
+{{- end }}
+{{- range .Messages }}
+{{- if eq .Role "system" }}
+{{- continue }}
+{{- else if eq .Role "user" }}
+<start_of_turn>user
+{{ .Content }}<end_of_turn>
+{{- else if eq .Role "assistant" }}
+<start_of_turn>model
+{{- if .ToolCalls }}
+{{- range .ToolCalls }}
+<start_function_call>call:{{ .Function.Name }}{{ json .Function.Arguments }}<end_function_call>
+{{- end }}
+{{- else }}
+{{ .Content }}
+{{- end }}<end_of_turn>
+{{- else if eq .Role "tool" }}
+<start_function_response>response:{{ .ToolName }}{{ json .Content }}<end_function_response>
+{{- end }}
+{{- end }}
+<start_of_turn>model

--- a/template/functiongemma.json
+++ b/template/functiongemma.json
@@ -1,0 +1,6 @@
+{
+  "stop": [
+    "<start_of_turn>",
+    "<end_of_turn>"
+  ]
+}

--- a/template/template.go
+++ b/template/template.go
@@ -122,6 +122,7 @@ var funcs = template.FuncMap{
 		b, _ := json.Marshal(v)
 		return string(b)
 	},
+	"upper": strings.ToUpper,
 	"currentDate": func(args ...string) string {
 		// Currently ignoring the format argument, but accepting it for future use
 		// Default format is YYYY-MM-DD

--- a/template/testdata/functiongemma.gotmpl/system-user-assistant-user
+++ b/template/testdata/functiongemma.gotmpl/system-user-assistant-user
@@ -1,0 +1,10 @@
+<start_of_turn>developer
+You are a helpful assistant.
+<end_of_turn>
+<start_of_turn>user
+Hello, how are you?<end_of_turn>
+<start_of_turn>model
+I'm doing great. How can I help you today?<end_of_turn>
+<start_of_turn>user
+I'd like to show off how chat templating works!<end_of_turn>
+<start_of_turn>model

--- a/template/testdata/functiongemma.gotmpl/user
+++ b/template/testdata/functiongemma.gotmpl/user
@@ -1,0 +1,4 @@
+
+<start_of_turn>user
+Hello, how are you?<end_of_turn>
+<start_of_turn>model

--- a/template/testdata/functiongemma.gotmpl/user-assistant-user
+++ b/template/testdata/functiongemma.gotmpl/user-assistant-user
@@ -1,0 +1,8 @@
+
+<start_of_turn>user
+Hello, how are you?<end_of_turn>
+<start_of_turn>model
+I'm doing great. How can I help you today?<end_of_turn>
+<start_of_turn>user
+I'd like to show off how chat templating works!<end_of_turn>
+<start_of_turn>model

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bytes"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -327,7 +328,145 @@ func findArguments(tool *api.Tool, buffer []byte) (map[string]any, int) {
 		}
 	}
 
+	// Fallback: try FunctionGemma <escape>-delimited format
+	if bytes.Contains(buffer, []byte("<escape>")) {
+		return convertEscapeArgs(buffer)
+	}
+
 	return nil, 0
+}
+
+// convertEscapeArgs parses FunctionGemma's <escape>-delimited argument format.
+// Format: {key:<escape>value<escape>,key2:true,key3:123}
+// Returns nil if the buffer doesn't contain the <escape> token.
+func convertEscapeArgs(buffer []byte) (map[string]any, int) {
+	s := string(buffer)
+	if !strings.Contains(s, "<escape>") {
+		return nil, 0
+	}
+
+	// Find the first { that starts the arguments block
+	start := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == '{' {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		return nil, 0
+	}
+
+	// Find the matching closing brace, accounting for <escape> tokens
+	depth := 0
+	inEscape := false
+	end := -1
+	for i := start; i < len(s); i++ {
+		if i+8 <= len(s) && s[i:i+8] == "<escape>" {
+			inEscape = !inEscape
+			i += 7 // loop will increment by 1
+			continue
+		}
+		if inEscape {
+			continue
+		}
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				end = i
+				goto found
+			}
+		}
+	}
+	return nil, 0
+
+found:
+	inner := s[start+1 : end]
+	args := make(map[string]any)
+
+	for len(inner) > 0 {
+		inner = strings.TrimSpace(inner)
+		if len(inner) == 0 {
+			break
+		}
+
+		// Read key (up to first ':' that isn't inside <escape>)
+		colonIdx := -1
+		esc := false
+		for i := 0; i < len(inner); i++ {
+			if i+8 <= len(inner) && inner[i:i+8] == "<escape>" {
+				esc = !esc
+				i += 7
+				continue
+			}
+			if !esc && inner[i] == ':' {
+				colonIdx = i
+				break
+			}
+		}
+		if colonIdx == -1 {
+			break
+		}
+
+		key := strings.TrimSpace(inner[:colonIdx])
+		inner = inner[colonIdx+1:]
+
+		// Read value
+		inner = strings.TrimSpace(inner)
+		if strings.HasPrefix(inner, "<escape>") {
+			// String value delimited by <escape>...<escape>
+			inner = inner[8:] // skip opening <escape>
+			endEsc := strings.Index(inner, "<escape>")
+			if endEsc == -1 {
+				break
+			}
+			args[key] = inner[:endEsc]
+			inner = inner[endEsc+8:] // skip closing <escape>
+		} else if strings.HasPrefix(inner, "true") {
+			args[key] = true
+			inner = inner[4:]
+		} else if strings.HasPrefix(inner, "false") {
+			args[key] = false
+			inner = inner[5:]
+		} else {
+			// Read until comma or end of args
+			endVal := len(inner)
+			esc = false
+			for i := 0; i < len(inner); i++ {
+				if i+8 <= len(inner) && inner[i:i+8] == "<escape>" {
+					esc = !esc
+					i += 7
+					continue
+				}
+				if !esc && (inner[i] == ',' || inner[i] == '}') {
+					endVal = i
+					break
+				}
+			}
+			val := strings.TrimSpace(inner[:endVal])
+			if n, err := strconv.ParseFloat(val, 64); err == nil {
+				args[key] = n
+			} else {
+				args[key] = val
+			}
+			inner = inner[endVal:]
+		}
+
+		// Skip comma separator
+		inner = strings.TrimSpace(inner)
+		if len(inner) > 0 && inner[0] == ',' {
+			inner = inner[1:]
+		}
+	}
+
+	if len(args) == 0 {
+		return nil, 0
+	}
+
+	return args, end
 }
 
 // done checks if the parser is done parsing by looking

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1321,3 +1321,217 @@ func TestFindArguments(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertEscapeArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		buffer []byte
+		want   map[string]any
+	}{
+		{
+			name:   "no escape tokens",
+			buffer: []byte(`{"location": "London"}`),
+			want:   nil,
+		},
+		{
+			name:   "single string arg",
+			buffer: []byte(`{location:<escape>London<escape>}`),
+			want: map[string]any{
+				"location": "London",
+			},
+		},
+		{
+			name:   "multiple string args",
+			buffer: []byte(`{location:<escape>San Francisco<escape>,format:<escape>celsius<escape>}`),
+			want: map[string]any{
+				"location": "San Francisco",
+				"format":   "celsius",
+			},
+		},
+		{
+			name:   "boolean arg",
+			buffer: []byte(`{verbose:true,location:<escape>Tokyo<escape>}`),
+			want: map[string]any{
+				"verbose":  true,
+				"location": "Tokyo",
+			},
+		},
+		{
+			name:   "numeric arg",
+			buffer: []byte(`{count:42,location:<escape>Paris<escape>}`),
+			want: map[string]any{
+				"count":    float64(42),
+				"location": "Paris",
+			},
+		},
+		{
+			name:   "with surrounding context",
+			buffer: []byte(`call:get_weather{location:<escape>London<escape>}<end_function_call>`),
+			want: map[string]any{
+				"location": "London",
+			},
+		},
+		{
+			name:   "value with colon",
+			buffer: []byte(`{url:<escape>http://example.com<escape>}`),
+			want: map[string]any{
+				"url": "http://example.com",
+			},
+		},
+		{
+			name:   "empty args",
+			buffer: []byte(`{}<escape>ignored<escape>`),
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := convertEscapeArgs(tt.buffer)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("convertEscapeArgs() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFunctionGemmaParser(t *testing.T) {
+	functiongemma, err := template.New("functiongemma").Parse(`{{if .ToolCalls}}{{range .ToolCalls}}
+<start_function_call>call:{{ .Function.Name }}{{ .Function.Arguments }}<end_function_call>{{end}}{{end}}`)
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+
+	tools := []api.Tool{
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get weather for a location",
+				Parameters: api.ToolFunctionParameters{
+					Type:     "object",
+					Required: []string{"location"},
+					Properties: map[string]api.ToolProperty{
+						"location": {
+							Type:        api.PropertyType{"string"},
+							Description: "The city name",
+						},
+					},
+				},
+			},
+		},
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "search",
+				Description: "Search the web",
+				Parameters: api.ToolFunctionParameters{
+					Type: "object",
+					Properties: map[string]api.ToolProperty{
+						"query": {
+							Type:        api.PropertyType{"string"},
+							Description: "Search query",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		inputs  []string
+		content string
+		calls   []api.ToolCall
+	}{
+		{
+			name:    "single function call",
+			inputs:  []string{"<start_function_call>call:get_weather{location:<escape>London<escape>}<end_function_call>"},
+			content: "",
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_weather",
+						Arguments: api.ToolCallFunctionArguments{
+							"location": "London",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "text before function call",
+			inputs:  []string{"Let me check. <start_function_call>call:get_weather{location:<escape>Tokyo<escape>}<end_function_call>"},
+			content: "Let me check. ",
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_weather",
+						Arguments: api.ToolCallFunctionArguments{
+							"location": "Tokyo",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "incremental streaming",
+			inputs: []string{
+				"<start_function_call>",
+				"call:get_weather",
+				"{location:<escape>",
+				"San Francisco",
+				"<escape>}",
+				"<end_function_call>",
+			},
+			content: "",
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_weather",
+						Arguments: api.ToolCallFunctionArguments{
+							"location": "San Francisco",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "no tool call - just text",
+			inputs:  []string{"Hello, how can I help?"},
+			content: "Hello, how can I help?",
+			calls:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewParser(functiongemma, tools)
+
+			var calls []api.ToolCall
+			var content string
+			for _, input := range tt.inputs {
+				tcs, c := parser.Add(input)
+				calls = append(calls, tcs...)
+				content += c
+			}
+
+			if content != tt.content {
+				t.Errorf("Expected content %q, got %q", tt.content, content)
+			}
+
+			if len(calls) != len(tt.calls) {
+				t.Fatalf("Expected %d tool calls, got %d", len(tt.calls), len(calls))
+			}
+
+			for i, want := range tt.calls {
+				if diff := cmp.Diff(calls[i], want); diff != "" {
+					t.Errorf("Tool call %d mismatch (-got +want):\n%s", i, diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add renderer and parser for FunctionGemma model (`RENDERER functiongemma` / `PARSER functiongemma` from GGUF metadata)
- Add chat template with developer/user/model roles and `<start_function_declaration>` tool definitions
- Add `convertEscapeArgs()` fallback in tool parser for FunctionGemma's `<escape>`-delimited argument format
- Add `upper` template function for type formatting
- Tests: escape-args parser (8 cases), streaming parser (4 cases), template golden files (3 cases)

## Test plan
- [x] Unit tests pass: `go test ./tools/ ./template/ -count=1`
- [x] Docker image builds successfully
- [x] `ollama run functiongemma:270m` responds without errors

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)