### PR TITLE
Add Go wrappers for DeltaNet GGML ops

### DIFF
--- a/ml/backend.go
+++ b/ml/backend.go
@@ -172,7 +172,9 @@ type Tensor interface {
 
 	Sin(ctx Context) Tensor
 	Cos(ctx Context) Tensor
+	Exp(ctx Context) Tensor
 	Tanh(ctx Context) Tensor
+	Softplus(ctx Context) Tensor
 	GELU(ctx Context, up ...Tensor) Tensor
 	SILU(ctx Context, up ...Tensor) Tensor
 	RELU(ctx Context, up ...Tensor) Tensor
@@ -180,6 +182,12 @@ type Tensor interface {
 
 	// AlphaLimitSILU is a variant of SILU that clamps the input to the range [-limit, limit]
 	SILUAlphaLimit(ctx Context, up Tensor, alpha, limit float32) Tensor
+
+	// Cumsum computes the cumulative sum along the first axis
+	Cumsum(ctx Context) Tensor
+
+	// Conv1D performs 1D convolution: kernel convolved with data
+	Conv1D(ctx Context, kernel Tensor, stride, padding, dilation int) Tensor
 
 	Reshape(ctx Context, shape ...int) Tensor
 	View(ctx Context, offset int, shape ...int) Tensor

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -1469,6 +1469,34 @@ func (t *Tensor) Sigmoid(ctx ml.Context) ml.Tensor {
 	}
 }
 
+func (t *Tensor) Exp(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_exp(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Softplus(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_softplus(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Cumsum(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_cumsum(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Conv1D(ctx ml.Context, kernel ml.Tensor, stride, padding, dilation int) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_conv_1d(ctx.(*Context).ctx, kernel.(*Tensor).t, t.t, C.int(stride), C.int(padding), C.int(dilation)),
+	}
+}
+
 func (t *Tensor) View(ctx ml.Context, offset int, shape ...int) ml.Tensor {
 	switch len(shape) {
 	case 1:


### PR DESCRIPTION
## Summary

- Add `Exp()`, `Cumsum()`, `Softplus()`, `Conv1D()` to Tensor interface
- Implement in ggml backend wrapping existing C functions
- Required by qwen35 DeltaNet model (#82)

## Test plan

- [ ] Build verification passes (confirms CGO wrappers compile)

Fixes #80
Relates to #72