### PR TITLE
Fix ministral-3 support: template function and YaRN RoPE

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -267,11 +267,13 @@ func (pt PropertyType) String() string {
 }
 
 type ToolProperty struct {
-	AnyOf       []ToolProperty `json:"anyOf,omitempty"`
-	Type        PropertyType   `json:"type,omitempty"`
-	Items       any            `json:"items,omitempty"`
-	Description string         `json:"description,omitempty"`
-	Enum        []any          `json:"enum,omitempty"`
+	AnyOf       []ToolProperty          `json:"anyOf,omitempty"`
+	Type        PropertyType            `json:"type,omitempty"`
+	Items       any                     `json:"items,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	Enum        []any                   `json:"enum,omitempty"`
+	Properties  map[string]ToolProperty `json:"properties,omitempty"`
+	Required    []string                `json:"required,omitempty"`
 }
 
 // ToTypeScriptType converts a ToolProperty to a TypeScript type string

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -81,7 +81,8 @@ build-runtime: ensure-builder
 	@echo "→ Building runtime image..."
 	@echo "  Image: $(RUNTIME_IMAGE):$(RUNTIME_TAG)"
 	@echo "  Dockerfile: $(RUNTIME_DOCKERFILE)"
-	@echo "  Source: GitHub (uses cache)"
+	@echo "  Source: GitHub (cache-busted by commit hash)"
+	@echo "  Commit: $(shell git rev-parse HEAD)"
 	@echo ""
 	@echo "  This will:"
 	@echo "    - Clone ollama37 source from GitHub"
@@ -92,6 +93,7 @@ build-runtime: ensure-builder
 	@echo ""
 	@docker build \
 		--build-arg OLLAMA_VERSION=$(OLLAMA_VERSION) \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
 		-f $(RUNTIME_DOCKERFILE) \
 		-t $(RUNTIME_IMAGE):$(RUNTIME_TAG) \
 		$(RUNTIME_CONTEXT)
@@ -119,6 +121,7 @@ build-runtime-no-cache: ensure-builder
 	@echo ""
 	@docker build --no-cache \
 		--build-arg OLLAMA_VERSION=$(OLLAMA_VERSION) \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
 		-f $(RUNTIME_DOCKERFILE) \
 		-t $(RUNTIME_IMAGE):$(RUNTIME_TAG) \
 		$(RUNTIME_CONTEXT)
@@ -145,6 +148,7 @@ build-runtime-local: ensure-builder
 	@echo ""
 	@docker build \
 		--build-arg OLLAMA_VERSION=$(OLLAMA_VERSION) \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
 		-f $(RUNTIME_DOCKERFILE_LOCAL) \
 		-t $(RUNTIME_IMAGE):$(RUNTIME_TAG) \
 		$(RUNTIME_CONTEXT)
@@ -172,6 +176,7 @@ build-runtime-local-no-cache: ensure-builder
 	@echo ""
 	@docker build --no-cache \
 		--build-arg OLLAMA_VERSION=$(OLLAMA_VERSION) \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
 		-f $(RUNTIME_DOCKERFILE_LOCAL) \
 		-t $(RUNTIME_IMAGE):$(RUNTIME_TAG) \
 		$(RUNTIME_CONTEXT)

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -9,9 +9,14 @@
 # Builder image: ollama37-builder contains GCC 10, CUDA 11.4, and build tools
 FROM ollama37-builder AS builder
 
+# GIT_COMMIT busts Docker cache when new commits are pushed to GitHub.
+# Without this, Docker caches the git clone layer and never picks up new code.
+ARG GIT_COMMIT=HEAD
 # Clone ollama37 source code from GitHub
 RUN cd /usr/local/src \
-    && git clone https://github.com/dogkeeper886/ollama37.git
+    && git clone https://github.com/dogkeeper886/ollama37.git \
+    && cd ollama37 \
+    && git checkout ${GIT_COMMIT}
 
 # Set working directory for build
 WORKDIR /usr/local/src/ollama37

--- a/docker/runtime/Dockerfile.local
+++ b/docker/runtime/Dockerfile.local
@@ -13,6 +13,10 @@
 # Builder image: ollama37-builder contains GCC 10, CUDA 11.4, and build tools
 FROM ollama37-builder AS builder
 
+# GIT_COMMIT invalidates Docker cache when local source changes.
+# Even though COPY detects file changes, cached builder layers above
+# can mask stale builds. This arg ensures rebuild on new commits.
+ARG GIT_COMMIT=HEAD
 # Copy local source code to container
 # Build context should be the repository root
 COPY . /usr/local/src/ollama37

--- a/docker/runtime/Dockerfile.local
+++ b/docker/runtime/Dockerfile.local
@@ -13,16 +13,18 @@
 # Builder image: ollama37-builder contains GCC 10, CUDA 11.4, and build tools
 FROM ollama37-builder AS builder
 
-# GIT_COMMIT invalidates Docker cache when local source changes.
-# Even though COPY detects file changes, cached builder layers above
-# can mask stale builds. This arg ensures rebuild on new commits.
-ARG GIT_COMMIT=HEAD
 # Copy local source code to container
 # Build context should be the repository root
 COPY . /usr/local/src/ollama37
 
 # Set working directory for build
 WORKDIR /usr/local/src/ollama37
+
+# GIT_COMMIT invalidates all subsequent layers when the commit hash changes.
+# Docker only busts cache on ARG when it's used in a RUN instruction.
+# Without this, COPY and subsequent RUN layers can be cached even when source changes.
+ARG GIT_COMMIT=HEAD
+RUN echo "Build commit: ${GIT_COMMIT}" > /tmp/build-commit
 
 # Configure build with CMake
 # Use "CUDA 11 K80" preset: compiles native CUBIN for sm_37 (no PTX JIT needed)

--- a/docs/traces/ministral3-garbage-output.md
+++ b/docs/traces/ministral3-garbage-output.md
@@ -1,0 +1,74 @@
+# Trace: ministral-3 garbage output — missing YaRN RoPE and position scaling
+
+## Symptom
+Model loads and generates tokens (no crash), but output is repetitive garbage:
+`ral**ral**ral**ral**ral...` — the model gets stuck in a loop.
+
+Also: `cudaMalloc failed: out of memory` during layer fitting (non-fatal, Ollama retries).
+
+## Model architecture
+- Architecture: `mistral3`, registered in `model/models/mistral3/model.go:167`
+- 27 layers, Q4_K_M quantization, 3.8B params (~3GB on disk)
+- Uses YaRN RoPE scaling (rope.scaling.type = "yarn" in GGUF)
+- FlashAttention: false on K80 (compute 3.7)
+
+## Root cause: missing YaRN RoPE options and position scaling
+
+### What upstream has (model_text.go)
+1. **`TextOptions`** includes YaRN fields: `ropeOrigPosEmbeddings`, `ropeScalingBeta`,
+   `ropeBetaFast`, `ropeBetaSlow`, `ropeType`, `ropeMscale`, `ropeMscaleAllDim`,
+   `ropeExtrapolation`
+2. **`applyRotaryPositionEmbeddings()`** dispatches to `nn.RoPE()` with YaRN options
+   when `ropeType == "yarn"`
+3. **`getScale()`** computes position-dependent query scaling:
+   `scale = 1 + beta * log(1 + floor(pos / origContextLen))`
+4. **`SelfAttention.Forward()`** applies `positionsScale` to query:
+   `q = q.Mul(ctx, positionsScale)` when `ropeOrigPosEmbeddings > 0`
+
+### What our fork had
+1. Basic `TextOptions` with only `ropeBase` and `ropeScale`
+2. Direct `fast.RoPE()` call without any YaRN options
+3. No `getScale()` function
+4. No position scaling on query tensors
+
+### Impact
+Without YaRN RoPE, the rotary position embeddings use wrong frequency bases
+for the model's expected context length scaling. Without position scaling,
+attention weights are computed incorrectly. Both cause the model to lose
+coherent generation and fall into repetitive loops.
+
+## Call flow
+```
+Model.Forward()                                    # model.go:160
+  ├── ctx.Input().FromInts(positions)              # position tensor
+  ├── TextModel.getScale(ctx, positions)           # NEW: position scaling
+  └── TextModel.Forward(inputs, pos, scale, ...)   # model_text.go:130
+      ├── TokenEmbedding.Forward()                 # model_text.go:131
+      └── for each Layer:
+          └── Layer.Forward(hiddenState, pos, posScale, ...)  # model_text.go:109
+              ├── AttentionNorm.Forward()
+              ├── SelfAttention.Forward(pos, posScale)        # model_text.go:70
+              │   ├── Query/Key/Value linear projections
+              │   ├── applyRotaryPositionEmbeddings(q, pos)   # NEW: YaRN RoPE
+              │   │   └── nn.RoPE(ctx, states, pos, dim, base, scale, yarnOpts...)
+              │   ├── applyRotaryPositionEmbeddings(k, pos)   # NEW: YaRN RoPE
+              │   ├── q.Mul(ctx, positionsScale)              # NEW: query scaling
+              │   └── nn.Attention(q, k, v, scale, cache)
+              │       └── SDPA fallback (no flash attention on K80)
+              ├── residual connection
+              └── MLP.Forward()
+```
+
+## Fix applied
+- Added YaRN RoPE fields to `TextOptions` and GGUF config loading
+- Added `applyRotaryPositionEmbeddings()` with YaRN dispatch
+- Added `getScale()` for position-dependent query scaling
+- Added `WithBetaFast`/`WithBetaSlow` to `ml/nn/rope/rope.go`
+- Updated `Forward()` signatures to pass `positionsScale`
+
+## Verified
+- [x] Upstream uses same `NewCausalCache` (not sliding window) — confirmed
+- [x] `rope.Options` struct already has YaRN fields in our fork
+- [x] `ggml_rope_ext` already passes BetaFast/BetaSlow to C layer
+- [x] `nn.RoPE` wrapper added in earlier commit delegates to fast.RoPE correctly
+- [ ] Awaiting CI validation with TC-MODELS-013

--- a/docs/traces/ministral3-memory-usage.md
+++ b/docs/traces/ministral3-memory-usage.md
@@ -1,0 +1,61 @@
+# Trace: ministral-3 memory usage on K80
+
+## Environment
+- 4× Tesla K80 GPUs (11.2 GiB free each)
+- Model: ministral-3:3b (mistral3 architecture, Q4_K_M, 3.8B params, 27 layers)
+- Parameters: BatchSize=512, KvSize=4096, FlashAttention=false
+
+## Allocation sequence
+
+Ollama tries GPU splits until one fits:
+
+| Attempt | Split | Result |
+|---------|-------|--------|
+| 1 (fit) | 27 on GPU0 | Doesn't fit |
+| 2 (fit) | 5/22 on GPU0/GPU1 | Fit OK |
+| 3 (alloc) | 5/22 on GPU0/GPU1 | `cudaMalloc failed: 9199.70 MiB on device 1` |
+| 4 (alloc) | 21/6 on GPU0/GPU2 | Retry |
+| 5 (alloc) | 11/14/2 on GPU0/GPU1/GPU3 | Retry |
+| 6 (alloc) | 12/12/3 on GPU0/GPU1/GPU2 | Retry |
+| 7 (alloc) | 12/12/3 on GPU0/GPU1/GPU3 | **Success** |
+
+Note: "fit" probes graph size without allocation; "alloc" actually allocates buffers.
+
+## Final memory breakdown
+
+| Resource | CUDA0 (12 layers) | CUDA1 (12 layers) | CUDA3 (3 layers) | CPU | Total |
+|----------|-------|-------|-------|-----|-------|
+| Weights | 797.5 MiB | 787.4 MiB | 1.2 GiB | 315.0 MiB | ~3.1 GiB |
+| KV cache | 192.0 MiB | 192.0 MiB | 32.0 MiB | — | 416 MiB |
+| Compute graph | 411.8 MiB | 400.0 MiB | **9.1 GiB** | 6.0 MiB | ~9.9 GiB |
+| **Per GPU total** | ~1.4 GiB | ~1.4 GiB | ~10.3 GiB | ~321 MiB | **13.3 GiB** |
+
+## Anomaly: 9.1 GiB compute graph on CUDA3
+
+CUDA3 has only 3 layers (24-26: last 2 transformer layers + output head) but 9.1 GiB compute graph.
+
+### Expected compute per layer (non-flash attention)
+- QK^T intermediate: heads × batch × kv_size × sizeof(F32) = 24 × 512 × 4096 × 4 = ~192 MiB
+- Softmax output: same size = ~192 MiB
+- V×attention output: smaller
+- Per layer total: ~400-500 MiB
+
+3 layers should be ~1.2-1.5 GiB, not 9.1 GiB. The extra ~7.6 GiB is unexplained.
+
+### Hypotheses
+1. **Output projection activation**: `[vocab_size × batch]` in F32 — but 32768 × 512 × 4 = only 64 MiB
+2. **GGML scheduler over-allocation**: `ggml_backend_sched_reserve` may allocate worst-case buffers for cross-GPU tensor transfers
+3. **Non-flash softmax intermediate storage**: Without flash attention, full `[batch, heads, seq, seq]` attention matrix may be materialized — but only for the layers on that GPU
+4. **Logit tensor**: Full vocab logits may be allocated on the GPU hosting the output layer
+
+### TODO
+- [ ] Add GGML debug logging to trace per-tensor allocations during graph reservation
+- [ ] Compare with flash attention enabled (on a newer GPU) to measure the non-flash overhead
+- [ ] Check if reducing BatchSize or KvSize shrinks the compute graph proportionally
+- [ ] Profile with `nvprof` to see actual VRAM usage during inference
+
+## Non-fatal cudaMalloc failure
+
+The `cudaMalloc failed: out of memory` at attempt 3 is **expected behavior**. Ollama's scheduler probes GPU memory by attempting allocations and retrying with different splits. This is not a bug — the model loads successfully after finding a working split.
+
+The simple judge flags this as a CUDA error because it pattern-matches `cudaMalloc failed` in Docker container logs. This is a false positive for the simple judge.

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -206,6 +206,9 @@ type Tensor interface {
 	Sqr(ctx Context) Tensor
 	Sqrt(ctx Context) Tensor
 	Clamp(ctx Context, min, max float32) Tensor
+
+	// Slice extracts a sub-tensor along the given dimension from start to end with stride.
+	Slice(ctx Context, dim, start, end, stride int) Tensor
 }
 
 // ScaledDotProductAttention implements a fused attention

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -1505,6 +1505,58 @@ func (t *Tensor) View(ctx ml.Context, offset int, shape ...int) ml.Tensor {
 	}
 }
 
+func (t *Tensor) Slice(ctx ml.Context, dim, start, end, stride int) ml.Tensor {
+	nDims := int(C.ggml_n_dims(t.t))
+	if dim < 0 || dim >= nDims {
+		panic("Slice: dimension out of range")
+	}
+
+	sliceLen := (end - start + stride - 1) / stride
+	offset := start * t.Stride(dim)
+
+	// Build shape/stride pairs for View: [ne0, nb1, ne1, nb2, ne2, ...]
+	// View expects interleaved (shape, stride) pairs after the first dimension
+	switch nDims {
+	case 1:
+		return t.View(ctx, offset, sliceLen)
+	case 2:
+		ne := [2]int{t.Dim(0), t.Dim(1)}
+		nb := [2]int{t.Stride(0), t.Stride(1)}
+		ne[dim] = sliceLen
+		return &Tensor{
+			b: t.b,
+			t: C.ggml_view_2d(ctx.(*Context).ctx, t.t,
+				C.int64_t(ne[0]), C.int64_t(ne[1]),
+				C.size_t(nb[1]),
+				C.size_t(offset)),
+		}
+	case 3:
+		ne := [3]int{t.Dim(0), t.Dim(1), t.Dim(2)}
+		nb := [3]int{t.Stride(0), t.Stride(1), t.Stride(2)}
+		ne[dim] = sliceLen
+		return &Tensor{
+			b: t.b,
+			t: C.ggml_view_3d(ctx.(*Context).ctx, t.t,
+				C.int64_t(ne[0]), C.int64_t(ne[1]), C.int64_t(ne[2]),
+				C.size_t(nb[1]), C.size_t(nb[2]),
+				C.size_t(offset)),
+		}
+	case 4:
+		ne := [4]int{t.Dim(0), t.Dim(1), t.Dim(2), t.Dim(3)}
+		nb := [4]int{t.Stride(0), t.Stride(1), t.Stride(2), t.Stride(3)}
+		ne[dim] = sliceLen
+		return &Tensor{
+			b: t.b,
+			t: C.ggml_view_4d(ctx.(*Context).ctx, t.t,
+				C.int64_t(ne[0]), C.int64_t(ne[1]), C.int64_t(ne[2]), C.int64_t(ne[3]),
+				C.size_t(nb[1]), C.size_t(nb[2]), C.size_t(nb[3]),
+				C.size_t(offset)),
+		}
+	default:
+		panic("Slice: unsupported number of dimensions")
+	}
+}
+
 func (t *Tensor) RoPE(ctx ml.Context, positions ml.Tensor, ropeDim int, ropeBase, ropeScale float32, options ...func(*rope.Options)) ml.Tensor {
 	// Default options
 	opts := rope.Options{Factors: &Tensor{}}

--- a/ml/nn/rope.go
+++ b/ml/nn/rope.go
@@ -1,0 +1,13 @@
+package nn
+
+import (
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/ml/nn/fast"
+	"github.com/ollama/ollama/ml/nn/rope"
+)
+
+// RoPE applies rotary positional embedding to tensor t.
+// This delegates to the fast (fused) implementation.
+func RoPE(ctx ml.Context, t, positions ml.Tensor, dim int, base, scale float32, options ...func(*rope.Options)) ml.Tensor {
+	return fast.RoPE(ctx, t, positions, dim, base, scale, options...)
+}

--- a/ml/nn/rope/rope.go
+++ b/ml/nn/rope/rope.go
@@ -57,6 +57,18 @@ func WithAttentionFactor(attentionFactor float32) func(*Options) {
 	}
 }
 
+func WithBetaFast(betaFast float32) func(*Options) {
+	return func(opts *Options) {
+		opts.YaRN.BetaFast = betaFast
+	}
+}
+
+func WithBetaSlow(betaSlow float32) func(*Options) {
+	return func(opts *Options) {
+		opts.YaRN.BetaSlow = betaSlow
+	}
+}
+
 func WithMRoPESections(sections []int) func(*Options) {
 	return func(opts *Options) {
 		opts.Type |= 1 << 3

--- a/model/models/gemma4/model.go
+++ b/model/models/gemma4/model.go
@@ -96,7 +96,7 @@ func New(c fs.Config) (model.Model, error) {
 	slog.Info("gemma4: token IDs", "image", imageTokenID, "image_end", imageEndTokenID, "audio", audioTokenID, "audio_end", audioEndTokenID)
 
 	m := Model{
-		Tokenizer:                t,
+		TextProcessor:            t,
 		TextModel:                newTextModel(c),
 		VisionModel:              newVisionModel(c),
 		AudioModel:               newAudioModel(c),

--- a/model/models/gemma4/model_audio.go
+++ b/model/models/gemma4/model_audio.go
@@ -112,25 +112,25 @@ func (l *AudioClippableLinear) loadClamps() {
 	}
 	l.clampsLoaded = true
 	if l.InputMin != nil {
-		vals := l.InputMin.BackendGet()
+		vals := l.InputMin.Floats()
 		if len(vals) > 0 {
 			l.inMin = vals[0]
 		}
 	}
 	if l.InputMax != nil {
-		vals := l.InputMax.BackendGet()
+		vals := l.InputMax.Floats()
 		if len(vals) > 0 {
 			l.inMax = vals[0]
 		}
 	}
 	if l.OutputMin != nil {
-		vals := l.OutputMin.BackendGet()
+		vals := l.OutputMin.Floats()
 		if len(vals) > 0 {
 			l.outMin = vals[0]
 		}
 	}
 	if l.OutputMax != nil {
-		vals := l.OutputMax.BackendGet()
+		vals := l.OutputMax.Floats()
 		if len(vals) > 0 {
 			l.outMax = vals[0]
 		}

--- a/model/models/gemma4/model_audio.go
+++ b/model/models/gemma4/model_audio.go
@@ -527,7 +527,14 @@ func (cb *AudioConformerBlock) forwardLightConv(ctx ml.Context, x ml.Tensor, opt
 			shifted = x
 		} else {
 			trimmed := x.Slice(ctx, 1, 0, seqLen-shift, 1).Contiguous(ctx)
-			shifted = trimmed.PadExt(ctx, 0, 0, shift, 0, 0, 0, 0, 0)
+			// PadExt equivalent: pad 'shift' zeros before dim 1 (causal padding).
+			// Strategy: pad 'shift' after dim1 (ggml_pad), then roll by slicing
+			// the last 'shift' elements to the front via Concat.
+			padded := trimmed.Pad(ctx, 0, shift, 0, 0)
+			totalLen := seqLen - shift + shift // = seqLen
+			tail := padded.Slice(ctx, 1, totalLen-shift, totalLen, 1).Contiguous(ctx)
+			head := padded.Slice(ctx, 1, 0, totalLen-shift, 1).Contiguous(ctx)
+			shifted = tail.Concat(ctx, head, 1)
 		}
 
 		wk := kernelT.Slice(ctx, 1, k, k+1, 1).Contiguous(ctx) // [D, 1]

--- a/model/models/gemma4/model_vision.go
+++ b/model/models/gemma4/model_vision.go
@@ -31,7 +31,7 @@ func scalarValue(t ml.Tensor) (float32, bool) {
 		return 0, false
 	}
 
-	data := t.BackendGet()
+	data := t.Floats()
 	if len(data) == 0 {
 		return 0, false
 	}
@@ -124,7 +124,7 @@ func (m *VisionModel) InitClamp(proj *MultiModalProjector) {
 	}
 
 	// Read all clamp values from packed F32 tensor
-	data := m.ClampData.BackendGet()
+	data := m.ClampData.Floats()
 	if len(data) == 0 {
 		return
 	}
@@ -226,7 +226,8 @@ type VisionMLP struct {
 func (mlp *VisionMLP) Forward(ctx ml.Context, hiddenState ml.Tensor) ml.Tensor {
 	gate := mlp.Gate.Forward(ctx, hiddenState)
 	up := mlp.Up.Forward(ctx, hiddenState)
-	hiddenState = gate.QuickGELU(ctx, up)
+	// QuickGELU: x * sigmoid(1.702 * x), then multiply by up
+	hiddenState = gate.Scale(ctx, 1.702).Sigmoid(ctx).Mul(ctx, gate).Mul(ctx, up)
 	return mlp.Down.Forward(ctx, hiddenState)
 }
 

--- a/model/models/mistral3/model.go
+++ b/model/models/mistral3/model.go
@@ -159,8 +159,9 @@ func (m *Model) PostTokenize(inputs []*input.Input) ([]*input.Input, error) {
 
 func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 	positions := ctx.Input().FromInts(batch.Positions, len(batch.Positions))
+	positionsScale := m.TextModel.getScale(ctx, batch.Positions)
 
-	return m.TextModel.Forward(ctx, batch.Inputs, positions, batch.Outputs, batch, m.Cache), nil
+	return m.TextModel.Forward(ctx, batch.Inputs, positions, positionsScale, batch.Outputs, batch, m.Cache), nil
 }
 
 func init() {

--- a/model/models/mistral3/model_text.go
+++ b/model/models/mistral3/model_text.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ollama/ollama/kvcache"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/ml/nn"
-	"github.com/ollama/ollama/ml/nn/fast"
+	"github.com/ollama/ollama/ml/nn/rope"
 	"github.com/ollama/ollama/model/input"
 )
 
@@ -16,6 +16,32 @@ type TextOptions struct {
 	hiddenSize, numHeads, numKVHeads int
 	headDim, ropeDim                 int
 	eps, ropeBase, ropeScale         float32
+	ropeOrigPosEmbeddings            int
+	ropeScalingBeta                  float32
+	ropeBetaFast                     float32
+	ropeBetaSlow                     float32
+	ropeType                         string
+	ropeMscale                       float32
+	ropeMscaleAllDim                 float32
+	ropeExtrapolation                float32
+}
+
+func (o TextOptions) applyRotaryPositionEmbeddings(ctx ml.Context, states, positions ml.Tensor) ml.Tensor {
+	var ropeOpts []func(*rope.Options)
+	if o.ropeType == "yarn" {
+		if o.ropeMscale != 0 && o.ropeMscaleAllDim != 0 {
+			ropeOpts = append(ropeOpts, rope.WithAttentionFactor(1.0/float32(0.1*math.Log(float64(o.ropeScale))+1.0)))
+		}
+
+		ropeOpts = append(ropeOpts,
+			rope.WithOriginalContextLength(o.ropeOrigPosEmbeddings),
+			rope.WithExtrapolationFactor(o.ropeExtrapolation),
+			rope.WithBetaFast(o.ropeBetaFast),
+			rope.WithBetaSlow(o.ropeBetaSlow),
+		)
+	}
+
+	return nn.RoPE(ctx, states, positions, o.ropeDim, o.ropeBase, 1./o.ropeScale, ropeOpts...)
 }
 
 type TextModel struct {
@@ -34,20 +60,24 @@ type SelfAttention struct {
 	Output *nn.Linear `gguf:"attn_output"`
 }
 
-func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Tensor, cache kvcache.Cache, opts *TextOptions) ml.Tensor {
+func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs, positionsScale ml.Tensor, cache kvcache.Cache, opts *TextOptions) ml.Tensor {
 	batchSize := hiddenState.Dim(1)
 	headDim := cmp.Or(opts.headDim, opts.hiddenSize/opts.numHeads)
 
 	q := sa.Query.Forward(ctx, hiddenState)
 	q = q.Reshape(ctx, headDim, opts.numHeads, batchSize)
-	q = fast.RoPE(ctx, q, positionIDs, opts.ropeDim, opts.ropeBase, 1./opts.ropeScale)
+	q = opts.applyRotaryPositionEmbeddings(ctx, q, positionIDs)
 
 	k := sa.Key.Forward(ctx, hiddenState)
 	k = k.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
-	k = fast.RoPE(ctx, k, positionIDs, opts.ropeDim, opts.ropeBase, 1./opts.ropeScale)
+	k = opts.applyRotaryPositionEmbeddings(ctx, k, positionIDs)
 
 	v := sa.Value.Forward(ctx, hiddenState)
 	v = v.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
+
+	if opts.ropeOrigPosEmbeddings > 0 {
+		q = q.Mul(ctx, positionsScale)
+	}
 
 	kqv := nn.Attention(ctx, q, k, v, 1.0/math.Sqrt(float64(headDim)), cache)
 	kqv = kqv.Reshape(ctx, headDim*opts.numHeads, batchSize)
@@ -55,7 +85,7 @@ func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Ten
 }
 
 func (m *TextModel) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
-	return fast.RoPE(ctx, key, shift, m.ropeDim, m.ropeBase, 1./m.ropeScale), nil
+	return m.applyRotaryPositionEmbeddings(ctx, key, shift), nil
 }
 
 type MLP struct {
@@ -76,11 +106,11 @@ type Layer struct {
 	MLP           *MLP
 }
 
-func (l *Layer) Forward(ctx ml.Context, hiddenState, positionIDs, outputs ml.Tensor, cache kvcache.Cache, opts *TextOptions) ml.Tensor {
+func (l *Layer) Forward(ctx ml.Context, hiddenState, positionIDs, positionsScale, outputs ml.Tensor, cache kvcache.Cache, opts *TextOptions) ml.Tensor {
 	residual := hiddenState
 
 	hiddenState = l.AttentionNorm.Forward(ctx, hiddenState, opts.eps)
-	hiddenState = l.SelfAttention.Forward(ctx, hiddenState, positionIDs, cache, opts)
+	hiddenState = l.SelfAttention.Forward(ctx, hiddenState, positionIDs, positionsScale, cache, opts)
 
 	// In the final layer (outputs != nil), optimize by pruning to just the token positions
 	// we need logits for.
@@ -97,7 +127,7 @@ func (l *Layer) Forward(ctx ml.Context, hiddenState, positionIDs, outputs ml.Ten
 	return hiddenState.Add(ctx, residual)
 }
 
-func (m *TextModel) Forward(ctx ml.Context, inputs, positions, outputs ml.Tensor, batch input.Batch, cache kvcache.Cache) ml.Tensor {
+func (m *TextModel) Forward(ctx ml.Context, inputs, positions, positionsScale, outputs ml.Tensor, batch input.Batch, cache kvcache.Cache) ml.Tensor {
 	hiddenState := m.TokenEmbedding.Forward(ctx, inputs).Duplicate(ctx)
 
 	// image embeddings
@@ -114,25 +144,42 @@ func (m *TextModel) Forward(ctx ml.Context, inputs, positions, outputs ml.Tensor
 			lastLayerOutputs = outputs
 		}
 
-		hiddenState = layer.Forward(ctx, hiddenState, positions, lastLayerOutputs, cache, m.TextOptions)
+		hiddenState = layer.Forward(ctx, hiddenState, positions, positionsScale, lastLayerOutputs, cache, m.TextOptions)
 	}
 
 	hiddenState = m.OutputNorm.Forward(ctx, hiddenState, m.eps)
 	return m.Output.Forward(ctx, hiddenState)
 }
 
+func (m *TextModel) getScale(ctx ml.Context, positions []int32) ml.Tensor {
+	posScale := make([]float32, len(positions))
+	for n, pos := range positions {
+		interval := math.Floor(float64(pos) / float64(m.ropeOrigPosEmbeddings))
+		posScale[n] = float32(1.0 + float64(m.ropeScalingBeta)*math.Log(1.0+interval))
+	}
+	return ctx.Input().FromFloats(posScale, 1, 1, len(posScale))
+}
+
 func newTextModel(c fs.Config) *TextModel {
 	return &TextModel{
 		Layers: make([]Layer, c.Uint("block_count")),
 		TextOptions: &TextOptions{
-			hiddenSize: int(c.Uint("embedding_length")),
-			numHeads:   int(c.Uint("attention.head_count")),
-			numKVHeads: int(c.Uint("attention.head_count_kv")),
-			headDim:    int(c.Uint("attention.key_length")),
-			ropeDim:    int(c.Uint("rope.dimension_count")),
-			eps:        c.Float("attention.layer_norm_rms_epsilon"),
-			ropeBase:   c.Float("rope.freq_base"),
-			ropeScale:  c.Float("rope.scaling.factor", 1),
+			hiddenSize:            int(c.Uint("embedding_length")),
+			numHeads:              int(c.Uint("attention.head_count")),
+			numKVHeads:            int(c.Uint("attention.head_count_kv")),
+			headDim:               int(c.Uint("attention.key_length")),
+			ropeDim:               int(c.Uint("rope.dimension_count")),
+			eps:                   c.Float("attention.layer_norm_rms_epsilon"),
+			ropeBase:              c.Float("rope.freq_base"),
+			ropeScale:             c.Float("rope.scaling.factor", 1.0),
+			ropeOrigPosEmbeddings: int(c.Uint("rope.scaling.original_context_length")),
+			ropeScalingBeta:       c.Float("rope.scaling_beta", 0.1),
+			ropeBetaFast:          c.Float("rope.scaling.beta_fast", 32.0),
+			ropeBetaSlow:          c.Float("rope.scaling.beta_slow", 1.0),
+			ropeType:              c.String("rope.scaling.type"),
+			ropeMscale:            c.Float("rope.scaling.mscale"),
+			ropeMscaleAllDim:      c.Float("rope.scaling.mscale_all_dim"),
+			ropeExtrapolation:     c.Float("rope.scaling.extrapolation_factor", 1),
 		},
 	}
 }

--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -426,7 +426,7 @@ func repairGemma4ToolCallArgs(argsStr, toolName string, tools []api.Tool) (api.T
 	return api.ToolCallFunctionArguments{}, errors.New("repair failed to produce valid JSON arguments")
 }
 
-func gemma4ToolProperties(toolName string, tools []api.Tool) *api.ToolPropertiesMap {
+func gemma4ToolProperties(toolName string, tools []api.Tool) map[string]api.ToolProperty {
 	for i := range tools {
 		if tools[i].Function.Name == toolName {
 			return tools[i].Function.Parameters.Properties
@@ -590,7 +590,7 @@ func repairGemma4RawTerminalStringValue(argsStr, toolName string, tools []api.To
 		return "", false
 	}
 
-	for key, prop := range props.All() {
+	for key, prop := range props {
 		if !gemma4PropertyAcceptsString(prop) {
 			continue
 		}
@@ -603,7 +603,7 @@ func repairGemma4RawTerminalStringValue(argsStr, toolName string, tools []api.To
 	return "", false
 }
 
-func repairGemma4RawTerminalStringValueForKey(s, key string, props *api.ToolPropertiesMap) (string, bool) {
+func repairGemma4RawTerminalStringValueForKey(s, key string, props map[string]api.ToolProperty) (string, bool) {
 	for searchStart := 0; searchStart < len(s); {
 		valueStart, ok := gemma4FindValueStartForKey(s, key, searchStart)
 		if !ok {
@@ -659,7 +659,7 @@ func gemma4FindValueStartForKey(s, key string, searchStart int) (int, bool) {
 	return 0, false
 }
 
-func gemma4RawStringValueEnd(s string, start int, props *api.ToolPropertiesMap) int {
+func gemma4RawStringValueEnd(s string, start int, props map[string]api.ToolProperty) int {
 	for i := start; i < len(s); i++ {
 		if s[i] != ',' {
 			continue
@@ -680,7 +680,7 @@ func gemma4RawStringValueEnd(s string, start int, props *api.ToolPropertiesMap) 
 
 		colon := gemma4SkipSpace(s, keyEnd)
 		if colon < len(s) && s[colon] == ':' {
-			if _, ok := props.Get(s[keyStart:keyEnd]); ok {
+			if _, ok := props[s[keyStart:keyEnd]]; ok {
 				return i
 			}
 		}

--- a/model/renderers/gemma4.go
+++ b/model/renderers/gemma4.go
@@ -142,7 +142,7 @@ func (r *Gemma4Renderer) renderToolDeclaration(tool api.Tool) string {
 
 		needsComma := false
 
-		if fn.Parameters.Properties != nil && fn.Parameters.Properties.Len() > 0 {
+		if fn.Parameters.Properties != nil && len(fn.Parameters.Properties) > 0 {
 			sb.WriteString("properties:{")
 			r.writeProperties(&sb, fn.Parameters.Properties)
 			sb.WriteString("}")
@@ -178,16 +178,16 @@ func (r *Gemma4Renderer) renderToolDeclaration(tool api.Tool) string {
 	return sb.String()
 }
 
-func (r *Gemma4Renderer) writeProperties(sb *strings.Builder, props *api.ToolPropertiesMap) {
-	keys := make([]string, 0, props.Len())
-	for k := range props.All() {
+func (r *Gemma4Renderer) writeProperties(sb *strings.Builder, props map[string]api.ToolProperty) {
+	keys := make([]string, 0, len(props))
+	for k := range props {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
 	first := true
 	for _, name := range keys {
-		prop, _ := props.Get(name)
+		prop := props[name]
 		if !first {
 			sb.WriteString(",")
 		}
@@ -227,7 +227,7 @@ func (r *Gemma4Renderer) writeProperties(sb *strings.Builder, props *api.ToolPro
 				// and this does NOT set hasContent — the comma before type:
 				// depends only on whether description was present.
 				sb.WriteString(",properties:{")
-				if prop.Properties != nil && prop.Properties.Len() > 0 {
+				if prop.Properties != nil && len(prop.Properties) > 0 {
 					r.writeProperties(sb, prop.Properties)
 				}
 				sb.WriteString("}")
@@ -297,15 +297,15 @@ func (r *Gemma4Renderer) formatToolCall(tc api.ToolCall) string {
 	var sb strings.Builder
 	sb.WriteString("<|tool_call>call:" + tc.Function.Name + "{")
 
-	keys := make([]string, 0, tc.Function.Arguments.Len())
-	for k := range tc.Function.Arguments.All() {
+	keys := make([]string, 0, len(tc.Function.Arguments))
+	for k := range tc.Function.Arguments {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
 	first := true
 	for _, key := range keys {
-		value, _ := tc.Function.Arguments.Get(key)
+		value := tc.Function.Arguments[key]
 		if !first {
 			sb.WriteString(",")
 		}

--- a/template/template.go
+++ b/template/template.go
@@ -128,6 +128,9 @@ var funcs = template.FuncMap{
 		// Default format is YYYY-MM-DD
 		return time.Now().Format("2006-01-02")
 	},
+	"yesterdayDate": func(args ...string) string {
+		return time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	},
 	"toTypeScriptType": func(v any) string {
 		if param, ok := v.(api.ToolProperty); ok {
 			return param.ToTypeScriptType()


### PR DESCRIPTION
## Summary
- Add `yesterdayDate` template function to fix model loading error
- Port YaRN RoPE options and position-dependent query scaling for mistral3
- Fix gemma4 build errors: `nn.RoPE`, `Tensor.Slice`, `BackendGet`, `QuickGELU`, `PadExt`, parser/renderer type adaptations
- Fix Docker build cache: add `GIT_COMMIT` arg to bust stale layers

Fixes #49
Fixes #61
Fixes #62

## Test plan
- [x] TC-MODELS-013: ministral-3:3b inference — response `"4"` for "What is 2+2?"
- [x] Build passes with all gemma4 code compiled (no more false-positive cached builds)
- [x] Runtime and inference suites pass
- [ ] Simple judge flags non-fatal `cudaMalloc` retry — tracked in #63

## Details

**ministral-3 had two issues:**
1. Template error: `yesterdayDate` function not defined — 3-line fix in `template/template.go`
2. Garbage output: missing YaRN RoPE and position scaling — ported from upstream, adapted to our fork's interfaces (`nn.RoPE` wrapper, `model.TextProcessor`)

**gemma4 build was broken** (masked by Docker cache):
- Added `nn.RoPE` wrapper delegating to `fast.RoPE`
- Added `Tensor.Slice` to `ml.Tensor` interface with ggml backend
- Replaced `BackendGet()` with existing `Floats()` method
- Replaced upstream ordered map APIs with plain Go maps in parsers/renderers
- Implemented `QuickGELU` via `Scale+Sigmoid+Mul` and `PadExt` via `Pad+Slice+Concat`

**Docker cache** was causing false-positive builds — `git clone` and `COPY` layers were cached indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)