### PR TITLE
Add num_predict:200 to all model tests

### DIFF
--- a/cicd/tests/testcases/models/TC-MODELS-001.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-001.yml
@@ -10,7 +10,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gpt-oss:20b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"gpt-oss:20b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-002.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-002.yml
@@ -10,7 +10,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gemma3:27b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"gemma3:27b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-003.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-003.yml
@@ -10,7 +10,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"deepseek-r1:14b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"deepseek-r1:14b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-004.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-004.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"qwen3.5:9b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"qwen3.5:9b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-005.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-005.yml
@@ -17,7 +17,7 @@ steps:
           "messages":[{"role":"user","content":"What is the weather in San Francisco?"}],
           "tools":[{"type":"function","function":{"name":"get_weather","description":"Get the current weather in a given location","parameters":{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city and state"}}}}}],
           "stream":false,
-          "options":{"temperature":0}
+          "options":{"temperature":0,"num_predict":200}
         }' | head -c 4000
     expectPatterns:
       - "get_weather"

--- a/cicd/tests/testcases/models/TC-MODELS-006.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-006.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gemma4:e4b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"gemma4:e4b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-007.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-007.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gemma4:26b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"gemma4:26b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-008.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-008.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gemma3:4b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"gemma3:4b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-009.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-009.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"deepseek-r1:32b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"deepseek-r1:32b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-010.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-010.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"qwen3.5:27b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":100}}' \
+        -d '{"model":"qwen3.5:27b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-011.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-011.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"qwen3-vl:8b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"qwen3-vl:8b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-012.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-012.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"qwen3-vl:30b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"qwen3-vl:30b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"

--- a/cicd/tests/testcases/models/TC-MODELS-013.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-013.yml
@@ -12,7 +12,7 @@ steps:
   - name: Test inference
     command: |
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"ministral-3:3b","prompt":"What is 2+2? Answer briefly.","stream":false}' \
+        -d '{"model":"ministral-3:3b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
         | head -c 2000
     expectPatterns:
       - "response"


### PR DESCRIPTION
## Summary

- Add `num_predict:200` to all 13 model test inference requests
- Prevents broken models from generating infinite garbage tokens (20 min timeout waste)
- 200 tokens covers all thinking models (max observed: 184 for qwen3.5:9b)

Fixes #84

## Test plan

- [ ] Run `test-models.yml` with a known-good model — should finish with `done_reason: "stop"` under 200 tokens
- [ ] Verify a broken model (garbage output) gets cut off at 200 tokens with `done_reason: "length"` instead of running to timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)