### PR TITLE
Add GPU count validation to model test cases

### DIFF
--- a/cicd/tests/src/judge/llm-judge.ts
+++ b/cicd/tests/src/judge/llm-judge.ts
@@ -80,6 +80,7 @@ export class LLMJudge {
         'For AI-generated text, accept reasonable variations (e.g. "4", "four", "The answer is 4")',
         'Long durations within timeout are acceptable',
         'Build times are expected to be long for CUDA compilation',
+        'GPU_COUNT_EXCEEDED in step output means the model is using more GPUs than its total VRAM requires (each K80 has 11441 MiB) → FAIL',
       ],
       test: {
         id: r.testCase.id,

--- a/cicd/tests/testcases/models/TC-MODELS-001.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-001.yml
@@ -23,6 +23,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -38,6 +57,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-002.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-002.yml
@@ -23,6 +23,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -38,6 +57,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-003.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-003.yml
@@ -23,6 +23,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -38,6 +57,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-004.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-004.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-005.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-005.yml
@@ -31,6 +31,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -48,5 +67,7 @@ criteria: |
   - Model maps natural language intent to the correct function (get_weather)
   - Model extracts the correct argument (San Francisco) from context
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully

--- a/cicd/tests/testcases/models/TC-MODELS-006.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-006.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-007.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-007.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated on multiple GPUs (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-008.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-008.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-009.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-009.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated on multiple GPUs (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-010.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-010.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated on multiple GPUs (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-011.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-011.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -41,6 +60,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-012.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-012.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -42,6 +61,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field containing coherent text
   - GPU memory is allocated on multiple GPUs (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 

--- a/cicd/tests/testcases/models/TC-MODELS-013.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-013.yml
@@ -25,6 +25,25 @@ steps:
     expectPatterns:
       - "[0-9]+ MiB"
 
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
   - name: Unload model
     command: |
       curl -s http://localhost:11434/api/generate \
@@ -40,6 +59,8 @@ criteria: |
   Expected:
   - API returns JSON with "response" field
   - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
   - No CUDA/CUBLAS errors in output
   - Model unloads successfully
 


### PR DESCRIPTION
## Summary

- Add "Check GPU count" step to all 13 model test cases that validates models don't spread across more GPUs than their total VRAM requires
- Logic: if `total_vram <= (active_gpus - 1) * 11441`, model could fit on fewer GPUs → FAIL
- Add `GPU_COUNT_EXCEEDED` rule to LLM judge prompt
- Update criteria text in all model tests for LLM judge context

No hardcoded values — uses real K80 GPU capacity (11,441 MiB) and actual nvidia-smi readings.

Fixes #78

## Test plan

- [ ] Run `test-models.yml` workflow — expect 12 models pass, qwen3.5:27b fails (known #72)
- [ ] Verify GPU_COUNT_EXCEEDED output triggers simple judge reject pattern
- [ ] Verify LLM judge sees GPU count criteria and rule


🤖 Generated with [Claude Code](https://claude.com/claude-code)