### PR TITLE
Port qwen3.5 to ollama engine with DeltaNet recurrent state

### DIFF
--- a/docs/traces/qwen35-27b-gpu0-memory.md
+++ b/docs/traces/qwen35-27b-gpu0-memory.md
@@ -1,0 +1,83 @@
+# Trace: qwen3.5:27b GPU0 uses 10 GiB
+
+**Issue**: #72 — qwen3.5:27b GPU0 uses 10 GiB while GPU1-3 use 4 GiB each
+**Date**: 2026-04-11
+
+## nvidia-smi vs llama.cpp Reported Allocations
+
+| GPU | Weights | KV | RS | Compute | llama.cpp total | nvidia-smi | Gap |
+|---|---|---|---|---|---|---|---|
+| CUDA0 | 3492 | 64 | 37 | 1493 | 5086 | **10149** | **5063** |
+| CUDA1 | 3405 | 64 | 37 | 266 | 3772 | 4325 | 553 |
+| CUDA2 | 3383 | 64 | 37 | 266 | 3750 | 4303 | 553 |
+| CUDA3 | 3514 | 64 | 37 | 266 | 3881 | 4434 | 553 |
+
+All values in MiB.
+
+## GPU1-3 Gap: Normal (~553 MiB each)
+
+CUDA runtime overhead per GPU. Expected.
+
+## GPU0 Gap: 5063 MiB
+
+### Accounted allocations on GPU0
+
+```
+CUDA0 model weights:       3492 MiB
+CUDA0 KV cache:              64 MiB
+CUDA0 RS recurrent state:    37 MiB
+CUDA0 compute buffer:      1493 MiB
+CUDA_Host model (pinned):   995 MiB  ← cudaMallocHost, nvidia-smi counts on GPU0
+CUDA_Host compute (pinned):  22 MiB
+CUDA runtime overhead:     ~500 MiB
+─────────────────────────────────
+Subtotal:                  6603 MiB
+nvidia-smi:               10149 MiB
+Unexplained:               3546 MiB
+```
+
+### Two known issues
+
+**1. Compute buffer imbalance**: GPU0 = 1493 MiB vs GPU1-3 = 266 MiB.
+This is the llama.cpp scheduler putting more compute on GPU0 (first graph split,
+embedding lookup, cross-GPU transfer staging).
+
+**2. Unexplained 3.5 GiB on GPU0**: Not reported by llama.cpp logging. Possible causes:
+
+#### H1: Cross-GPU transfer staging buffers
+qwen3.5 has 98-109 graph splits across 4 GPUs. Each split boundary needs
+staging buffers for tensor copies between GPUs. These are allocated on
+GPU0 (the "main" GPU) by the GGML scheduler but not reported in the
+per-backend buffer size logs.
+
+Graph stats: `nodes=16749, splits=98` (batch=512). Extremely high split count
+due to the hybrid DeltaNet+attention architecture — each layer type transition
+creates a new split.
+
+#### H2: DeltaNet state buffers
+DeltaNet layers use `ssm_d_state × ssm_d_inner = 128 × 6144` state per layer.
+With 48 DeltaNet layers, the state storage is significant. These may be
+allocated on GPU0 as the "recurrent state host" beyond what's reported in
+the RS buffer logs.
+
+#### H3: CUDA memory fragmentation
+Multiple allocation/free cycles during the iterative graph reservation
+may leave fragmented GPU memory that nvidia-smi counts but isn't usable.
+
+## Model Parameters
+
+```
+Architecture: qwen35 (DeltaNet hybrid)
+Layers: 64 (48 DeltaNet + 16 full attention)
+n_embd: 5120, n_head: 24, n_ff: 17408
+ssm_d_inner: 6144, ssm_d_state: 128
+BatchSize: 512, KvSize: 4096, FlashAttention: false
+File: Q4_K_M, 16.21 GiB, 1307 tensors (456 vision skipped)
+```
+
+## TODO
+
+- [ ] Run with `GGML_CUDA_NO_PINNED=1` to see if pinned memory accounts for more than reported
+- [ ] Run with `CUDA_LAUNCH_BLOCKING=1` and check nvidia-smi during each allocation phase
+- [ ] Check if reducing graph splits (by changing layer assignment) reduces GPU0 memory
+- [ ] Compare with a non-hybrid model of similar size (e.g., gemma3:27b) to see if the gap exists

--- a/docs/traces/qwen35-9b-gpu-memory.md
+++ b/docs/traces/qwen35-9b-gpu-memory.md
@@ -1,0 +1,107 @@
+# Trace: Ghost 93 MiB GPU Allocations
+
+**Date**: 2026-04-11
+**Issue**: #73
+**Run**: 24271631817 (full suite)
+
+## Problem
+
+Some models show 93 MiB CUDA primary context overhead on GPUs they don't use.
+Each model runs in its own subprocess (different PIDs), so these are NOT
+residual from previous models.
+
+## Full Suite Data
+
+| # | Model | GPU0 | GPU1 | GPU2 | GPU3 | Ghosts |
+|---|-------|------|------|------|------|--------|
+| 1 | gpt-oss:20b | 7375 | 7549 | — | — | 0 |
+| 3 | gemma3:27b | 9961 | 10228 | — | — | 0 |
+| 4 | deepseek-r1:14b | 5195 | 8217 | **93** | **93** | 2 |
+| 5 | qwen3-vl:30b | 10487 | 10355 | **93** | — | 1 |
+| 6 | qwen3-vl:8b | 7610 | — | — | — | 0 |
+| 7 | qwen3.5:27b | 10151 | 4327 | 4305 | 4436 | 0 |
+| 8 | deepseek-r1:32b | 7689 | 7585 | 10213 | **93** | 1 |
+| 9 | gemma3:4b | 4818 | — | — | — | 0 |
+| 10 | gemma4:26b | 9614 | 9462 | — | — | 0 |
+| 11 | gemma4:e4b | 9899 | — | — | — | 0 |
+| 12 | functiongemma | 517 | — | — | — | 0 |
+| 13 | qwen3.5:9b | 9509 | **93** | **93** | **93** | 3 |
+
+## Root Cause: Two Code Paths
+
+### Path 1: llama engine — pipeline parallelism events (confirmed)
+
+**Affected**: deepseek-r1:14b, deepseek-r1:32b, qwen3-vl:30b
+
+The llama engine runner calls `llama_init_from_model()` which creates a
+llama.cpp context. At `llama-context.cpp:240-244`:
+
+```cpp
+bool pipeline_parallel =
+    model.n_devices() > 1 &&           // ALWAYS 4 (all GPUs added)
+    model.params.n_gpu_layers > n_layer // true when fully offloaded
+    ...
+```
+
+When `pipeline_parallel=true`, the scheduler creates CUDA events on
+**all 4 GPU backends** (`ggml-backend.cpp:1692-1696`):
+
+```cpp
+if (sched->n_copies > 1) {
+    for (int c = 0; c < sched->n_copies; c++) {
+        sched->events[b][c] = ggml_backend_event_new(backends[b]->device);
+    }
+}
+```
+
+`ggml_backend_event_new` calls `cudaSetDevice(device)` +
+`cudaEventCreateWithFlags` (`ggml-cuda.cu:4109-4112`), which creates a
+CUDA primary context (~93 MiB) on each device.
+
+**Why `model.n_devices() = 4`**: At `llama.cpp:188-248`, ALL visible
+GPUs are added to `model->devices` regardless of which ones have layers.
+Only `LLAMA_SPLIT_MODE_NONE` prunes the list, but the default is
+`LLAMA_SPLIT_MODE_LAYER`.
+
+### Path 2: ollama engine — needs instrumentation (unconfirmed)
+
+**Affected**: qwen3.5:9b
+
+The ollama engine passes `parallel=false` to the scheduler (`ggml.go:388`),
+so no events are created. The GPU filter at `ggml.go:364` correctly
+excludes unused GPUs from the scheduler.
+
+The ghost source for qwen3.5:9b is still unconfirmed. Most likely the
+`/info` endpoint is called on the runner subprocess during the load
+process, creating a dummy model with `AllocMemory=false` that queries
+all GPUs via `ggml_backend_dev_memory()` → `cudaMemGetInfo`.
+
+## Fix
+
+### For llama engine (Path 1)
+
+The fix is in `llama.cpp:188-248`: only add GPUs that actually have
+layers to `model->devices`. Or add a check in the context init to only
+create backends/events for devices that have tensors.
+
+**Option A**: Filter `model->devices` based on `tensor_split` — only
+include GPUs with non-zero split.
+
+**Option B**: Change `pipeline_parallel` condition to check if layers are
+actually distributed across multiple devices, not just that multiple
+devices exist.
+
+### For ollama engine (Path 2)
+
+Add instrumentation to confirm, then either:
+- Make `BackendDevices()` always skip GPUs not in `schedBackends`
+- Or restrict the `/info` dummy model to CPU-only
+
+## Code References
+
+- `model->devices` population: `llama.cpp:188-248`
+- Pipeline parallel decision: `llama-context.cpp:240-244`
+- Event creation: `ggml-backend.cpp:1692-1696`
+- CUDA event → context: `ggml-cuda.cu:4109-4112`
+- Ollama scheduler parallel flag: `ggml.go:388` (`false`)
+- Ollama GPU filter: `ggml.go:364-367`

--- a/kvcache/cache.go
+++ b/kvcache/cache.go
@@ -75,3 +75,10 @@ type Cache interface {
 	// removed by calling Remove(seq, 0, math.MaxInt32)
 	Remove(seq int, beginIndex, endIndex int32) error
 }
+
+// CheckpointCache optionally supports restoring recurrent state to a prior
+// position to avoid full prompt reprocessing when a prefix mismatch occurs.
+// The returned position is the number of tokens that can be kept (prefix length).
+type CheckpointCache interface {
+	PrepareRestore(seq int, targetPos int32) (int32, bool)
+}

--- a/kvcache/recurrent.go
+++ b/kvcache/recurrent.go
@@ -1,0 +1,752 @@
+package kvcache
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model/input"
+)
+
+const (
+	DefaultCheckpointCount    = 24
+	DefaultCheckpointMinPos   = int32(16)
+	DefaultCheckpointInterval = int32(1664)
+)
+
+var ErrInvalidRecurrentShape = errors.New("kvcache: invalid recurrent state shape")
+
+// Config configures a shared hybrid recurrent cache.
+type RecurrentConfig struct {
+	Shift               func(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error)
+	ConvDim             int
+	ConvChannels        int
+	RecurrentStateSize  int
+	CheckpointLogPrefix string
+}
+
+var (
+	_ Cache           = (*Recurrent)(nil)
+	_ CheckpointCache = (*Recurrent)(nil)
+)
+
+// Cache stores:
+// - a standard causal KV cache
+// - per-sequence conv state for recurrent operators
+// - per-sequence recurrent state for recurrent operators
+//
+// Conv state shape (per layer, per sequence): [convDim, convChannels]
+// Recurrent state shape (per layer, per sequence): [recurrentStateSize]
+type Recurrent struct {
+	kv *Causal
+
+	backend      ml.Backend
+	dtype        ml.DType
+	maxSequences int
+
+	// Conv state dimensions
+	convDim      int
+	convChannels int
+
+	// Recurrent state dimensions
+	recurrentStateSize int
+
+	logPrefix string
+
+	// slot mapping for recurrent state (copy-on-write)
+	slotForSeq  map[int]int
+	refCount    []int
+	freeSlots   []int
+	seqCounts   map[int]int
+	slotScratch [1]int32
+
+	// per-layer conv state buffers (allocated lazily)
+	convCtxs   map[int]ml.Context
+	convStates map[int]ml.Tensor // [convDim*convChannels, maxSlots]
+
+	// per-layer recurrent state buffers (allocated lazily)
+	recurrentCtxs   map[int]ml.Context
+	recurrentStates map[int]ml.Tensor // [recurrentStateSize, maxSlots]
+
+	// recurrent checkpoints (per slot)
+	checkpointCount     int
+	checkpointMinPos    int32
+	checkpointInterval  int32
+	checkpointCtxSize   int
+	checkpoints         map[int]*slotCheckpointStore
+	pendingRestore      map[int]checkpointRestore
+	curCheckpointPos    []int32
+	curCheckpointSlots  map[int]int
+	reserveCheckpoints  bool
+	checkpointConvCtxs  map[int]ml.Context
+	checkpointRecurCtxs map[int]ml.Context
+	checkpointReserved  map[int]struct{}
+
+	// current forward batch (derived in StartForward)
+	curSeqs       []int
+	curSlots      []int
+	curSlotsInput ml.Tensor
+	curSeqTokens  int
+
+	// track if EnsureWritable has been called for this forward pass
+	writableEnsured bool
+	writableError   error
+}
+
+func NewRecurrentCache(config RecurrentConfig) *Recurrent {
+	return &Recurrent{
+		kv:                  NewCausalCache(config.Shift),
+		convDim:             config.ConvDim,
+		convChannels:        config.ConvChannels,
+		recurrentStateSize:  config.RecurrentStateSize,
+		logPrefix:           config.CheckpointLogPrefix,
+		slotForSeq:          make(map[int]int),
+		seqCounts:           make(map[int]int),
+		convCtxs:            make(map[int]ml.Context),
+		convStates:          make(map[int]ml.Tensor),
+		recurrentCtxs:       make(map[int]ml.Context),
+		recurrentStates:     make(map[int]ml.Tensor),
+		checkpointCount:     DefaultCheckpointCount,
+		checkpointMinPos:    DefaultCheckpointMinPos,
+		checkpointInterval:  DefaultCheckpointInterval,
+		checkpoints:         make(map[int]*slotCheckpointStore),
+		pendingRestore:      make(map[int]checkpointRestore),
+		curCheckpointSlots:  make(map[int]int),
+		checkpointConvCtxs:  make(map[int]ml.Context),
+		checkpointRecurCtxs: make(map[int]ml.Context),
+		checkpointReserved:  make(map[int]struct{}),
+	}
+}
+
+func (c *Recurrent) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) {
+	c.backend = backend
+	c.dtype = dtype
+	c.maxSequences = maxSequences
+	c.checkpoints = make(map[int]*slotCheckpointStore)
+	c.pendingRestore = make(map[int]checkpointRestore)
+	c.curCheckpointPos = c.curCheckpointPos[:0]
+	c.curCheckpointSlots = make(map[int]int)
+	c.checkpointReserved = make(map[int]struct{})
+	c.checkpointCtxSize = c.checkpointCount * c.maxSequences
+	if c.checkpointCtxSize < 8 {
+		c.checkpointCtxSize = 8
+	}
+
+	// initialize slot allocator
+	c.refCount = make([]int, maxSequences)
+	c.freeSlots = c.freeSlots[:0]
+	for i := maxSequences - 1; i >= 0; i-- {
+		c.freeSlots = append(c.freeSlots, i)
+	}
+
+	c.kv.Init(backend, dtype, maxSequences, capacity, maxBatch)
+}
+
+func (c *Recurrent) Close() {
+	for _, ctx := range c.convCtxs {
+		ctx.Close()
+	}
+	for _, ctx := range c.recurrentCtxs {
+		ctx.Close()
+	}
+	for _, ctx := range c.checkpointConvCtxs {
+		ctx.Close()
+	}
+	for _, ctx := range c.checkpointRecurCtxs {
+		ctx.Close()
+	}
+	c.kv.Close()
+}
+
+func (c *Recurrent) SetConfig(config ml.CacheConfig) {
+	c.kv.SetConfig(config)
+}
+
+func (c *Recurrent) SetLayer(layer int) {
+	c.kv.SetLayer(layer)
+}
+
+func (c *Recurrent) Get(ctx ml.Context) (ml.Tensor, ml.Tensor, ml.Tensor) {
+	return c.kv.Get(ctx)
+}
+
+func (c *Recurrent) Put(ctx ml.Context, key, value ml.Tensor) {
+	c.kv.Put(ctx, key, value)
+}
+
+func (c *Recurrent) StartForward(ctx ml.Context, batch input.Batch, reserve bool) error {
+	if err := c.kv.StartForward(ctx, batch, reserve); err != nil {
+		return err
+	}
+
+	nTokens := len(batch.Sequences)
+	if nTokens == 0 {
+		c.curSeqs = c.curSeqs[:0]
+		c.curSlots = c.curSlots[:0]
+		c.curSlotsInput = nil
+		c.curSeqTokens = 0
+		c.reserveCheckpoints = false
+		c.writableEnsured = false
+		c.writableError = nil
+		return nil
+	}
+
+	// Fast path for single-sequence batches (common during decode and prefill).
+	firstSeq := batch.Sequences[0]
+	singleSeq := true
+	for _, s := range batch.Sequences[1:] {
+		if s != firstSeq {
+			singleSeq = false
+			break
+		}
+	}
+	if singleSeq {
+		return c.startForwardSingleSeq(ctx, firstSeq, nTokens, batch, reserve)
+	}
+
+	// Derive equal-length sequence layout for recurrent layers.
+	seqCounts := c.seqCounts
+	for s := range seqCounts {
+		delete(seqCounts, s)
+	}
+
+	c.curSeqs = c.curSeqs[:0]
+	for _, s := range batch.Sequences {
+		if seqCounts[s] == 0 {
+			c.curSeqs = append(c.curSeqs, s)
+		}
+		seqCounts[s]++
+	}
+
+	nSeqs := len(c.curSeqs)
+	want := nTokens / nSeqs
+	for _, s := range c.curSeqs {
+		if seqCounts[s] != want {
+			return ErrNotSupported
+		}
+	}
+
+	c.curSeqTokens = want
+
+	if reserve {
+		c.curSlots = c.curSlots[:0]
+		for i := range nSeqs {
+			c.curSlots = append(c.curSlots, i)
+		}
+		c.finalizeStartForward(ctx, batch, true)
+		return nil
+	}
+
+	// Ensure slots exist for sequences in this batch.
+	c.curSlots = c.curSlots[:0]
+	var newSlots []int
+	for _, s := range c.curSeqs {
+		slot, ok := c.slotForSeq[s]
+		if !ok {
+			var err error
+			slot, err = c.allocSlot()
+			if err != nil {
+				return err
+			}
+			c.slotForSeq[s] = slot
+			c.refCount[slot] = 1
+			newSlots = append(newSlots, slot)
+		}
+		c.curSlots = append(c.curSlots, slot)
+	}
+
+	if len(newSlots) > 0 {
+		c.zeroSlots(ctx, newSlots)
+	}
+
+	c.finalizeStartForward(ctx, batch, false)
+
+	return nil
+}
+
+func (c *Recurrent) startForwardSingleSeq(ctx ml.Context, seq, seqTokens int, batch input.Batch, reserve bool) error {
+	c.curSeqs = append(c.curSeqs[:0], seq)
+	c.curSeqTokens = seqTokens
+
+	if reserve {
+		c.curSlots = append(c.curSlots[:0], 0)
+		c.finalizeStartForward(ctx, batch, true)
+		return nil
+	}
+
+	slot, ok := c.slotForSeq[seq]
+	if !ok {
+		var err error
+		slot, err = c.allocSlot()
+		if err != nil {
+			return err
+		}
+
+		c.slotForSeq[seq] = slot
+		c.refCount[slot] = 1
+		slotList := [1]int{slot}
+		c.zeroSlots(ctx, slotList[:])
+	}
+
+	c.curSlots = append(c.curSlots[:0], slot)
+	c.finalizeStartForward(ctx, batch, false)
+
+	return nil
+}
+
+func (c *Recurrent) finalizeStartForward(ctx ml.Context, batch input.Batch, reserve bool) {
+	c.setCurSlotsInput(ctx)
+	c.writableEnsured = false
+	c.writableError = nil
+	c.reserveCheckpoints = reserve
+	c.planCheckpoints(batch)
+}
+
+func (c *Recurrent) setCurSlotsInput(ctx ml.Context) {
+	c.curSlotsInput = c.slotsInput(ctx, c.curSlots)
+}
+
+func (c *Recurrent) slotsInput(ctx ml.Context, slots []int) ml.Tensor {
+	switch len(slots) {
+	case 0:
+		return nil
+	case 1:
+		c.slotScratch[0] = int32(slots[0])
+		return ctx.Input().FromInts(c.slotScratch[:], 1)
+	default:
+		slotIndices := make([]int32, len(slots))
+		for i, v := range slots {
+			slotIndices[i] = int32(v)
+		}
+		return ctx.Input().FromInts(slotIndices, len(slotIndices))
+	}
+}
+
+func (c *Recurrent) allocSlot() (int, error) {
+	if len(c.freeSlots) == 0 {
+		return 0, ErrKvCacheFull
+	}
+	slot := c.freeSlots[len(c.freeSlots)-1]
+	c.freeSlots = c.freeSlots[:len(c.freeSlots)-1]
+	return slot, nil
+}
+
+func (c *Recurrent) freeSlot(slot int) {
+	if slot >= 0 && slot < c.maxSequences {
+		c.freeSlots = append(c.freeSlots, slot)
+	}
+}
+
+// zeroSlots zeros recurrent state for the given slots across all cached layers.
+func (c *Recurrent) zeroSlots(ctx ml.Context, slots []int) {
+	if len(slots) == 0 {
+		return
+	}
+
+	inputCtx := ctx.Input()
+	slotsTensor := c.slotsInput(ctx, slots)
+
+	if len(c.convStates) > 0 {
+		zeros := inputCtx.Zeros(ml.DTypeF32, c.convDim*c.convChannels, len(slots))
+		for _, buf := range c.convStates {
+			ctx.Forward(buf.SetRows(ctx, zeros, slotsTensor))
+		}
+	}
+
+	if len(c.recurrentStates) > 0 {
+		zeros := inputCtx.Zeros(ml.DTypeF32, c.recurrentStateSize, len(slots))
+		for _, buf := range c.recurrentStates {
+			ctx.Forward(buf.SetRows(ctx, zeros, slotsTensor))
+		}
+	}
+}
+
+// EnsureWritable ensures sequences have private slots (copy-on-write).
+func (c *Recurrent) EnsureWritable(ctx ml.Context) error {
+	for i, seq := range c.curSeqs {
+		slot, ok := c.slotForSeq[seq]
+		if !ok {
+			continue
+		}
+
+		if slot < 0 || slot >= len(c.refCount) {
+			continue
+		}
+
+		if c.refCount[slot] <= 1 {
+			continue
+		}
+
+		newSlot, err := c.allocSlot()
+		if err != nil {
+			return err
+		}
+		c.refCount[slot]--
+		c.refCount[newSlot] = 1
+		c.slotForSeq[seq] = newSlot
+		c.curSlots[i] = newSlot
+
+		c.copyRecurrentState(ctx, slot, newSlot)
+		c.copyCheckpoints(ctx, slot, newSlot)
+	}
+
+	c.setCurSlotsInput(ctx)
+
+	return nil
+}
+
+func (c *Recurrent) copyRecurrentState(ctx ml.Context, srcSlot, dstSlot int) {
+	src := ctx.Input().FromInts([]int32{int32(srcSlot)}, 1)
+	dst := ctx.Input().FromInts([]int32{int32(dstSlot)}, 1)
+
+	for _, buf := range c.convStates {
+		rows := buf.Rows(ctx, src)
+		if rows.DType() != ml.DTypeF32 {
+			rows = rows.Cast(ctx, ml.DTypeF32)
+		}
+		ctx.Forward(buf.SetRows(ctx, rows, dst))
+	}
+
+	for _, buf := range c.recurrentStates {
+		rows := buf.Rows(ctx, src)
+		if rows.DType() != ml.DTypeF32 {
+			rows = rows.Cast(ctx, ml.DTypeF32)
+		}
+		ctx.Forward(buf.SetRows(ctx, rows, dst))
+	}
+}
+
+func (c *Recurrent) CopyPrefix(srcSeq, dstSeq int, prefixLen int32) {
+	c.kv.CopyPrefix(srcSeq, dstSeq, prefixLen)
+
+	if dstSlot, ok := c.slotForSeq[dstSeq]; ok {
+		if c.validSlot(dstSlot) {
+			c.refCount[dstSlot]--
+			if c.refCount[dstSlot] <= 0 {
+				c.refCount[dstSlot] = 0
+				c.freeSlot(dstSlot)
+			}
+		}
+		delete(c.slotForSeq, dstSeq)
+	}
+
+	srcSlot, ok := c.slotForSeq[srcSeq]
+	if !ok {
+		return
+	}
+
+	if c.validSlot(srcSlot) {
+		c.slotForSeq[dstSeq] = srcSlot
+		c.refCount[srcSlot]++
+	}
+}
+
+func (c *Recurrent) CanResume(seq int, pos int32) bool {
+	if !c.kv.CanResume(seq, pos) {
+		return false
+	}
+	if pos == 0 {
+		return true
+	}
+	return c.hasCheckpoint(seq, pos)
+}
+
+func (c *Recurrent) Remove(seq int, beginIndex, endIndex int32) error {
+	if beginIndex > 0 && endIndex != math.MaxInt32 {
+		if err := c.kv.Remove(seq, beginIndex, endIndex); err != nil {
+			return err
+		}
+		delete(c.pendingRestore, seq)
+
+		slot, ok := c.slotForSeq[seq]
+		if !ok || !c.validSlot(slot) {
+			return nil
+		}
+
+		// Detach shared recurrent state/checkpoints before mutating checkpoint positions.
+		if c.refCount[slot] > 1 {
+			newSlot, err := c.allocSlot()
+			if err != nil {
+				return err
+			}
+			ctx := c.backend.NewContext()
+			c.copyRecurrentState(ctx, slot, newSlot)
+			c.copyCheckpoints(ctx, slot, newSlot)
+			if len(c.convStates) > 0 || len(c.recurrentStates) > 0 {
+				ctx.Compute()
+			}
+			ctx.Close()
+
+			c.refCount[slot]--
+			c.refCount[newSlot] = 1
+			c.slotForSeq[seq] = newSlot
+			slot = newSlot
+		}
+
+		c.shiftCheckpoints(slot, beginIndex, endIndex)
+		return nil
+	}
+
+	if beginIndex > 0 {
+		restore, ok := c.pendingRestore[seq]
+		if !ok || restore.pos+1 != beginIndex {
+			return ErrNotSupported
+		}
+		if !c.restoreComplete(restore) {
+			return ErrNotSupported
+		}
+		if slot, ok := c.slotForSeq[seq]; ok && c.validSlot(slot) && c.refCount[slot] > 1 {
+			newSlot, err := c.allocSlot()
+			if err != nil {
+				return err
+			}
+			ctx := c.backend.NewContext()
+			c.copyRecurrentState(ctx, slot, newSlot)
+			c.copyCheckpoints(ctx, slot, newSlot)
+			if len(c.convStates) > 0 || len(c.recurrentStates) > 0 {
+				ctx.Compute()
+			}
+			ctx.Close()
+
+			c.refCount[slot]--
+			c.refCount[newSlot] = 1
+			c.slotForSeq[seq] = newSlot
+
+			restore.slot = newSlot
+			c.pendingRestore[seq] = restore
+		}
+	}
+
+	if err := c.kv.Remove(seq, beginIndex, endIndex); err != nil {
+		return err
+	}
+
+	if beginIndex > 0 {
+		restore := c.pendingRestore[seq]
+		delete(c.pendingRestore, seq)
+		return c.applyCheckpointRestore(restore)
+	}
+
+	slot, ok := c.slotForSeq[seq]
+	delete(c.pendingRestore, seq)
+	if !ok {
+		return nil
+	}
+
+	if !c.validSlot(slot) {
+		delete(c.slotForSeq, seq)
+		return nil
+	}
+
+	c.refCount[slot]--
+	if c.refCount[slot] <= 0 {
+		c.refCount[slot] = 0
+		c.clearCheckpoints(slot)
+		c.freeSlot(slot)
+	}
+	delete(c.slotForSeq, seq)
+
+	return nil
+}
+
+func (c *Recurrent) validSlot(slot int) bool {
+	return slot >= 0 && slot < len(c.refCount)
+}
+
+func (c *Recurrent) SlotsTensor() ml.Tensor {
+	return c.curSlotsInput
+}
+
+// contiguousSlots returns the starting slot if current slots are contiguous and ordered.
+func (c *Recurrent) contiguousSlots() (int, bool) {
+	if len(c.curSlots) == 0 {
+		return 0, false
+	}
+	start := c.curSlots[0]
+	for i, s := range c.curSlots {
+		if s != start+i {
+			return 0, false
+		}
+	}
+	return start, true
+}
+
+func (c *Recurrent) SeqTokens() int {
+	return c.curSeqTokens
+}
+
+func (c *Recurrent) NumSeqs() int {
+	return len(c.curSeqs)
+}
+
+func (c *Recurrent) convBuffer(layer int) ml.Tensor {
+	if buf, ok := c.convStates[layer]; ok {
+		return buf
+	}
+
+	if _, ok := c.convCtxs[layer]; !ok {
+		c.convCtxs[layer] = c.backend.NewContextSize(1).Layer(layer)
+	}
+
+	buf := c.convCtxs[layer].Zeros(ml.DTypeF32, c.convDim*c.convChannels, c.maxSequences)
+	c.convStates[layer] = buf
+	return buf
+}
+
+func (c *Recurrent) recurrentBuffer(layer int) ml.Tensor {
+	if buf, ok := c.recurrentStates[layer]; ok {
+		return buf
+	}
+
+	if _, ok := c.recurrentCtxs[layer]; !ok {
+		c.recurrentCtxs[layer] = c.backend.NewContextSize(1).Layer(layer)
+	}
+
+	buf := c.recurrentCtxs[layer].Zeros(ml.DTypeF32, c.recurrentStateSize, c.maxSequences)
+	c.recurrentStates[layer] = buf
+	return buf
+}
+
+func (c *Recurrent) ensureWritable(ctx ml.Context) error {
+	c.ensureWritableOnce(ctx)
+	return c.writableError
+}
+
+func (c *Recurrent) currentSlotRows(ctx ml.Context, buf ml.Tensor, rowSize int) ml.Tensor {
+	if start, ok := c.contiguousSlots(); ok {
+		offset := start * buf.Stride(1)
+		return buf.View(ctx, offset, rowSize, buf.Stride(1), c.NumSeqs())
+	}
+
+	return buf.Rows(ctx, c.SlotsTensor())
+}
+
+func (c *Recurrent) writeCurrentSlotRows(ctx ml.Context, buf ml.Tensor, rowSize int, src ml.Tensor) {
+	if start, ok := c.contiguousSlots(); ok {
+		offset := start * buf.Stride(1)
+		view := buf.View(ctx, offset, rowSize, buf.Stride(1), c.NumSeqs())
+		ctx.Forward(src.Copy(ctx, view))
+		return
+	}
+
+	ctx.Forward(buf.SetRows(ctx, src, c.SlotsTensor()))
+}
+
+func (c *Recurrent) ensureWritableOnce(ctx ml.Context) {
+	if !c.writableEnsured {
+		needsWritable := false
+		for _, seq := range c.curSeqs {
+			slot, ok := c.slotForSeq[seq]
+			if !ok {
+				continue
+			}
+			if slot >= 0 && slot < len(c.refCount) && c.refCount[slot] > 1 {
+				needsWritable = true
+				break
+			}
+		}
+
+		if needsWritable {
+			if err := c.EnsureWritable(ctx); err != nil {
+				c.writableError = err
+			}
+		}
+		c.writableEnsured = true
+	}
+}
+
+// ConvState returns conv state for current batch sequences as [convDim, convChannels, nSeqs].
+func (c *Recurrent) ConvState(ctx ml.Context, layer int) (ml.Tensor, error) {
+	if err := c.ensureWritable(ctx); err != nil {
+		return nil, err
+	}
+
+	buf := c.convBuffer(layer)
+	cur := c.currentSlotRows(ctx, buf, c.convDim*c.convChannels)
+	return cur.Reshape(ctx, c.convDim, c.convChannels, c.NumSeqs()), nil
+}
+
+// UpdateConvState writes new conv state for current batch sequences.
+func (c *Recurrent) UpdateConvState(ctx ml.Context, layer int, newState ml.Tensor) {
+	buf := c.convBuffer(layer)
+	src := newState.Reshape(ctx, c.convDim*c.convChannels, c.NumSeqs())
+	srcF32 := src
+	if src.DType() != ml.DTypeF32 {
+		srcF32 = src.Cast(ctx, ml.DTypeF32)
+	}
+	c.writeCurrentSlotRows(ctx, buf, c.convDim*c.convChannels, srcF32)
+
+	c.captureConvCheckpoint(ctx, layer, srcF32)
+}
+
+// RecurrentState returns recurrent state for current batch sequences with shape [dims..., nSeqs].
+func (c *Recurrent) RecurrentState(ctx ml.Context, layer int, dims ...int) (ml.Tensor, error) {
+	if err := c.ensureWritable(ctx); err != nil {
+		return nil, err
+	}
+	if len(dims) == 0 {
+		return nil, ErrInvalidRecurrentShape
+	}
+
+	size := 1
+	for _, d := range dims {
+		if d <= 0 {
+			return nil, ErrInvalidRecurrentShape
+		}
+		size *= d
+	}
+	if size != c.recurrentStateSize {
+		return nil, fmt.Errorf("%w: got %v (size %d), want size %d", ErrInvalidRecurrentShape, dims, size, c.recurrentStateSize)
+	}
+
+	buf := c.recurrentBuffer(layer)
+	cur := c.currentSlotRows(ctx, buf, c.recurrentStateSize)
+	shape := make([]int, 0, len(dims)+1)
+	shape = append(shape, dims...)
+	shape = append(shape, c.NumSeqs())
+	return cur.Reshape(ctx, shape...), nil
+}
+
+// RecurrentState4D returns recurrent state as [dim0, dim1, dim2, nSeqs].
+func (c *Recurrent) RecurrentState4D(ctx ml.Context, layer int, dim0, dim1, dim2 int) (ml.Tensor, error) {
+	if err := c.ensureWritable(ctx); err != nil {
+		return nil, err
+	}
+	if dim0 <= 0 || dim1 <= 0 || dim2 <= 0 {
+		return nil, ErrInvalidRecurrentShape
+	}
+
+	size := dim0 * dim1 * dim2
+	if size != c.recurrentStateSize {
+		return nil, fmt.Errorf("%w: got [%d %d %d] (size %d), want size %d", ErrInvalidRecurrentShape, dim0, dim1, dim2, size, c.recurrentStateSize)
+	}
+
+	buf := c.recurrentBuffer(layer)
+	cur := c.currentSlotRows(ctx, buf, c.recurrentStateSize)
+	return cur.Reshape(ctx, dim0, dim1, dim2, c.NumSeqs()), nil
+}
+
+// UpdateRecurrentState writes new recurrent state for current batch sequences.
+func (c *Recurrent) UpdateRecurrentState(ctx ml.Context, layer int, newState ml.Tensor) {
+	buf := c.recurrentBuffer(layer)
+	src := newState.Reshape(ctx, c.recurrentStateSize, c.NumSeqs())
+	srcF32 := src
+	if src.DType() != ml.DTypeF32 {
+		srcF32 = src.Cast(ctx, ml.DTypeF32)
+	}
+	c.writeCurrentSlotRows(ctx, buf, c.recurrentStateSize, srcF32)
+
+	c.captureRecurrentCheckpoint(ctx, layer, srcF32)
+}
+
+// IsSupportedForBatch returns true if the current batch layout supports recurrent layers.
+func (c *Recurrent) IsSupportedForBatch() bool {
+	return c.curSeqTokens > 0 && len(c.curSeqs) > 0
+}
+
+// Seqs returns the ordered unique sequences for the current forward pass.
+func (c *Recurrent) Seqs() []int {
+	return slices.Clone(c.curSeqs)
+}

--- a/kvcache/recurrent_checkpoints.go
+++ b/kvcache/recurrent_checkpoints.go
@@ -1,0 +1,561 @@
+package kvcache
+
+import (
+	"log/slog"
+	"math"
+
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model/input"
+)
+
+// TODO(jmorganca): Add byte-serialized host-RAM checkpoints to reduce GPU
+// memory usage while preserving prefix reuse for recurrent state.
+
+type checkpointEntry struct {
+	pos       int32
+	conv      map[int]ml.Tensor
+	recurrent map[int]ml.Tensor
+}
+
+type slotCheckpointStore struct {
+	entries []checkpointEntry
+	size    int
+	next    int
+	lastPos int32
+}
+
+type checkpointRestore struct {
+	slot int
+	idx  int
+	pos  int32
+}
+
+func newSlotCheckpointStore(n int) *slotCheckpointStore {
+	entries := make([]checkpointEntry, n)
+	for i := range entries {
+		entries[i].pos = -1
+	}
+	return &slotCheckpointStore{
+		entries: entries,
+		lastPos: -1,
+	}
+}
+
+func (s *slotCheckpointStore) reset() {
+	s.size = 0
+	s.next = 0
+	s.lastPos = -1
+	for i := range s.entries {
+		s.entries[i].pos = -1
+	}
+}
+
+func (s *slotCheckpointStore) record(pos int32) int {
+	if len(s.entries) == 0 {
+		return -1
+	}
+	idx := s.next
+	s.next = (s.next + 1) % len(s.entries)
+	if s.size < len(s.entries) {
+		s.size++
+	}
+	s.entries[idx].pos = pos
+	s.lastPos = pos
+	return idx
+}
+
+func (s *slotCheckpointStore) bestIndex(targetPos int32) (int, int32, bool) {
+	bestIdx := -1
+	bestPos := int32(-1)
+	for i := range s.entries {
+		pos := s.entries[i].pos
+		if pos < 0 || pos >= targetPos {
+			continue
+		}
+		if pos > bestPos {
+			bestPos = pos
+			bestIdx = i
+		}
+	}
+	if bestIdx < 0 {
+		return -1, -1, false
+	}
+	return bestIdx, bestPos, true
+}
+
+func (s *slotCheckpointStore) pruneAfter(pos int32) {
+	if len(s.entries) == 0 {
+		s.size = 0
+		s.next = 0
+		s.lastPos = -1
+		return
+	}
+
+	size := 0
+	next := -1
+	minPos := int32(math.MaxInt32)
+	minIdx := 0
+	for i := range s.entries {
+		if s.entries[i].pos > pos {
+			s.entries[i].pos = -1
+		}
+		if s.entries[i].pos >= 0 {
+			size++
+			if s.entries[i].pos < minPos {
+				minPos = s.entries[i].pos
+				minIdx = i
+			}
+		} else if next == -1 {
+			next = i
+		}
+	}
+
+	s.size = size
+	if size == 0 {
+		s.next = 0
+		s.lastPos = -1
+		return
+	}
+	if next != -1 {
+		s.next = next
+	} else {
+		// Full ring: overwrite the oldest checkpoint next.
+		s.next = minIdx
+	}
+	s.lastPos = pos
+}
+
+func (s *slotCheckpointStore) shiftRange(beginIndex, endIndex int32) {
+	if len(s.entries) == 0 {
+		s.size = 0
+		s.next = 0
+		s.lastPos = -1
+		return
+	}
+
+	offset := beginIndex - endIndex
+
+	size := 0
+	next := -1
+	minPos := int32(math.MaxInt32)
+	maxPos := int32(-1)
+	minIdx := 0
+
+	for i := range s.entries {
+		pos := s.entries[i].pos
+		if pos >= 0 {
+			if pos >= beginIndex && pos < endIndex {
+				s.entries[i].pos = -1
+			} else if pos >= endIndex {
+				s.entries[i].pos = pos + offset
+			}
+		}
+
+		pos = s.entries[i].pos
+		if pos >= 0 {
+			size++
+			if pos < minPos {
+				minPos = pos
+				minIdx = i
+			}
+			if pos > maxPos {
+				maxPos = pos
+			}
+		} else if next == -1 {
+			next = i
+		}
+	}
+
+	s.size = size
+	if size == 0 {
+		s.next = 0
+		s.lastPos = -1
+		return
+	}
+
+	if next != -1 {
+		s.next = next
+	} else {
+		// Full ring: overwrite the oldest checkpoint next.
+		s.next = minIdx
+	}
+	s.lastPos = maxPos
+}
+
+func (s *slotCheckpointStore) window() (size int, minPos, maxPos, lastPos int32) {
+	minPos = int32(math.MaxInt32)
+	maxPos = int32(-1)
+	for i := range s.entries {
+		pos := s.entries[i].pos
+		if pos < 0 {
+			continue
+		}
+		size++
+		if pos < minPos {
+			minPos = pos
+		}
+		if pos > maxPos {
+			maxPos = pos
+		}
+	}
+	if size == 0 {
+		minPos = -1
+		maxPos = -1
+	}
+	return size, minPos, maxPos, s.lastPos
+}
+
+func (c *Recurrent) checkpointTag() string {
+	if c.logPrefix == "" {
+		return "kvcache.recurrent"
+	}
+	return c.logPrefix
+}
+
+func (c *Recurrent) planCheckpoints(batch input.Batch) {
+	if c.checkpointCount == 0 || len(c.curSeqs) == 0 {
+		c.curCheckpointPos = c.curCheckpointPos[:0]
+		for k := range c.curCheckpointSlots {
+			delete(c.curCheckpointSlots, k)
+		}
+		return
+	}
+
+	if cap(c.curCheckpointPos) < len(c.curSeqs) {
+		c.curCheckpointPos = make([]int32, len(c.curSeqs))
+	} else {
+		c.curCheckpointPos = c.curCheckpointPos[:len(c.curSeqs)]
+	}
+	for i := range c.curCheckpointPos {
+		c.curCheckpointPos[i] = -1
+	}
+	for k := range c.curCheckpointSlots {
+		delete(c.curCheckpointSlots, k)
+	}
+
+	posMax := make(map[int]int32, len(c.curSeqs))
+	for i, seq := range batch.Sequences {
+		pos := batch.Positions[i]
+		if cur, ok := posMax[seq]; !ok || pos > cur {
+			posMax[seq] = pos
+		}
+	}
+
+	for i, seq := range c.curSeqs {
+		pos, ok := posMax[seq]
+		if !ok {
+			continue
+		}
+		if pos < c.checkpointMinPos {
+			continue
+		}
+		slot := c.curSlots[i]
+		store := c.checkpointStore(slot)
+		lastPos := store.lastPos
+		if lastPos < 0 || pos-lastPos >= c.checkpointInterval {
+			c.curCheckpointPos[i] = pos
+		}
+	}
+}
+
+func (c *Recurrent) checkpointStore(slot int) *slotCheckpointStore {
+	store, ok := c.checkpoints[slot]
+	if ok {
+		return store
+	}
+	store = newSlotCheckpointStore(c.checkpointCount)
+	c.checkpoints[slot] = store
+	return store
+}
+
+func (c *Recurrent) checkpointIndexForSlot(slot int, pos int32) int {
+	if c.checkpointCount == 0 {
+		return -1
+	}
+	if idx, ok := c.curCheckpointSlots[slot]; ok {
+		return idx
+	}
+	store := c.checkpointStore(slot)
+	idx := store.record(pos)
+	if idx >= 0 {
+		c.curCheckpointSlots[slot] = idx
+	}
+	return idx
+}
+
+func (c *Recurrent) hasCheckpoint(seq int, pos int32) bool {
+	if pos <= 0 {
+		return false
+	}
+	slot, ok := c.slotForSeq[seq]
+	if !ok {
+		return false
+	}
+	store, ok := c.checkpoints[slot]
+	if !ok {
+		return false
+	}
+	_, _, ok = store.bestIndex(pos)
+	return ok
+}
+
+func (c *Recurrent) PrepareRestore(seq int, targetPos int32) (int32, bool) {
+	if targetPos <= 0 {
+		return 0, false
+	}
+	slot, ok := c.slotForSeq[seq]
+	if !ok {
+		return 0, false
+	}
+	store, ok := c.checkpoints[slot]
+	if !ok {
+		slog.Debug(c.checkpointTag()+": checkpoint miss", "seq", seq, "slot", slot, "target", targetPos, "size", 0)
+		return 0, false
+	}
+	idx, pos, ok := store.bestIndex(targetPos)
+	if !ok {
+		size, minPos, maxPos, lastPos := store.window()
+		slog.Debug(c.checkpointTag()+": checkpoint miss", "seq", seq, "slot", slot, "target", targetPos, "size", size,
+			"min", minPos, "max", maxPos, "last", lastPos)
+		return 0, false
+	}
+	c.pendingRestore[seq] = checkpointRestore{
+		slot: slot,
+		idx:  idx,
+		pos:  pos,
+	}
+	return pos + 1, true
+}
+
+func (c *Recurrent) applyCheckpointRestore(restore checkpointRestore) error {
+	entry, ok := c.restoreEntry(restore)
+	if !ok {
+		return ErrNotSupported
+	}
+
+	ctx := c.backend.NewContext()
+	defer ctx.Close()
+
+	slotIdx := ctx.Input().FromInts([]int32{int32(restore.slot)}, 1)
+	for layer, src := range entry.conv {
+		buf := c.convBuffer(layer)
+		ctx.Forward(buf.SetRows(ctx, src, slotIdx))
+	}
+	for layer, src := range entry.recurrent {
+		buf := c.recurrentBuffer(layer)
+		ctx.Forward(buf.SetRows(ctx, src, slotIdx))
+	}
+
+	if len(entry.conv) > 0 || len(entry.recurrent) > 0 {
+		ctx.Compute()
+	}
+	store := c.checkpoints[restore.slot]
+	store.pruneAfter(restore.pos)
+	return nil
+}
+
+func (c *Recurrent) restoreComplete(restore checkpointRestore) bool {
+	_, ok := c.restoreEntry(restore)
+	return ok
+}
+
+func (c *Recurrent) restoreEntry(restore checkpointRestore) (*checkpointEntry, bool) {
+	store, ok := c.checkpoints[restore.slot]
+	if !ok || restore.idx < 0 || restore.idx >= len(store.entries) {
+		return nil, false
+	}
+	entry := &store.entries[restore.idx]
+	if entry.pos < 0 {
+		return nil, false
+	}
+	if !c.entryComplete(entry) {
+		return nil, false
+	}
+	return entry, true
+}
+
+func (c *Recurrent) entryComplete(entry *checkpointEntry) bool {
+	for layer := range c.convStates {
+		if entry.conv == nil || entry.conv[layer] == nil {
+			return false
+		}
+	}
+	for layer := range c.recurrentStates {
+		if entry.recurrent == nil || entry.recurrent[layer] == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *Recurrent) clearCheckpoints(slot int) {
+	if store, ok := c.checkpoints[slot]; ok {
+		store.reset()
+	}
+}
+
+func (c *Recurrent) shiftCheckpoints(slot int, beginIndex, endIndex int32) {
+	if store, ok := c.checkpoints[slot]; ok {
+		store.shiftRange(beginIndex, endIndex)
+	}
+}
+
+func (c *Recurrent) copyCheckpoints(ctx ml.Context, srcSlot, dstSlot int) {
+	if c.checkpointCount == 0 {
+		return
+	}
+	srcStore, ok := c.checkpoints[srcSlot]
+	if !ok || srcStore.size == 0 {
+		return
+	}
+	dstStore := c.checkpointStore(dstSlot)
+	dstStore.size = srcStore.size
+	dstStore.next = srcStore.next
+	dstStore.lastPos = srcStore.lastPos
+
+	for i := range srcStore.entries {
+		srcEntry := &srcStore.entries[i]
+		dstEntry := &dstStore.entries[i]
+		dstEntry.pos = srcEntry.pos
+		if srcEntry.conv != nil {
+			if dstEntry.conv == nil {
+				dstEntry.conv = make(map[int]ml.Tensor)
+			}
+			for layer, src := range srcEntry.conv {
+				dst := c.ensureCheckpointConv(layer, dstEntry)
+				ctx.Forward(src.Copy(ctx, dst))
+			}
+		}
+		if srcEntry.recurrent != nil {
+			if dstEntry.recurrent == nil {
+				dstEntry.recurrent = make(map[int]ml.Tensor)
+			}
+			for layer, src := range srcEntry.recurrent {
+				dst := c.ensureCheckpointRecurrent(layer, dstEntry)
+				ctx.Forward(src.Copy(ctx, dst))
+			}
+		}
+	}
+}
+
+func (c *Recurrent) captureConvCheckpoint(ctx ml.Context, layer int, src ml.Tensor) {
+	if c.checkpointCount == 0 {
+		return
+	}
+	if c.reserveCheckpoints {
+		c.reserveCheckpointConv(layer)
+		return
+	}
+	if len(c.curCheckpointPos) == 0 {
+		return
+	}
+	for i, pos := range c.curCheckpointPos {
+		if pos < 0 {
+			continue
+		}
+		slot := c.curSlots[i]
+		idx := c.checkpointIndexForSlot(slot, pos)
+		if idx < 0 {
+			continue
+		}
+		entry := &c.checkpoints[slot].entries[idx]
+		dst := c.ensureCheckpointConv(layer, entry)
+		seqSlice := src.Slice(ctx, 1, i, i+1, 1)
+		ctx.Forward(seqSlice.Copy(ctx, dst))
+	}
+}
+
+func (c *Recurrent) captureRecurrentCheckpoint(ctx ml.Context, layer int, src ml.Tensor) {
+	if c.checkpointCount == 0 {
+		return
+	}
+	if c.reserveCheckpoints {
+		c.reserveCheckpointRecurrent(layer)
+		return
+	}
+	if len(c.curCheckpointPos) == 0 {
+		return
+	}
+	for i, pos := range c.curCheckpointPos {
+		if pos < 0 {
+			continue
+		}
+		slot := c.curSlots[i]
+		idx := c.checkpointIndexForSlot(slot, pos)
+		if idx < 0 {
+			continue
+		}
+		entry := &c.checkpoints[slot].entries[idx]
+		dst := c.ensureCheckpointRecurrent(layer, entry)
+		seqSlice := src.Slice(ctx, 1, i, i+1, 1)
+		ctx.Forward(seqSlice.Copy(ctx, dst))
+	}
+}
+
+func (c *Recurrent) ensureCheckpointConv(layer int, entry *checkpointEntry) ml.Tensor {
+	if entry.conv == nil {
+		entry.conv = make(map[int]ml.Tensor)
+	}
+	if t, ok := entry.conv[layer]; ok {
+		return t
+	}
+	ctx, ok := c.checkpointConvCtxs[layer]
+	if !ok {
+		ctx = c.backend.NewContextSize(c.checkpointCtxSize).Layer(layer)
+		c.checkpointConvCtxs[layer] = ctx
+	}
+	t := ctx.Zeros(ml.DTypeF32, c.convDim*c.convChannels, 1)
+	entry.conv[layer] = t
+	return t
+}
+
+func (c *Recurrent) ensureCheckpointRecurrent(layer int, entry *checkpointEntry) ml.Tensor {
+	if entry.recurrent == nil {
+		entry.recurrent = make(map[int]ml.Tensor)
+	}
+	if t, ok := entry.recurrent[layer]; ok {
+		return t
+	}
+	ctx, ok := c.checkpointRecurCtxs[layer]
+	if !ok {
+		ctx = c.backend.NewContextSize(c.checkpointCtxSize).Layer(layer)
+		c.checkpointRecurCtxs[layer] = ctx
+	}
+	t := ctx.Zeros(ml.DTypeF32, c.recurrentStateSize, 1)
+	entry.recurrent[layer] = t
+	return t
+}
+
+func (c *Recurrent) reserveCheckpointConv(layer int) {
+	key := checkpointReserveKey(layer, 0)
+	if _, ok := c.checkpointReserved[key]; ok {
+		return
+	}
+	for slot := range c.maxSequences {
+		store := c.checkpointStore(slot)
+		for i := range store.entries {
+			entry := &store.entries[i]
+			_ = c.ensureCheckpointConv(layer, entry)
+		}
+	}
+	c.checkpointReserved[key] = struct{}{}
+}
+
+func (c *Recurrent) reserveCheckpointRecurrent(layer int) {
+	key := checkpointReserveKey(layer, 1)
+	if _, ok := c.checkpointReserved[key]; ok {
+		return
+	}
+	for slot := range c.maxSequences {
+		store := c.checkpointStore(slot)
+		for i := range store.entries {
+			entry := &store.entries[i]
+			_ = c.ensureCheckpointRecurrent(layer, entry)
+		}
+	}
+	c.checkpointReserved[key] = struct{}{}
+}
+
+func checkpointReserveKey(layer int, kind int) int {
+	return layer*2 + kind
+}

--- a/kvcache/recurrent_checkpoints_test.go
+++ b/kvcache/recurrent_checkpoints_test.go
@@ -1,0 +1,288 @@
+package kvcache
+
+import (
+	"errors"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/ml"
+)
+
+func newTestCache() *Recurrent {
+	return NewRecurrentCache(RecurrentConfig{ConvDim: 1, ConvChannels: 2, RecurrentStateSize: 2})
+}
+
+func TestSlotCheckpointStoreBestIndex(t *testing.T) {
+	store := newSlotCheckpointStore(2)
+	store.record(10)
+	store.record(20)
+
+	_, pos, ok := store.bestIndex(15)
+	if !ok || pos != 10 {
+		t.Fatalf("expected best pos 10, got pos=%d ok=%v", pos, ok)
+	}
+
+	store.record(30) // overwrite oldest (10)
+
+	if _, _, ok := store.bestIndex(15); ok {
+		t.Fatalf("expected no checkpoint for targetPos=15 after overwrite")
+	}
+
+	_, pos, ok = store.bestIndex(40)
+	if !ok || pos != 30 {
+		t.Fatalf("expected best pos 30, got pos=%d ok=%v", pos, ok)
+	}
+}
+
+func TestCachePrepareRestore(t *testing.T) {
+	cache := newTestCache()
+	cache.checkpointCount = 3
+	cache.checkpoints = make(map[int]*slotCheckpointStore)
+	cache.pendingRestore = make(map[int]checkpointRestore)
+
+	cache.slotForSeq[1] = 0
+	store := cache.checkpointStore(0)
+	store.record(5)
+	store.record(9)
+	store.record(15)
+
+	restorePos, ok := cache.PrepareRestore(1, 12)
+	if !ok {
+		t.Fatalf("expected restore ok")
+	}
+	if restorePos != 10 {
+		t.Fatalf("expected restorePos 10, got %d", restorePos)
+	}
+	rest, ok := cache.pendingRestore[1]
+	if !ok {
+		t.Fatalf("expected pending restore entry")
+	}
+	if rest.pos != 9 {
+		t.Fatalf("expected pending restore pos 9, got %d", rest.pos)
+	}
+}
+
+func TestSlotCheckpointStorePruneAfter(t *testing.T) {
+	store := newSlotCheckpointStore(3)
+	store.record(10)
+	store.record(20)
+	store.record(30)
+
+	store.pruneAfter(20)
+
+	if store.lastPos != 20 {
+		t.Fatalf("expected lastPos 20, got %d", store.lastPos)
+	}
+
+	_, pos, ok := store.bestIndex(25)
+	if !ok || pos != 20 {
+		t.Fatalf("expected best pos 20 after prune, got pos=%d ok=%v", pos, ok)
+	}
+
+	_, pos, ok = store.bestIndex(35)
+	if !ok || pos != 20 {
+		t.Fatalf("expected pruned best pos 20 for targetPos=35, got pos=%d ok=%v", pos, ok)
+	}
+}
+
+func TestCacheRestoreRejectsIncompleteCheckpoint(t *testing.T) {
+	cache := newTestCache()
+	cache.checkpointCount = 3
+	cache.checkpoints = make(map[int]*slotCheckpointStore)
+	cache.pendingRestore = make(map[int]checkpointRestore)
+
+	cache.slotForSeq[1] = 0
+	cache.refCount = []int{1}
+	cache.freeSlots = nil
+
+	// Simulate layer 0 requires both conv and recurrent checkpoints.
+	cache.convStates[0] = nil
+	cache.recurrentStates[0] = nil
+
+	store := cache.checkpointStore(0)
+	idx := store.record(9)
+	entry := &store.entries[idx]
+	entry.conv = map[int]ml.Tensor{0: nil}
+	// entry.recurrent intentionally missing
+
+	cache.pendingRestore[1] = checkpointRestore{slot: 0, idx: idx, pos: 9}
+
+	err := cache.Remove(1, 10, math.MaxInt32)
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("expected ErrNotSupported for incomplete checkpoint, got %v", err)
+	}
+}
+
+func TestCacheRestoreAcceptsCompleteCheckpoint(t *testing.T) {
+	cache := newTestCache()
+	cache.checkpointCount = 3
+	cache.checkpoints = make(map[int]*slotCheckpointStore)
+	cache.pendingRestore = make(map[int]checkpointRestore)
+
+	cache.slotForSeq[1] = 0
+	cache.refCount = []int{1}
+	cache.freeSlots = nil
+
+	store := cache.checkpointStore(0)
+	idx := store.record(9)
+
+	cache.pendingRestore[1] = checkpointRestore{slot: 0, idx: idx, pos: 9}
+
+	restore := cache.pendingRestore[1]
+	if !cache.restoreComplete(restore) {
+		t.Fatalf("expected restoreComplete to return true for complete checkpoint")
+	}
+}
+
+func TestCacheRecurrentStateShapeValidation(t *testing.T) {
+	cache := newTestCache()
+	_, err := cache.RecurrentState(nil, 0, 3)
+	if !errors.Is(err, ErrInvalidRecurrentShape) {
+		t.Fatalf("expected ErrInvalidRecurrentShape, got %v", err)
+	}
+}
+
+func TestSlotCheckpointStoreShiftRange(t *testing.T) {
+	store := newSlotCheckpointStore(5)
+	store.record(1)
+	store.record(4)
+	store.record(7)
+	store.record(10)
+
+	store.shiftRange(2, 6)
+
+	var positions []int32
+	for i := range store.entries {
+		if store.entries[i].pos >= 0 {
+			positions = append(positions, store.entries[i].pos)
+		}
+	}
+	slices.Sort(positions)
+
+	want := []int32{1, 3, 6}
+	if !slices.Equal(positions, want) {
+		t.Fatalf("unexpected shifted positions: got=%v want=%v", positions, want)
+	}
+	if store.lastPos != 6 {
+		t.Fatalf("expected lastPos 6, got %d", store.lastPos)
+	}
+}
+
+func TestCacheRemoveMiddleShiftsCheckpoints(t *testing.T) {
+	cache := newTestCache()
+	cache.slotForSeq[1] = 0
+	cache.refCount = []int{1}
+	cache.pendingRestore[1] = checkpointRestore{slot: 0, idx: 0, pos: 1}
+
+	store := cache.checkpointStore(0)
+	store.record(1)
+	store.record(4)
+	store.record(7)
+	store.record(10)
+
+	if err := cache.Remove(1, 2, 6); err != nil {
+		t.Fatalf("expected middle remove to succeed, got %v", err)
+	}
+
+	if _, ok := cache.pendingRestore[1]; ok {
+		t.Fatalf("expected pending restore to be cleared after middle remove")
+	}
+
+	var positions []int32
+	for i := range store.entries {
+		if store.entries[i].pos >= 0 {
+			positions = append(positions, store.entries[i].pos)
+		}
+	}
+	slices.Sort(positions)
+
+	want := []int32{1, 3, 6}
+	if !slices.Equal(positions, want) {
+		t.Fatalf("unexpected checkpoint positions after remove: got=%v want=%v", positions, want)
+	}
+}
+
+func TestSlotCheckpointStoreRingBufferWrapAround(t *testing.T) {
+	store := newSlotCheckpointStore(3)
+
+	store.record(10)
+	store.record(20)
+	store.record(30)
+
+	store.entries[0].conv = make(map[int]ml.Tensor)
+	store.entries[0].conv[0] = nil
+	store.entries[0].recurrent = make(map[int]ml.Tensor)
+	store.entries[0].recurrent[0] = nil
+
+	store.record(40)
+
+	if store.entries[0].conv == nil {
+		t.Fatalf("expected conv map to be preserved on reuse")
+	}
+	if store.entries[0].recurrent == nil {
+		t.Fatalf("expected recurrent map to be preserved on reuse")
+	}
+	if store.entries[0].pos != 40 {
+		t.Fatalf("expected entry 0 pos to be 40, got %d", store.entries[0].pos)
+	}
+}
+
+func TestSlotCheckpointStoreFullCapacity(t *testing.T) {
+	store := newSlotCheckpointStore(2)
+
+	idx1 := store.record(10)
+	idx2 := store.record(20)
+
+	if idx1 != 0 || idx2 != 1 {
+		t.Fatalf("expected indices 0, 1, got %d, %d", idx1, idx2)
+	}
+	if store.size != 2 {
+		t.Fatalf("expected size 2, got %d", store.size)
+	}
+
+	_, pos1, ok1 := store.bestIndex(15)
+	_, pos2, ok2 := store.bestIndex(25)
+
+	if !ok1 || pos1 != 10 {
+		t.Fatalf("expected best pos 10 for target 15, got pos=%d ok=%v", pos1, ok1)
+	}
+	if !ok2 || pos2 != 20 {
+		t.Fatalf("expected best pos 20 for target 25, got pos=%d ok=%v", pos2, ok2)
+	}
+}
+
+func TestSlotCheckpointStoreEmptyBuffer(t *testing.T) {
+	store := newSlotCheckpointStore(0)
+
+	idx := store.record(10)
+	if idx != -1 {
+		t.Fatalf("expected record to return -1 for empty buffer, got %d", idx)
+	}
+
+	_, _, ok := store.bestIndex(15)
+	if ok {
+		t.Fatalf("expected no checkpoint for empty buffer")
+	}
+}
+
+func TestSlotCheckpointStorePruneAfterAll(t *testing.T) {
+	store := newSlotCheckpointStore(3)
+	store.record(10)
+	store.record(20)
+	store.record(30)
+
+	store.pruneAfter(5)
+
+	if store.size != 0 {
+		t.Fatalf("expected size 0 after pruning all, got %d", store.size)
+	}
+	if store.lastPos != -1 {
+		t.Fatalf("expected lastPos -1 after pruning all, got %d", store.lastPos)
+	}
+
+	_, _, ok := store.bestIndex(100)
+	if ok {
+		t.Fatalf("expected no checkpoint after pruning all")
+	}
+}

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -186,7 +186,6 @@ type Tensor interface {
 	Cumsum(ctx Context) Tensor
 	Conv1D(ctx Context, kernel Tensor, stride, padding, dilation int) Tensor
 	SSMConv(ctx Context, kernel Tensor) Tensor
-	Neg(ctx Context) Tensor
 	Fill(ctx Context, value float32) Tensor
 	Diag(ctx Context) Tensor
 	Tri(ctx Context, triType int) Tensor

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -172,7 +172,9 @@ type Tensor interface {
 
 	Sin(ctx Context) Tensor
 	Cos(ctx Context) Tensor
+	Exp(ctx Context) Tensor
 	Tanh(ctx Context) Tensor
+	Softplus(ctx Context) Tensor
 	GELU(ctx Context, up ...Tensor) Tensor
 	SILU(ctx Context, up ...Tensor) Tensor
 	RELU(ctx Context, up ...Tensor) Tensor
@@ -180,6 +182,16 @@ type Tensor interface {
 
 	// AlphaLimitSILU is a variant of SILU that clamps the input to the range [-limit, limit]
 	SILUAlphaLimit(ctx Context, up Tensor, alpha, limit float32) Tensor
+
+	Cumsum(ctx Context) Tensor
+	Conv1D(ctx Context, kernel Tensor, stride, padding, dilation int) Tensor
+	SSMConv(ctx Context, kernel Tensor) Tensor
+	Neg(ctx Context) Tensor
+	Fill(ctx Context, value float32) Tensor
+	Diag(ctx Context) Tensor
+	Tri(ctx Context, triType int) Tensor
+	SolveTri(ctx Context, b Tensor, left, lower, unitDiag bool) Tensor
+	Repeat4D(ctx Context, ne0, ne1, ne2, ne3 int) Tensor
 
 	Reshape(ctx Context, shape ...int) Tensor
 	View(ctx Context, offset int, shape ...int) Tensor

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -179,11 +179,13 @@ type Tensor interface {
 	SILU(ctx Context, up ...Tensor) Tensor
 	RELU(ctx Context, up ...Tensor) Tensor
 	Sigmoid(ctx Context) Tensor
+	SigmoidOut(ctx Context) Tensor
 
 	// AlphaLimitSILU is a variant of SILU that clamps the input to the range [-limit, limit]
 	SILUAlphaLimit(ctx Context, up Tensor, alpha, limit float32) Tensor
 
-	Cumsum(ctx Context) Tensor
+	// CumSum computes cumulative sum along dimension 0
+	CumSum(ctx Context) Tensor
 	Conv1D(ctx Context, kernel Tensor, stride, padding, dilation int) Tensor
 	SSMConv(ctx Context, kernel Tensor) Tensor
 	Fill(ctx Context, value float32) Tensor
@@ -206,6 +208,7 @@ type Tensor interface {
 	Repeat(ctx Context, dim, n int) Tensor
 	Concat(ctx Context, t2 Tensor, dim int) Tensor
 	Rows(ctx Context, t2 Tensor) Tensor
+	SetRows(ctx Context, src Tensor, idxs Tensor) Tensor
 	Copy(ctx Context, t2 Tensor) Tensor
 	Duplicate(ctx Context) Tensor
 

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -350,12 +350,13 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		}
 	}
 
-	// INSTRUMENT: dump blk.0 tensor names to debug gguf mapping
+	// INSTRUMENT: dump blk.0 and blk.1 tensor names to debug gguf mapping
 	for name := range tensors {
-		if strings.HasPrefix(name, "blk.0.") {
+		if strings.HasPrefix(name, "blk.0.") || strings.HasPrefix(name, "blk.1.") {
 			slog.Info("INSTRUMENT: tensor", "name", name)
 		}
 	}
+	slog.Info("INSTRUMENT: total tensors in backend", "count", len(tensors))
 
 	// map devices to backend buffer types so new tensors can be assigned to the correct device
 	deviceBufferTypes := make(map[C.ggml_backend_dev_t]C.ggml_backend_buffer_type_t)

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -1504,13 +1504,6 @@ func (t *Tensor) SSMConv(ctx ml.Context, kernel ml.Tensor) ml.Tensor {
 	}
 }
 
-func (t *Tensor) Neg(ctx ml.Context) ml.Tensor {
-	return &Tensor{
-		b: t.b,
-		t: C.ggml_neg(ctx.(*Context).ctx, t.t),
-	}
-}
-
 func (t *Tensor) Fill(ctx ml.Context, value float32) ml.Tensor {
 	return &Tensor{
 		b: t.b,

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -1469,6 +1469,83 @@ func (t *Tensor) Sigmoid(ctx ml.Context) ml.Tensor {
 	}
 }
 
+func (t *Tensor) Exp(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_exp(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Softplus(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_softplus(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Cumsum(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_cumsum(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Conv1D(ctx ml.Context, kernel ml.Tensor, stride, padding, dilation int) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_conv_1d(ctx.(*Context).ctx, kernel.(*Tensor).t, t.t, C.int(stride), C.int(padding), C.int(dilation)),
+	}
+}
+
+func (t *Tensor) SSMConv(ctx ml.Context, kernel ml.Tensor) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_ssm_conv(ctx.(*Context).ctx, t.t, kernel.(*Tensor).t),
+	}
+}
+
+func (t *Tensor) Neg(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_neg(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Fill(ctx ml.Context, value float32) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_fill(ctx.(*Context).ctx, t.t, C.float(value)),
+	}
+}
+
+func (t *Tensor) Diag(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_diag(ctx.(*Context).ctx, t.t),
+	}
+}
+
+func (t *Tensor) Tri(ctx ml.Context, triType int) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_tri(ctx.(*Context).ctx, t.t, C.enum_ggml_tri_type(triType)),
+	}
+}
+
+func (t *Tensor) SolveTri(ctx ml.Context, b ml.Tensor, left, lower, unitDiag bool) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_solve_tri(ctx.(*Context).ctx, t.t, b.(*Tensor).t, C._Bool(left), C._Bool(lower), C._Bool(unitDiag)),
+	}
+}
+
+func (t *Tensor) Repeat4D(ctx ml.Context, ne0, ne1, ne2, ne3 int) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_repeat_4d(ctx.(*Context).ctx, t.t, C.int64_t(ne0), C.int64_t(ne1), C.int64_t(ne2), C.int64_t(ne3)),
+	}
+}
+
 func (t *Tensor) View(ctx ml.Context, offset int, shape ...int) ml.Tensor {
 	switch len(shape) {
 	case 1:

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -350,6 +350,13 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		}
 	}
 
+	// INSTRUMENT: dump blk.0 tensor names to debug gguf mapping
+	for name := range tensors {
+		if strings.HasPrefix(name, "blk.0.") {
+			slog.Info("INSTRUMENT: tensor", "name", name)
+		}
+	}
+
 	// map devices to backend buffer types so new tensors can be assigned to the correct device
 	deviceBufferTypes := make(map[C.ggml_backend_dev_t]C.ggml_backend_buffer_type_t)
 

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -386,7 +386,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		}
 	}
 
-	maxGraphNodes := max(1024, len(meta.Tensors().Items())*8)
+	maxGraphNodes := max(1024, len(meta.Tensors().Items())*32)
 
 	sched := C.ggml_backend_sched_new_ext(
 		(*C.ggml_backend_t)(unsafe.Pointer(&schedBackends[0])),

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -1358,6 +1358,13 @@ func (t *Tensor) Rows(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	}
 }
 
+func (t *Tensor) SetRows(ctx ml.Context, src ml.Tensor, idxs ml.Tensor) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_set_rows(ctx.(*Context).ctx, t.t, src.(*Tensor).t, idxs.(*Tensor).t),
+	}
+}
+
 func (t *Tensor) Copy(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	return &Tensor{
 		b: t.b,
@@ -1477,6 +1484,13 @@ func (t *Tensor) Sigmoid(ctx ml.Context) ml.Tensor {
 	}
 }
 
+func (t *Tensor) SigmoidOut(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_sigmoid(ctx.(*Context).ctx, t.t),
+	}
+}
+
 func (t *Tensor) Exp(ctx ml.Context) ml.Tensor {
 	return &Tensor{
 		b: t.b,
@@ -1491,7 +1505,7 @@ func (t *Tensor) Softplus(ctx ml.Context) ml.Tensor {
 	}
 }
 
-func (t *Tensor) Cumsum(ctx ml.Context) ml.Tensor {
+func (t *Tensor) CumSum(ctx ml.Context) ml.Tensor {
 	return &Tensor{
 		b: t.b,
 		t: C.ggml_cumsum(ctx.(*Context).ctx, t.t),

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -1597,55 +1597,39 @@ func (t *Tensor) View(ctx ml.Context, offset int, shape ...int) ml.Tensor {
 	}
 }
 
+// Slice returns a view of the tensor sliced along dim from start to end with stride.
+// Slice panics if the dimension is invalid or the slice parameters are out of range.
+// If dim=0 and stride>1, the tensor is a copy rather than a view to ensure proper shape.
 func (t *Tensor) Slice(ctx ml.Context, dim, start, end, stride int) ml.Tensor {
-	nDims := int(C.ggml_n_dims(t.t))
-	if dim < 0 || dim >= nDims {
-		panic("Slice: dimension out of range")
+	if dim < 0 || dim >= C.GGML_MAX_DIMS {
+		panic("invalid dimension")
+	} else if start < 0 || end > t.Dim(dim) || start >= end || stride < 1 {
+		panic("invalid slice parameters")
 	}
 
-	sliceLen := (end - start + stride - 1) / stride
-	offset := start * t.Stride(dim)
+	if dim == 0 && stride > 1 {
+		return t.View(ctx,
+			start*t.Stride(0), 1,
+			stride*t.Stride(0), (end-start+1)/stride,
+			t.Stride(1), t.Dim(1),
+			t.Stride(2), t.Dim(2)*t.Dim(3),
+		).Contiguous(ctx, (end-start+1)/stride, t.Dim(1), t.Dim(2), t.Dim(3))
+	}
 
-	// Build shape/stride pairs for View: [ne0, nb1, ne1, nb2, ne2, ...]
-	// View expects interleaved (shape, stride) pairs after the first dimension
-	switch nDims {
-	case 1:
-		return t.View(ctx, offset, sliceLen)
-	case 2:
-		ne := [2]int{t.Dim(0), t.Dim(1)}
-		nb := [2]int{t.Stride(0), t.Stride(1)}
-		ne[dim] = sliceLen
-		return &Tensor{
-			b: t.b,
-			t: C.ggml_view_2d(ctx.(*Context).ctx, t.t,
-				C.int64_t(ne[0]), C.int64_t(ne[1]),
-				C.size_t(nb[1]),
-				C.size_t(offset)),
-		}
-	case 3:
-		ne := [3]int{t.Dim(0), t.Dim(1), t.Dim(2)}
-		nb := [3]int{t.Stride(0), t.Stride(1), t.Stride(2)}
-		ne[dim] = sliceLen
-		return &Tensor{
-			b: t.b,
-			t: C.ggml_view_3d(ctx.(*Context).ctx, t.t,
-				C.int64_t(ne[0]), C.int64_t(ne[1]), C.int64_t(ne[2]),
-				C.size_t(nb[1]), C.size_t(nb[2]),
-				C.size_t(offset)),
-		}
-	case 4:
-		ne := [4]int{t.Dim(0), t.Dim(1), t.Dim(2), t.Dim(3)}
-		nb := [4]int{t.Stride(0), t.Stride(1), t.Stride(2), t.Stride(3)}
-		ne[dim] = sliceLen
-		return &Tensor{
-			b: t.b,
-			t: C.ggml_view_4d(ctx.(*Context).ctx, t.t,
-				C.int64_t(ne[0]), C.int64_t(ne[1]), C.int64_t(ne[2]), C.int64_t(ne[3]),
-				C.size_t(nb[1]), C.size_t(nb[2]), C.size_t(nb[3]),
-				C.size_t(offset)),
-		}
-	default:
-		panic("Slice: unsupported number of dimensions")
+	args := []int{
+		start * t.Stride(dim), t.Dim(0),
+		t.Stride(1), t.Dim(1),
+		t.Stride(2), t.Dim(2),
+		t.Stride(3), t.Dim(3),
+	}
+
+	if stride == 1 {
+		args[dim*2+1] = end - start
+		return t.View(ctx, args[0], args[1:]...)
+	} else {
+		args[dim*2] = stride * t.Stride(dim)
+		args[dim*2+1] = (end - start + 1) / stride
+		return t.View(ctx, args[0], args[1:]...)
 	}
 }
 

--- a/ml/nn/rope/rope.go
+++ b/ml/nn/rope/rope.go
@@ -75,3 +75,17 @@ func WithMRoPESections(sections []int) func(*Options) {
 		opts.MRoPE.Sections = sections
 	}
 }
+
+func WithMRoPE(sections []int) func(*Options) {
+	return func(opts *Options) {
+		opts.Type |= 1 << 3
+		opts.MRoPE.Sections = sections
+	}
+}
+
+func WithInterleaveMRoPE(sections []int) func(*Options) {
+	return func(opts *Options) {
+		opts.Type |= 1<<3 | 1<<5
+		opts.MRoPE.Sections = sections
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -211,7 +211,17 @@ func populateFields(base Base, v reflect.Value, tags ...Tag) reflect.Value {
 
 				names := fn(tagsCopy, "", "")
 				for _, name := range names {
-					if tensor := base.Backend().Get(strings.Join(name, ".")); tensor != nil {
+					fullName := strings.Join(name, ".")
+					tensor := base.Backend().Get(fullName)
+					// INSTRUMENT: log tensor lookups for blk.0 to debug qwen35 mapping
+					if strings.HasPrefix(fullName, "blk.0.") {
+						if tensor != nil {
+							slog.Info("INSTRUMENT: tensor found", "name", fullName)
+						} else {
+							slog.Info("INSTRUMENT: tensor NOT found", "name", fullName)
+						}
+					}
+					if tensor != nil {
 						logutil.Trace("found tensor", "", tensor)
 						vv.Set(reflect.ValueOf(tensor))
 						break

--- a/model/models/models.go
+++ b/model/models/models.go
@@ -15,5 +15,6 @@ import (
 	_ "github.com/ollama/ollama/model/models/qwen2"
 	_ "github.com/ollama/ollama/model/models/qwen25vl"
 	_ "github.com/ollama/ollama/model/models/qwen3"
+	_ "github.com/ollama/ollama/model/models/qwen35"
 	_ "github.com/ollama/ollama/model/models/qwen3vl"
 )

--- a/model/models/qwen35/attention.go
+++ b/model/models/qwen35/attention.go
@@ -1,0 +1,103 @@
+package qwen35
+
+import (
+	"errors"
+	"math"
+
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/ml/nn"
+)
+
+// ErrUnsupportedBatchLayout is returned when the batch layout is incompatible
+// with the attention layer requirements.
+var ErrUnsupportedBatchLayout = errors.New("qwen3next: unsupported batch layout")
+
+// FullAttention implements gated attention with QK normalization and sigmoid-gated output.
+// Key differences from standard attention:
+// - Q projection outputs 2x size (Q + gate interleaved)
+// - Both Q and K have RMSNorm
+// - Output is gated: attn * sigmoid(gate)
+type FullAttention struct {
+	Query     *nn.Linear  `gguf:"attn_q"` // outputs [n_embd_head * 2, n_head]
+	QueryNorm *nn.RMSNorm `gguf:"attn_q_norm"`
+	Key       *nn.Linear  `gguf:"attn_k"`
+	KeyNorm   *nn.RMSNorm `gguf:"attn_k_norm"`
+	Value     *nn.Linear  `gguf:"attn_v"`
+	Output    *nn.Linear  `gguf:"attn_output"`
+}
+
+func (sa *FullAttention) Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, cache *HybridCache, opts *Options) (ml.Tensor, error) {
+	// Use Dim() instead of Shape() for consistent behavior during graph construction
+	hiddenDim := hiddenStates.Dim(0)
+	batchSize := hiddenStates.Dim(1)
+	nSeqs := hiddenStates.Dim(2) // 0 if 2D tensor
+
+	if cache != nil && cache.IsSupportedForBatch() {
+		seqTokens := cache.seqTokens()
+		seqs := cache.numSeqs()
+		if seqTokens > 0 && seqs > 0 {
+			if nSeqs > 0 {
+				// 3D tensor: [hiddenDim, seqTokens, nSeqs]
+				if batchSize != seqTokens || nSeqs != seqs {
+					return nil, ErrUnsupportedBatchLayout
+				}
+				hiddenStates = hiddenStates.Reshape(ctx, hiddenDim, seqTokens*seqs)
+				batchSize = seqTokens * seqs
+			} else if batchSize != seqTokens*seqs {
+				return nil, ErrUnsupportedBatchLayout
+			}
+		}
+	}
+	headDim := opts.headDim()
+	numHeads := opts.numHeads
+
+	// Q projection outputs query + gate interleaved
+	qFull := sa.Query.Forward(ctx, hiddenStates)
+
+	// Reshape to [headDim * 2, numHeads, batchSize]
+	qFull = qFull.Reshape(ctx, headDim*2, numHeads, batchSize)
+
+	// Split Q and gate along dimension 0
+	// Q: first headDim elements, gate: second headDim elements
+	query := qFull.Slice(ctx, 0, 0, headDim, 1)
+	gate := qFull.Slice(ctx, 0, headDim, headDim*2, 1)
+
+	// Make query contiguous for further operations
+	query = query.Contiguous(ctx, headDim, numHeads, batchSize)
+
+	// K and V projections
+	key := sa.Key.Forward(ctx, hiddenStates)
+	value := sa.Value.Forward(ctx, hiddenStates)
+
+	// Derive numKVHeads from tensor dimensions (per-layer value)
+	numKVHeads := key.Dim(0) / headDim
+
+	key = key.Reshape(ctx, headDim, numKVHeads, batchSize)
+	value = value.Reshape(ctx, headDim, numKVHeads, batchSize)
+
+	// Apply QK normalization
+	query = sa.QueryNorm.Forward(ctx, query, opts.eps)
+	key = sa.KeyNorm.Forward(ctx, key, opts.eps)
+
+	// Apply RoPE
+	query = opts.applyRotaryPositionEmbeddings(ctx, query, positions)
+	key = opts.applyRotaryPositionEmbeddings(ctx, key, positions)
+
+	// Standard attention computation
+	scale := opts.attentionScale
+	if scale == 0 {
+		scale = 1.0 / math.Sqrt(float64(headDim))
+	}
+	attention := nn.Attention(ctx, query, key, value, scale, cache)
+
+	// Flatten heads
+	attention = attention.Reshape(ctx, headDim*numHeads, batchSize)
+
+	// Apply sigmoid gate
+	// gate shape: [headDim, numHeads, batchSize] -> [headDim*numHeads, batchSize]
+	gate = gate.Contiguous(ctx, headDim*numHeads, batchSize)
+	gateSigmoid := gate.Sigmoid(ctx)
+	attention = attention.Mul(ctx, gateSigmoid)
+
+	return sa.Output.Forward(ctx, attention), nil
+}

--- a/model/models/qwen35/cache.go
+++ b/model/models/qwen35/cache.go
@@ -1,0 +1,59 @@
+package qwen35
+
+import (
+	"math"
+
+	"github.com/ollama/ollama/kvcache"
+	"github.com/ollama/ollama/ml"
+)
+
+var (
+	_ kvcache.Cache           = (*HybridCache)(nil)
+	_ kvcache.CheckpointCache = (*HybridCache)(nil)
+)
+
+// HybridCache adapts the shared recurrent cache base for qwen35 naming.
+type HybridCache struct {
+	*kvcache.Recurrent
+}
+
+func NewHybridCache(
+	shift func(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error),
+	convDim, convChannels, deltaStateSize int,
+) *HybridCache {
+	base := kvcache.NewRecurrentCache(kvcache.RecurrentConfig{
+		Shift:               shift,
+		ConvDim:             convDim,
+		ConvChannels:        convChannels,
+		RecurrentStateSize:  deltaStateSize,
+		CheckpointLogPrefix: "qwen35",
+	})
+	return &HybridCache{Recurrent: base}
+}
+
+// DeltaState returns the delta state for current batch sequences as
+// [headVDim, headVDim*numVHeads, nSeqs].
+func (c *HybridCache) DeltaState(ctx ml.Context, layer int, headVDim, numVHeads int) (ml.Tensor, error) {
+	return c.RecurrentState(ctx, layer, headVDim, headVDim*numVHeads)
+}
+
+// UpdateDeltaState writes a new delta state for current batch sequences.
+func (c *HybridCache) UpdateDeltaState(ctx ml.Context, layer int, newState ml.Tensor) {
+	c.UpdateRecurrentState(ctx, layer, newState)
+}
+
+func (c *HybridCache) seqTokens() int {
+	return c.SeqTokens()
+}
+
+func (c *HybridCache) numSeqs() int {
+	return c.NumSeqs()
+}
+
+// Keep qwen35 behavior for partial mid-sequence removals.
+func (c *HybridCache) Remove(seq int, beginIndex, endIndex int32) error {
+	if beginIndex > 0 && endIndex != math.MaxInt32 {
+		return kvcache.ErrNotSupported
+	}
+	return c.Recurrent.Remove(seq, beginIndex, endIndex)
+}

--- a/model/models/qwen35/deltanet.go
+++ b/model/models/qwen35/deltanet.go
@@ -1,0 +1,539 @@
+package qwen35
+
+import (
+	"errors"
+	"log/slog"
+	"math"
+
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/ml/nn"
+)
+
+const chunkSize = 64
+
+// TriType constants for triangular matrix operations
+const (
+	TriTypeUpperDiag = 0
+	TriTypeUpper     = 1
+	TriTypeLowerDiag = 2
+	TriTypeLower     = 3
+)
+
+// convKernel wraps the 1D convolution kernel tensor
+type convKernel struct {
+	Weight ml.Tensor `gguf:"weight"`
+}
+
+// Masks holds pre-computed mask tensors for chunked attention
+type Masks struct {
+	Causal   ml.Tensor // Lower triangular [chunkSize, chunkSize]
+	Identity ml.Tensor // Diagonal [chunkSize, chunkSize]
+	Diag     ml.Tensor // causal + identity
+}
+
+// GatedDeltaNet implements linear attention with SSM convolution and recurrent state.
+// It implements the Operator interface directly.
+type GatedDeltaNet struct {
+	SSMQKV       *nn.Linear  `gguf:"attn_qkv"`  // -> Q, K, V (concatenated)
+	SSMQKVGate   *nn.Linear  `gguf:"attn_gate"` // -> Z gate
+	SSMIn        *nn.Linear  `gguf:"ssm_in"`
+	SSMBetaAlpha *nn.Linear  `gguf:"ssm_ba"`    // -> beta, alpha (legacy qwen3next)
+	SSMBeta      *nn.Linear  `gguf:"ssm_beta"`  // -> beta (qwen35)
+	SSMAlpha     *nn.Linear  `gguf:"ssm_alpha"` // -> alpha (qwen35)
+	SSMConv1D    *convKernel `gguf:"ssm_conv1d"`
+	SSMDT        ml.Tensor   `gguf:"ssm_dt,alt:ssm_dt.bias"` // alpha bias
+	SSMA         ml.Tensor   `gguf:"ssm_a"`                  // -A_log.exp()
+	SSMNorm      *nn.RMSNorm `gguf:"ssm_norm"`
+	SSMOut       *nn.Linear  `gguf:"ssm_out"`
+
+	// Layer index for cache access (set during model construction)
+	Layer int
+}
+
+// createMasks builds the constant mask tensors (called once, reused for all chunks)
+func createMasks(ctx ml.Context) *Masks {
+	ones := ctx.Input().Zeros(ml.DTypeF32, chunkSize, chunkSize)
+	ones = ones.Fill(ctx, 1.0)
+	causalMask := ones.Tri(ctx, TriTypeLower)
+
+	onesVec := ctx.Input().Zeros(ml.DTypeF32, chunkSize)
+	onesVec = onesVec.Fill(ctx, 1.0)
+	identity := onesVec.Diag(ctx)
+
+	diagMask := causalMask.Add(ctx, identity)
+
+	return &Masks{
+		Causal:   causalMask,
+		Identity: identity,
+		Diag:     diagMask,
+	}
+}
+
+func (gdn *GatedDeltaNet) Forward(ctx ml.Context, hiddenStates, _ ml.Tensor, cache *HybridCache, opts *Options) (ml.Tensor, error) {
+	layer := gdn.Layer
+	nSeqTokens := hiddenStates.Dim(1)
+	nSeqs := hiddenStates.Dim(2)
+	if cache != nil && cache.IsSupportedForBatch() {
+		seqTokens := cache.seqTokens()
+		seqs := cache.numSeqs()
+		if seqTokens > 0 && seqs > 0 {
+			if nSeqs > 1 {
+				if nSeqTokens != seqTokens || nSeqs != seqs {
+					return nil, ErrUnsupportedBatchLayout
+				}
+			} else {
+				if nSeqTokens != seqTokens*seqs {
+					return nil, ErrUnsupportedBatchLayout
+				}
+				hiddenStates = hiddenStates.Reshape(ctx, hiddenStates.Dim(0), seqTokens, seqs)
+				nSeqTokens = seqTokens
+				nSeqs = seqs
+			}
+		}
+	}
+
+	headKDim := opts.ssmDState
+	numKHeads := opts.ssmNGroup
+	numVHeads := opts.ssmDtRank
+	headVDim := opts.ssmDInner / numVHeads
+	convKernelSize := opts.convKernelSize
+
+	qkvDim := headKDim*numKHeads*2 + headVDim*numVHeads
+
+	// Support both current split projections and older qwen3-next imports that use ssm_in.
+	var qkvMixed, z ml.Tensor
+	switch {
+	case gdn.SSMQKV != nil && gdn.SSMQKVGate != nil:
+		qkvMixed = gdn.SSMQKV.Forward(ctx, hiddenStates).Reshape(ctx, qkvDim, nSeqTokens, nSeqs)
+		z = gdn.SSMQKVGate.Forward(ctx, hiddenStates)
+	case gdn.SSMIn != nil:
+		vPerHead := headVDim * numVHeads / numKHeads
+		qkvzDim := 2*headKDim + 2*vPerHead
+
+		combined := gdn.SSMIn.Forward(ctx, hiddenStates).Reshape(ctx, qkvzDim, numKHeads, nSeqTokens, nSeqs)
+		qPart := combined.Slice(ctx, 0, 0, headKDim, 1).Contiguous(ctx, headKDim*numKHeads, nSeqTokens, nSeqs)
+		kPart := combined.Slice(ctx, 0, headKDim, 2*headKDim, 1).Contiguous(ctx, headKDim*numKHeads, nSeqTokens, nSeqs)
+		vPart := combined.Slice(ctx, 0, 2*headKDim, 2*headKDim+vPerHead, 1).Contiguous(ctx, headVDim*numVHeads, nSeqTokens, nSeqs)
+		zPart := combined.Slice(ctx, 0, 2*headKDim+vPerHead, qkvzDim, 1).Contiguous(ctx, headVDim*numVHeads, nSeqTokens, nSeqs)
+
+		qkvMixed = qPart.Concat(ctx, kPart, 0).Concat(ctx, vPart, 0)
+		z = zPart
+	default:
+		return nil, errors.New("qwen3next: missing attn_qkv/attn_gate or ssm_in projections")
+	}
+
+	var beta ml.Tensor
+	var alpha ml.Tensor
+	switch {
+	case gdn.SSMBetaAlpha != nil:
+		// Legacy qwen3next path: in_proj_ba packs beta/alpha grouped by K-head.
+		mixedBA := gdn.SSMBetaAlpha.Forward(ctx, hiddenStates)
+		baNewDim := 2 * numVHeads / numKHeads
+		mixedBAReshaped := mixedBA.Reshape(ctx, baNewDim, numKHeads, nSeqTokens, nSeqs)
+
+		betaSize := numVHeads / numKHeads
+		alphaSize := numVHeads / numKHeads
+
+		b := mixedBAReshaped.Slice(ctx, 0, 0, betaSize, 1)
+		a := mixedBAReshaped.Slice(ctx, 0, betaSize, betaSize+alphaSize, 1)
+
+		// Keep beta layout consistent with qwen35.
+		// [1, numVHeads, nSeqTokens, nSeqs]
+		beta = b.Contiguous(ctx, 1, numVHeads, nSeqTokens, nSeqs)
+		alpha = a.Contiguous(ctx, numVHeads, nSeqTokens, nSeqs)
+
+	case gdn.SSMBeta != nil && gdn.SSMAlpha != nil:
+		// qwen35 path: beta/alpha are separate projections.
+		beta = gdn.SSMBeta.Forward(ctx, hiddenStates).Reshape(ctx, 1, numVHeads, nSeqTokens, nSeqs)
+		alpha = gdn.SSMAlpha.Forward(ctx, hiddenStates).Reshape(ctx, numVHeads, nSeqTokens, nSeqs)
+
+	default:
+		return nil, errors.New("qwen3next: missing linear attention beta/alpha projections")
+	}
+	if gdn.SSMDT == nil {
+		return nil, errors.New("qwen3next: missing linear attention ssm_dt tensor")
+	}
+	if gdn.SSMA == nil {
+		return nil, errors.New("qwen3next: missing linear attention ssm_a tensor")
+	}
+	if gdn.SSMConv1D == nil || gdn.SSMConv1D.Weight == nil {
+		return nil, errors.New("qwen3next: missing linear attention ssm_conv1d tensor")
+	}
+	if gdn.SSMNorm == nil || gdn.SSMOut == nil {
+		return nil, errors.New("qwen3next: missing linear attention ssm_norm/ssm_out projections")
+	}
+
+	// Compute gate: softplus(alpha + dt_bias) * -A
+	alphaBiased := alpha.Add(ctx, gdn.SSMDT)
+	alphaSoftplus := alphaBiased.Softplus(ctx)
+	gate := alphaSoftplus.Mul(ctx, gdn.SSMA)
+	gate = gate.Reshape(ctx, 1, numVHeads, nSeqTokens, nSeqs)
+	qkvMixed = qkvMixed.Permute(ctx, 1, 0, 2, 3)
+
+	// Get conv state from cache
+	convStates, err := cache.ConvState(ctx, layer)
+	if err != nil {
+		// Log this - if it happens, short-term context will be lost
+		slog.Warn("qwen3next: failed to get conv state, using zeros", "layer", layer, "error", err)
+		convStates = ctx.Input().Zeros(ml.DTypeF32, convKernelSize-1, qkvDim, nSeqs)
+	}
+
+	// Reshape conv states
+	convStates = convStates.Reshape(ctx, convKernelSize-1, qkvDim, nSeqs)
+
+	// Concatenate with input for convolution
+	convInput := convStates.Concat(ctx, qkvMixed, 0)
+
+	// Save new conv state (last convKernelSize-1 tokens)
+	lastConvStates := convInput.Slice(ctx, 0, nSeqTokens, nSeqTokens+convKernelSize-1, 1)
+	cache.UpdateConvState(ctx, layer, lastConvStates)
+
+	// Apply SSM convolution (kernel must be F32 for Metal)
+	convOutput := convInput.SSMConv(ctx, gdn.SSMConv1D.Weight)
+	convOutput = convOutput.SILU(ctx)
+
+	// Reshape for extraction
+	convQKVMix := convOutput.Contiguous(ctx, qkvDim, nSeqTokens*nSeqs)
+
+	// Extract convolved Q, K, V
+	qConv := convQKVMix.Slice(ctx, 0, 0, headKDim*numKHeads, 1)
+	kConv := convQKVMix.Slice(ctx, 0, headKDim*numKHeads, 2*headKDim*numKHeads, 1)
+	vConv := convQKVMix.Slice(ctx, 0, 2*headKDim*numKHeads, qkvDim, 1)
+
+	// Reshape to 4D
+	qConv = qConv.Contiguous(ctx, headKDim, numKHeads, nSeqTokens, nSeqs)
+	kConv = kConv.Contiguous(ctx, headKDim, numKHeads, nSeqTokens, nSeqs)
+	vConv = vConv.Contiguous(ctx, headVDim, numVHeads, nSeqTokens, nSeqs)
+
+	// Get delta state from cache
+	state, err := cache.DeltaState(ctx, layer, headVDim, numVHeads)
+	if err != nil {
+		// Log this - if it happens frequently, context will degrade
+		slog.Warn("qwen3next: failed to get delta state, using zeros", "layer", layer, "error", err)
+		state = ctx.Input().Zeros(ml.DTypeF32, headVDim, headVDim*numVHeads, nSeqs)
+	}
+	state = state.Reshape(ctx, headVDim, headVDim*numVHeads, 1, nSeqs)
+
+	// Repeat interleave Q and K if numKHeads != numVHeads
+	if numKHeads != numVHeads {
+		if opts.vHeadReordered {
+			qConv = qConv.Repeat4D(ctx, headKDim, numVHeads, nSeqTokens, nSeqs)
+			kConv = kConv.Repeat4D(ctx, headKDim, numVHeads, nSeqTokens, nSeqs)
+		} else {
+			repeatFactor := numVHeads / numKHeads
+			qReshaped := qConv.Reshape(ctx, headKDim, 1, numKHeads*nSeqTokens*nSeqs)
+			kReshaped := kConv.Reshape(ctx, headKDim, 1, numKHeads*nSeqTokens*nSeqs)
+
+			qRepeated := qReshaped.Repeat4D(ctx, headKDim, repeatFactor, numKHeads*nSeqTokens*nSeqs, 1)
+			kRepeated := kReshaped.Repeat4D(ctx, headKDim, repeatFactor, numKHeads*nSeqTokens*nSeqs, 1)
+
+			qConv = qRepeated.Reshape(ctx, headKDim, numKHeads*repeatFactor, nSeqTokens, nSeqs)
+			kConv = kRepeated.Reshape(ctx, headKDim, numKHeads*repeatFactor, nSeqTokens, nSeqs)
+		}
+	}
+
+	// Choose computation mode based on sequence length
+	var attnOut ml.Tensor
+	if nSeqTokens == 1 {
+		attnOut = gdn.deltaNetAutoregressive(ctx, qConv, kConv, vConv, gate, beta, state, opts, layer, cache)
+	} else {
+		if opts.masks == nil {
+			opts.masks = createMasks(ctx)
+		}
+		attnOut = gdn.deltaNetChunked(ctx, qConv, kConv, vConv, gate, beta, state, opts.masks, opts, layer, cache)
+	}
+
+	// Apply gated normalization
+	attnOut2D := attnOut.Contiguous(ctx, headVDim, numVHeads*nSeqTokens*nSeqs)
+	z2D := z.Contiguous(ctx, headVDim, numVHeads*nSeqTokens*nSeqs)
+
+	// norm(attnOut, z) = RMSNorm(attnOut) * silu(z)
+	attnOutNorm := gdn.SSMNorm.Forward(ctx, attnOut2D, opts.eps)
+	zSilu := z2D.SILU(ctx)
+	attnOutGated := attnOutNorm.Mul(ctx, zSilu)
+
+	// Reshape for output projection
+	finalOutput := attnOutGated.Reshape(ctx, headVDim*numVHeads, nSeqTokens, nSeqs)
+
+	out := gdn.SSMOut.Forward(ctx, finalOutput)
+	return out.Reshape(ctx, out.Dim(0), nSeqTokens*nSeqs), nil
+}
+
+// deltaNetAutoregressive implements single-token state update.
+// NOTE: Assumes headKDim == headVDim (state shape is [headVDim, headVDim, numVHeads, nSeqs]).
+func (gdn *GatedDeltaNet) deltaNetAutoregressive(
+	ctx ml.Context,
+	q, k, v, gate, beta, state ml.Tensor,
+	opts *Options,
+	layer int,
+	cache *HybridCache,
+) ml.Tensor {
+	numVHeads := v.Dim(1)
+	headVDim := v.Dim(0)
+	nSeqs := q.Dim(3)
+
+	// L2 normalize Q and K
+	q = q.L2Norm(ctx, opts.eps)
+	k = k.L2Norm(ctx, opts.eps)
+
+	// Scale Q
+	scale := 1.0 / math.Sqrt(float64(headVDim))
+	q = q.Scale(ctx, scale)
+
+	// Sigmoid beta
+	beta = beta.Sigmoid(ctx)
+
+	// Reshape state: [headVDim, headVDim, numVHeads, nSeqs]
+	state = state.Reshape(ctx, headVDim, headVDim, numVHeads, nSeqs)
+
+	// Reshape gate and beta for broadcasting
+	gT := gate.Permute(ctx, 1, 0, 2, 3).Reshape(ctx, 1, 1, numVHeads, nSeqs)
+	betaT := beta.Permute(ctx, 1, 0, 2, 3).Reshape(ctx, 1, 1, numVHeads, nSeqs)
+
+	// Apply exponential to gate
+	gT = gT.Exp(ctx)
+
+	// state = state * g_t
+	state = state.Mul(ctx, gT)
+
+	// kv_mem = (state * k_t.unsqueeze(-1)).sum(dim=-2)
+	kTUnsqueezed := k.Reshape(ctx, 1, headVDim, numVHeads, nSeqs)
+	kvMem := state.Mul(ctx, kTUnsqueezed)
+	// Sum over dim=-2 (second dimension after permute)
+	kvMem = kvMem.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	kvMem = kvMem.SumRows(ctx)
+	kvMem = kvMem.Permute(ctx, 1, 0, 2, 3)
+
+	// v_t with singleton dimension
+	vT := v.Reshape(ctx, headVDim, 1, numVHeads, nSeqs)
+
+	// delta = (v_t - kv_mem) * beta_t
+	vDiff := vT.Sub(ctx, kvMem)
+	delta := vDiff.Mul(ctx, betaT)
+
+	// state = state + k_t.unsqueeze(-1) * delta
+	kTUnsqueezedBroad := kTUnsqueezed.Repeat4D(ctx, headVDim, headVDim, numVHeads, nSeqs)
+	kTDelta := kTUnsqueezedBroad.Mul(ctx, delta)
+	state = state.Add(ctx, kTDelta)
+
+	// core_attn_out = (state * q_t.unsqueeze(-1)).sum(dim=-2)
+	qTUnsqueezed := q.Reshape(ctx, 1, headVDim, numVHeads, nSeqs)
+	stateQ := state.Mul(ctx, qTUnsqueezed)
+	stateQ = stateQ.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	coreAttnOut := stateQ.SumRows(ctx)
+	coreAttnOut = coreAttnOut.Permute(ctx, 1, 0, 2, 3)
+
+	// Update delta state in cache
+	cache.UpdateDeltaState(ctx, layer, state.Reshape(ctx, headVDim, headVDim*numVHeads, nSeqs))
+
+	return coreAttnOut.Reshape(ctx, headVDim, numVHeads, 1, nSeqs)
+}
+
+// deltaNetChunked implements chunked computation for prefill.
+// NOTE: Assumes headKDim == headVDim (state shape is [headVDim, headVDim, numVHeads, nSeqs]).
+func (gdn *GatedDeltaNet) deltaNetChunked(
+	ctx ml.Context,
+	q, k, v, gate, beta, state ml.Tensor,
+	masks *Masks,
+	opts *Options,
+	layer int,
+	cache *HybridCache,
+) ml.Tensor {
+	headKDim := q.Dim(0)
+	numVHeads := v.Dim(1)
+	headVDim := v.Dim(0)
+	nTokens := q.Dim(2)
+	nSeqs := q.Dim(3)
+
+	// L2 normalize Q and K
+	q = q.L2Norm(ctx, opts.eps)
+	k = k.L2Norm(ctx, opts.eps)
+
+	// Scale Q
+	scale := 1.0 / math.Sqrt(float64(headVDim))
+	q = q.Scale(ctx, scale)
+
+	// Sigmoid beta
+	beta = beta.Sigmoid(ctx)
+
+	// Permute tensors for chunked computation
+	q = q.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx, headKDim, nTokens, numVHeads, nSeqs)
+	k = k.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx, headKDim, nTokens, numVHeads, nSeqs)
+	v = v.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx, headVDim, nTokens, numVHeads, nSeqs)
+	// gate/beta: [1, numVHeads, nTokens, nSeqs] -> [1, nTokens, numVHeads, nSeqs]
+	gate = gate.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx, 1, nTokens, numVHeads, nSeqs)
+	beta = beta.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx, 1, nTokens, numVHeads, nSeqs)
+	state = state.Reshape(ctx, headVDim, headVDim, numVHeads, nSeqs)
+
+	// Compute padding
+	pad := (chunkSize - nTokens%chunkSize) % chunkSize
+	nChunks := (nTokens + pad) / chunkSize
+
+	// Pad tensors
+	if pad > 0 {
+		q = q.Pad(ctx, 0, pad, 0, 0)
+		k = k.Pad(ctx, 0, pad, 0, 0)
+		v = v.Pad(ctx, 0, pad, 0, 0)
+		gate = gate.Pad(ctx, 0, pad, 0, 0)
+		beta = beta.Pad(ctx, 0, pad, 0, 0)
+	}
+
+	// Use pre-computed masks (passed in, not recreated)
+	causalMask := masks.Causal
+	identity := masks.Identity
+	diagMask := masks.Diag
+	identity4D := identity.Reshape(ctx, chunkSize, chunkSize, 1, 1)
+
+	// v_beta = v * beta, k_beta = k * beta
+	vBeta := v.Mul(ctx, beta)
+	kBeta := k.Mul(ctx, beta)
+
+	// Reshape for chunked computation
+	q = q.Reshape(ctx, headKDim, chunkSize, nChunks, numVHeads*nSeqs)
+	k = k.Reshape(ctx, headKDim, chunkSize, nChunks, numVHeads*nSeqs)
+	kBeta = kBeta.Reshape(ctx, headKDim, chunkSize, nChunks, numVHeads*nSeqs)
+	vBeta = vBeta.Reshape(ctx, headVDim, chunkSize, nChunks, numVHeads*nSeqs)
+
+	// Reshape gate and cumsum over chunk axis.
+	// [1, chunkSize, nChunks, H*nSeqs] -> transpose -> [chunkSize, 1, nChunks, H*nSeqs]
+	gate = gate.Reshape(ctx, 1, chunkSize, nChunks, numVHeads*nSeqs)
+
+	// g_cumsum = cumsum(gate)
+	gCumsum := gate.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, chunkSize, 1, nChunks, numVHeads*nSeqs).CumSum(ctx)
+
+	// Compute decay mask
+	gcsI := gCumsum.Reshape(ctx, chunkSize, 1, nChunks, numVHeads*nSeqs)
+	gcsJ := gCumsum.Reshape(ctx, 1, chunkSize, nChunks, numVHeads*nSeqs)
+	gcsBroadcast := gcsJ.Repeat4D(ctx, chunkSize, chunkSize, nChunks, numVHeads*nSeqs)
+	decayMask := gcsBroadcast.Sub(ctx, gcsI)
+
+	decayMask = decayMask.Mul(ctx, diagMask)
+	decayMask = decayMask.Exp(ctx)
+	decayMask = decayMask.Mul(ctx, diagMask)
+
+	// k @ k_beta^T
+	kMulKBeta := k.Mulmat(ctx, kBeta)
+
+	// k_decay = k @ k_beta^T * decay_mask
+	kDecay := kMulKBeta.Mul(ctx, decayMask)
+
+	// attn = -k_decay * causal_mask
+	attn := kDecay.Neg(ctx).Mul(ctx, causalMask)
+
+	// Triangular solve: (I - attn_lower)^-1 @ attn
+	attnLower := attn.Mul(ctx, causalMask)
+	lhs := attnLower.Neg(ctx).Add(ctx, identity4D)
+	linSolve := lhs.SolveTri(ctx, attn, true, true, false)
+	attn = linSolve.Mul(ctx, causalMask)
+	attn = attn.Add(ctx, identity4D)
+
+	// v = v_beta^T @ attn
+	vBetaT := vBeta.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	v = vBetaT.Mulmat(ctx, attn)
+
+	// Compute g_exp for state update
+	gCumsumT := gCumsum.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	gExp := gCumsumT.Exp(ctx)
+
+	// kbeta_gexp = k_beta * g_exp
+	kBetaGExp := kBeta.Mul(ctx, gExp)
+
+	// k_cumdecay = attn @ kbeta_gexp^T
+	kBetaGExpT := kBetaGExp.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	kCumdecay := attn.Mulmat(ctx, kBetaGExpT)
+	kCumdecay = kCumdecay.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+
+	// Pre-compute attn_kq = (k @ q) * decay_mask * diag_mask
+	attnKQ := k.Mulmat(ctx, q)
+	attnKQ = attnKQ.Mul(ctx, decayMask)
+	attnKQ = attnKQ.Mul(ctx, diagMask)
+
+	// Pre-compute g_last and key_gdiff
+	// g_last = view of last element in g_cumsum along chunk_size dimension
+	// We need to get the last row of gCumsum: shape [chunkSize, 1, nChunks, H*n_seqs] -> [1, 1, nChunks, H*n_seqs]
+	gLast := gCumsum.Slice(ctx, 0, chunkSize-1, chunkSize, 1).Contiguous(ctx, 1, 1, nChunks, numVHeads*nSeqs)
+	gLastExp := gLast.Exp(ctx)
+
+	// g_diff = -(g_cumsum - g_last) = g_last - g_cumsum
+	gDiff := gCumsum.Neg(ctx).Add(ctx, gLast)
+	gDiffExp := gDiff.Exp(ctx)
+
+	// Reshapes g_diff_exp to [1, chunkSize, nChunks, ...]
+	gDiffExpReshaped := gDiffExp.Reshape(ctx, 1, chunkSize, nChunks, numVHeads*nSeqs)
+	keyGDiff := k.Mul(ctx, gDiffExpReshaped)
+	keyGDiffT := keyGDiff.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+
+	// Process chunks and update state.
+	// Keep a transposed view of v and recurrent state across chunks so the
+	// chunk loop does not need extra transpose+contiguous nodes.
+	vT := v.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, chunkSize, headVDim, nChunks, numVHeads*nSeqs)
+	stateT := state.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headVDim, headVDim, 1, numVHeads*nSeqs)
+
+	// Collect chunk outputs and concatenate at the end.
+	// Avoids SET on buffer-less intermediates under partial offload.
+	chunks := make([]ml.Tensor, nChunks)
+
+	for chunk := range nChunks {
+		qChunk := q.Slice(ctx, 2, chunk, chunk+1, 1)
+		vTChunk := vT.Slice(ctx, 2, chunk, chunk+1, 1)
+		gExpChunk := gExp.Slice(ctx, 2, chunk, chunk+1, 1)
+		kCumdecayChunk := kCumdecay.Slice(ctx, 2, chunk, chunk+1, 1)
+		attnChunk := attnKQ.Slice(ctx, 2, chunk, chunk+1, 1) // Pre-computed!
+
+		// v'_t = k_cumdecay @ state_t
+		vTPrime := kCumdecayChunk.Mulmat(ctx, stateT)
+
+		// v_t_new = v_t - v'_t
+		vTNewChunk := vTChunk.Sub(ctx, vTPrime)
+
+		// attn_inter = (q * g_exp) @ state
+		qGExp := qChunk.Mul(ctx, gExpChunk)
+		attnInter := stateT.Mulmat(ctx, qGExp)
+
+		// core_attn_out = attn_inter + attn @ v_new
+		vAttn := vTNewChunk.Mulmat(ctx, attnChunk)
+		coreAttnOutChunk := attnInter.Add(ctx, vAttn)
+
+		chunks[chunk] = coreAttnOutChunk
+
+		// Update state for next chunk
+		gExpLastChunk := gLastExp.Slice(ctx, 2, chunk, chunk+1, 1)
+		kGDiffChunkT := keyGDiffT.Slice(ctx, 2, chunk, chunk+1, 1)
+		// kgdmulvnew = key_gdiff_t @ v_new_t
+		kgdMulVNew := kGDiffChunkT.Mulmat(ctx, vTNewChunk)
+
+		// stateT = stateT * g_last + kgdmulvnew
+		stateT = stateT.Mul(ctx, gExpLastChunk)
+		stateT = stateT.Add(ctx, kgdMulVNew)
+	}
+
+	// Use a balanced concat tree so concat work does not balloon on long prompts.
+	for len(chunks) > 1 {
+		merged := make([]ml.Tensor, 0, (len(chunks)+1)/2)
+		for i := 0; i < len(chunks); i += 2 {
+			if i+1 < len(chunks) {
+				merged = append(merged, chunks[i].Concat(ctx, chunks[i+1], 2))
+			} else {
+				merged = append(merged, chunks[i])
+			}
+		}
+		chunks = merged
+	}
+	v = chunks[0]
+
+	// Final reshape
+	coreAttnOut := v.Contiguous(ctx, headVDim, chunkSize*nChunks, numVHeads, nSeqs)
+
+	// Slice to remove padding
+	if pad > 0 {
+		coreAttnOut = coreAttnOut.Slice(ctx, 1, 0, nTokens, 1)
+	}
+
+	// Convert stateT back to cache layout [S_v, S_v, H_v, nSeqs]
+	newState := stateT.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headVDim, headVDim, numVHeads, nSeqs)
+
+	// Update delta state in cache
+	cache.UpdateDeltaState(ctx, layer, newState.Reshape(ctx, headVDim, headVDim*numVHeads, nSeqs))
+
+	return coreAttnOut.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx, headVDim, numVHeads, nTokens, nSeqs)
+}

--- a/model/models/qwen35/deltanet.go
+++ b/model/models/qwen35/deltanet.go
@@ -185,7 +185,7 @@ func (gdn *GatedDeltaNet) Forward(ctx ml.Context, hiddenStates, _ ml.Tensor, cac
 	convInput := convStates.Concat(ctx, qkvMixed, 0)
 
 	// Save new conv state (last convKernelSize-1 tokens)
-	lastConvStates := convInput.Slice(ctx, 0, nSeqTokens, nSeqTokens+convKernelSize-1, 1)
+	lastConvStates := convInput.Slice(ctx, 0, nSeqTokens, nSeqTokens+convKernelSize-1, 1).Contiguous(ctx)
 	cache.UpdateConvState(ctx, layer, lastConvStates)
 
 	// Apply SSM convolution (kernel must be F32 for Metal)

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -147,12 +147,15 @@ func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Op
 	tokenStride := convOutput.Stride(1)
 
 	q := convOutput.View(ctx, 0, qDim, tokenStride, nTokens)
+	q = q.Contiguous(ctx)
 	q = q.Reshape(ctx, headKDim, numKHeads, nTokens)
 
 	k := convOutput.View(ctx, elemSize*qDim, kDim, tokenStride, nTokens)
+	k = k.Contiguous(ctx)
 	k = k.Reshape(ctx, headKDim, numKHeads, nTokens)
 
 	v := convOutput.View(ctx, elemSize*(qDim+kDim), dInner, tokenStride, nTokens)
+	v = v.Contiguous(ctx)
 	v = v.Reshape(ctx, headVDim, numVHeads, nTokens)
 
 	// 5. Repeat Q/K if head counts differ

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -52,29 +52,52 @@ func (o *Options) headDim() int {
 }
 
 // Attention layer (standard grouped-query attention with RoPE)
-type Attention struct {
+// Layer contains all possible tensors for both attention and DeltaNet layers.
+// The gguf auto-populator fills whichever tensors exist in the GGUF file.
+// At runtime, isRecurrent() determines which path to take.
+type Layer struct {
+	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
+	PostAttnNorm  *nn.RMSNorm `gguf:"post_attention_norm"`
+
+	// Attention layer tensors
 	Query     *nn.Linear  `gguf:"attn_q"`
 	QueryNorm *nn.RMSNorm `gguf:"attn_q_norm"`
 	Key       *nn.Linear  `gguf:"attn_k"`
 	KeyNorm   *nn.RMSNorm `gguf:"attn_k_norm"`
 	Value     *nn.Linear  `gguf:"attn_v"`
-	Output    *nn.Linear  `gguf:"attn_output"`
+	AttnOutput *nn.Linear `gguf:"attn_output"`
+
+	// DeltaNet layer tensors
+	WQkv      *nn.Linear  `gguf:"attn_qkv"`
+	WQkvGate  *nn.Linear  `gguf:"attn_gate"`
+	SSMAlpha  *nn.Linear  `gguf:"ssm_alpha"`
+	SSMBeta   *nn.Linear  `gguf:"ssm_beta"`
+	SSMDt     ml.Tensor   `gguf:"ssm_dt"`
+	SSMA      ml.Tensor   `gguf:"ssm_a"`
+	SSMConv1D ml.Tensor   `gguf:"ssm_conv1d"`
+	SSMNorm   *nn.RMSNorm `gguf:"ssm_norm"`
+	SSMOut    *nn.Linear  `gguf:"ssm_out"`
+
+	// FFN tensors (shared by both layer types)
+	FFNGate *nn.Linear `gguf:"ffn_gate"`
+	FFNUp   *nn.Linear `gguf:"ffn_up"`
+	FFNDown *nn.Linear `gguf:"ffn_down"`
 }
 
-func (sa *Attention) Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
+func (l *Layer) forwardAttention(ctx ml.Context, hiddenStates, positions ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
 	batchSize := hiddenStates.Dim(1)
 	kvHeads := opts.kvHeadsPerLayer[il]
 
-	query := sa.Query.Forward(ctx, hiddenStates)
-	key := sa.Key.Forward(ctx, hiddenStates)
-	value := sa.Value.Forward(ctx, hiddenStates)
+	query := l.Query.Forward(ctx, hiddenStates)
+	key := l.Key.Forward(ctx, hiddenStates)
+	value := l.Value.Forward(ctx, hiddenStates)
 
 	query = query.Reshape(ctx, opts.headDim(), opts.numHeads, batchSize)
 	key = key.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
 	value = value.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
 
-	query = sa.QueryNorm.Forward(ctx, query, opts.eps)
-	key = sa.KeyNorm.Forward(ctx, key, opts.eps)
+	query = l.QueryNorm.Forward(ctx, query, opts.eps)
+	key = l.KeyNorm.Forward(ctx, key, opts.eps)
 
 	ropeOpts := []func(*rope.Options){rope.WithTypeNeoX()}
 	query = fast.RoPE(ctx, query, positions, opts.headDim(), opts.ropeBase, 1./opts.ropeScale, ropeOpts...)
@@ -82,61 +105,17 @@ func (sa *Attention) Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, 
 
 	attention := nn.Attention(ctx, query, key, value, 1./math.Sqrt(float64(opts.headDim())), cache)
 	attention = attention.Reshape(ctx, attention.Dim(0)*attention.Dim(1), batchSize)
-	return sa.Output.Forward(ctx, attention)
+	return l.AttnOutput.Forward(ctx, attention)
 }
 
-// DeltaNet layer (linear attention with recurrent state)
-type DeltaNet struct {
-	WQkv     *nn.Linear  `gguf:"attn_qkv"`
-	WQkvGate *nn.Linear  `gguf:"attn_gate"`
-	SSMAlpha *nn.Linear  `gguf:"ssm_alpha"`
-	SSMBeta  *nn.Linear  `gguf:"ssm_beta"`
-	SSMDt    ml.Tensor   `gguf:"ssm_dt"`
-	SSMA     ml.Tensor   `gguf:"ssm_a"`
-	SSMConv1D ml.Tensor  `gguf:"ssm_conv1d"`
-	SSMNorm  *nn.RMSNorm `gguf:"ssm_norm"`
-	SSMOut   *nn.Linear  `gguf:"ssm_out"`
-}
-
-// Forward for DeltaNet layer
-// TODO: Full DeltaNet implementation with recurrent state, conv1d, chunked attention.
-// Currently a stub that passes through the output projection to maintain valid shapes
-// for memory measurement. This allows the ollama engine's iterative Load loop to
-// correctly estimate GPU count, even though inference output is not correct.
-func (dn *DeltaNet) Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
-	// Use output projection to produce correct output shape (hiddenSize, nTokens)
-	// Input: (hiddenSize, nTokens), SSMOut weight: (hiddenSize, d_inner)
-	// We need an intermediate of size (d_inner, nTokens)
-	// Use WQkvGate which projects hiddenSize -> d_inner
-	intermediate := dn.WQkvGate.Forward(ctx, hiddenStates)
-
-	// Gated normalization stub: just use SSMNorm on intermediate
-	normalized := dn.SSMNorm.Forward(ctx, intermediate, opts.eps)
-
-	return dn.SSMOut.Forward(ctx, normalized)
-}
-
-// FFN (feed-forward network)
-type FFN struct {
-	Gate *nn.Linear `gguf:"ffn_gate"`
-	Up   *nn.Linear `gguf:"ffn_up"`
-	Down *nn.Linear `gguf:"ffn_down"`
-}
-
-func (ffn *FFN) Forward(ctx ml.Context, hiddenStates ml.Tensor) ml.Tensor {
-	return ffn.Down.Forward(ctx, ffn.Gate.Forward(ctx, hiddenStates).SILU(ctx, ffn.Up.Forward(ctx, hiddenStates)))
-}
-
-// Layer can be either attention or DeltaNet
-type Layer struct {
-	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
-	PostAttnNorm  *nn.RMSNorm `gguf:"post_attention_norm"`
-
-	// Only one of these is used per layer
-	Attention *Attention
-	DeltaNet  *DeltaNet
-
-	FFN *FFN
+// forwardDeltaNet is a stub for DeltaNet layers.
+// TODO: Full implementation with recurrent state, conv1d, chunked attention.
+// Currently passes through output projection to maintain valid shapes for
+// memory measurement by the iterative Load loop.
+func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
+	intermediate := l.WQkvGate.Forward(ctx, hiddenStates)
+	normalized := l.SSMNorm.Forward(ctx, intermediate, opts.eps)
+	return l.SSMOut.Forward(ctx, normalized)
 }
 
 func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
@@ -145,11 +124,11 @@ func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tens
 	// Pre-attention norm
 	hiddenStates = l.AttentionNorm.Forward(ctx, hiddenStates, opts.eps)
 
-	// Attention or DeltaNet
+	// Attention or DeltaNet based on layer type
 	if opts.isRecurrent(il) {
-		hiddenStates = l.DeltaNet.Forward(ctx, hiddenStates, opts)
+		hiddenStates = l.forwardDeltaNet(ctx, hiddenStates, opts)
 	} else {
-		hiddenStates = l.Attention.Forward(ctx, hiddenStates, positions, cache, opts, il)
+		hiddenStates = l.forwardAttention(ctx, hiddenStates, positions, cache, opts, il)
 	}
 
 	// Output filtering on last layer
@@ -164,7 +143,7 @@ func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tens
 	// FFN with pre-norm and residual
 	ffnResidual := hiddenStates
 	hiddenStates = l.PostAttnNorm.Forward(ctx, hiddenStates, opts.eps)
-	hiddenStates = l.FFN.Forward(ctx, hiddenStates)
+	hiddenStates = l.FFNDown.Forward(ctx, l.FFNGate.Forward(ctx, hiddenStates).SILU(ctx, l.FFNUp.Forward(ctx, hiddenStates)))
 	return hiddenStates.Add(ctx, ffnResidual)
 }
 
@@ -227,16 +206,6 @@ func New(c fs.Config) (model.Model, error) {
 	}
 
 	layers := make([]Layer, blockCount)
-	for i := range layers {
-		if kvHeadsPerLayer[i] == 0 {
-			// DeltaNet layer
-			layers[i].DeltaNet = &DeltaNet{}
-		} else {
-			// Attention layer
-			layers[i].Attention = &Attention{}
-		}
-		layers[i].FFN = &FFN{}
-	}
 
 	opts := &Options{
 		hiddenSize:      int(c.Uint("embedding_length")),

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -13,11 +13,6 @@ import (
 	"github.com/ollama/ollama/model/input"
 )
 
-const chunkSize = 64
-
-// triTypeLower corresponds to GGML_TRI_TYPE_LOWER
-const triTypeLower = 3
-
 type Options struct {
 	hiddenSize int
 	numHeads   int
@@ -56,13 +51,6 @@ func (o *Options) headDim() int {
 	return o.hiddenSize / o.numHeads
 }
 
-func (o *Options) ssmHeadVDim() int {
-	if o.ssmDtRank > 0 {
-		return o.ssmDInner / o.ssmDtRank
-	}
-	return 0
-}
-
 // Attention layer (standard grouped-query attention with RoPE)
 type Attention struct {
 	Query     *nn.Linear  `gguf:"attn_q"`
@@ -99,95 +87,33 @@ func (sa *Attention) Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, 
 
 // DeltaNet layer (linear attention with recurrent state)
 type DeltaNet struct {
-	WQkv     *nn.Linear `gguf:"attn_qkv"`
-	WQkvGate *nn.Linear `gguf:"attn_qkv_gate"`
-	SSMAlpha *nn.Linear `gguf:"ssm_alpha"`
-	SSMBeta  *nn.Linear `gguf:"ssm_beta"`
-	SSMDt    ml.Tensor  // bias vector for decay
-	SSMA     ml.Tensor  // decay weight matrix
-	SSMConv  ml.Tensor  // 1D conv kernel
+	WQkv     *nn.Linear  `gguf:"attn_qkv"`
+	WQkvGate *nn.Linear  `gguf:"attn_gate"`
+	SSMAlpha *nn.Linear  `gguf:"ssm_alpha"`
+	SSMBeta  *nn.Linear  `gguf:"ssm_beta"`
+	SSMDt    ml.Tensor   `gguf:"ssm_dt"`
+	SSMA     ml.Tensor   `gguf:"ssm_a"`
+	SSMConv1D ml.Tensor  `gguf:"ssm_conv1d"`
 	SSMNorm  *nn.RMSNorm `gguf:"ssm_norm"`
 	SSMOut   *nn.Linear  `gguf:"ssm_out"`
 }
 
-// Forward for DeltaNet layer - autoregressive single-token path
-// This is the most common path during generation (one token at a time)
+// Forward for DeltaNet layer
+// TODO: Full DeltaNet implementation with recurrent state, conv1d, chunked attention.
+// Currently a stub that passes through the output projection to maintain valid shapes
+// for memory measurement. This allows the ollama engine's iterative Load loop to
+// correctly estimate GPU count, even though inference output is not correct.
 func (dn *DeltaNet) Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
-	nTokens := hiddenStates.Dim(1)
-	headKDim := opts.ssmDState
-	numKHeads := opts.ssmNGroup
-	numVHeads := opts.ssmDtRank
-	headVDim := opts.ssmHeadVDim()
+	// Use output projection to produce correct output shape (hiddenSize, nTokens)
+	// Input: (hiddenSize, nTokens), SSMOut weight: (hiddenSize, d_inner)
+	// We need an intermediate of size (d_inner, nTokens)
+	// Use WQkvGate which projects hiddenSize -> d_inner
+	intermediate := dn.WQkvGate.Forward(ctx, hiddenStates)
 
-	// Input projections
-	qkvMixed := dn.WQkv.Forward(ctx, hiddenStates)
-	z := dn.WQkvGate.Forward(ctx, hiddenStates)
+	// Gated normalization stub: just use SSMNorm on intermediate
+	normalized := dn.SSMNorm.Forward(ctx, intermediate, opts.eps)
 
-	beta := dn.SSMBeta.Forward(ctx, hiddenStates)
-	alpha := dn.SSMAlpha.Forward(ctx, hiddenStates)
-
-	// Decay computation: softplus(alpha + dt_bias) * ssm_a
-	alphaBiased := alpha.Add(ctx, dn.SSMDt)
-	alphaSoftplus := alphaBiased.Softplus(ctx)
-	_ = alphaSoftplus.Mul(ctx, dn.SSMA) // gate - used in DeltaNet state update (TODO)
-
-	// TODO: convolution state management and SSM conv
-	// For now, apply SSM conv directly
-	convOutput := qkvMixed.SSMConv(ctx, dn.SSMConv)
-	convOutput = convOutput.SILU(ctx)
-
-	// Extract Q, K, V from conv output
-	qkvDim := headKDim*numKHeads*2 + headVDim*numVHeads
-	_ = qkvDim
-
-	// Q: first portion
-	qConv := convOutput.View(ctx, 0, headKDim*numKHeads, nTokens)
-	qConv = qConv.Reshape(ctx, headKDim, numKHeads, nTokens)
-
-	// K: second portion
-	kConv := convOutput.View(ctx, headKDim*numKHeads*4, headKDim*numKHeads, nTokens)
-	kConv = kConv.Reshape(ctx, headKDim, numKHeads, nTokens)
-
-	// V: third portion
-	vConv := convOutput.View(ctx, 2*headKDim*numKHeads*4, headVDim*numVHeads, nTokens)
-	vConv = vConv.Reshape(ctx, headVDim, numVHeads, nTokens)
-
-	// Repeat Q/K if head counts differ
-	if numKHeads != numVHeads {
-		qConv = qConv.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
-		kConv = kConv.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
-	}
-
-	// L2 normalize Q and K
-	qConv = qConv.L2Norm(ctx, opts.eps)
-	kConv = kConv.L2Norm(ctx, opts.eps)
-
-	// Scale Q
-	scale := 1.0 / math.Sqrt(float64(headVDim))
-	qConv = qConv.Scale(ctx, float64(scale))
-
-	// Sigmoid beta
-	beta = beta.Sigmoid(ctx)
-
-	// TODO: DeltaNet state update (requires recurrent state cache)
-	// For single token decode:
-	// 1. state = state * exp(gate)
-	// 2. kv_mem = (state * k).sum(-2)
-	// 3. delta = (v - kv_mem) * beta
-	// 4. state = state + k * delta
-	// 5. output = (state * q).sum(-2)
-
-	// Gated normalization: rms_norm(output) * silu(z)
-	output := qConv // placeholder until state management is implemented
-	output2d := output.Reshape(ctx, headVDim, numVHeads*nTokens)
-	z2d := z.Reshape(ctx, headVDim, numVHeads*nTokens)
-
-	normalized := dn.SSMNorm.Forward(ctx, output2d, opts.eps)
-	gatedSilu := z2d.SILU(ctx)
-	attnOut := normalized.Mul(ctx, gatedSilu)
-
-	finalOutput := attnOut.Reshape(ctx, headVDim*numVHeads, nTokens)
-	return dn.SSMOut.Forward(ctx, finalOutput)
+	return dn.SSMOut.Forward(ctx, normalized)
 }
 
 // FFN (feed-forward network)
@@ -204,7 +130,7 @@ func (ffn *FFN) Forward(ctx ml.Context, hiddenStates ml.Tensor) ml.Tensor {
 // Layer can be either attention or DeltaNet
 type Layer struct {
 	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
-	PostAttnNorm  *nn.RMSNorm `gguf:"attn_post_norm"`
+	PostAttnNorm  *nn.RMSNorm `gguf:"post_attention_norm"`
 
 	// Only one of these is used per layer
 	Attention *Attention

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -1,276 +1,226 @@
 package qwen35
 
 import (
-	"log/slog"
+	"cmp"
+	"fmt"
 	"math"
+	"slices"
 
 	"github.com/ollama/ollama/fs"
-	"github.com/ollama/ollama/kvcache"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/ml/nn"
-	"github.com/ollama/ollama/ml/nn/fast"
 	"github.com/ollama/ollama/ml/nn/rope"
 	"github.com/ollama/ollama/model"
 	"github.com/ollama/ollama/model/input"
 )
 
+// Options contains model configuration
 type Options struct {
-	hiddenSize int
-	numHeads   int
-	numKVHeads int
-	keyLength  int
+	hiddenSize  int
+	numHeads    int
+	numKVHeads  int
+	keyLength   int
 	valueLength int
+	ropeDim     int
 
-	// DeltaNet SSM parameters
-	ssmDInner int
-	ssmDState int
-	ssmDConv  int
-	ssmNGroup int
-	ssmDtRank int
+	eps                   float32
+	ropeBase              float32
+	ropeScale             float32
+	ropeType              string
+	originalContextLength int
+	attentionScale        float64
 
-	eps       float32
-	ropeBase  float32
-	ropeScale float32
+	// MoE config
+	numExperts     int
+	numExpertsUsed int
+	normTopKProb   bool
 
-	// Per-layer head_count_kv array: 0 = DeltaNet, >0 = attention
-	kvHeadsPerLayer []int
+	// Linear attention (Gated Delta Net) config
+	ssmDInner      int // d_inner = head_v_dim * num_v_heads
+	ssmDState      int // head_k_dim
+	ssmNGroup      int // num_k_heads
+	ssmDtRank      int // num_v_heads
+	convKernelSize int // SSM conv kernel size
+	vHeadReordered bool
+
+	// Per-layer type from GGUF metadata
+	isRecurrent []bool
+
+	// RoPE mode config
+	mropeSections    []int
+	mropeInterleaved bool
+
+	// Pre-computed masks for chunked attention (created once per forward pass)
+	masks *Masks
 }
 
-func (o *Options) isRecurrent(il int) bool {
-	if il < len(o.kvHeadsPerLayer) {
-		return o.kvHeadsPerLayer[il] == 0
+func (o Options) headDim() int {
+	return cmp.Or(o.keyLength, o.valueLength, o.hiddenSize/o.numHeads)
+}
+
+func (o Options) applyRotaryPositionEmbeddings(ctx ml.Context, states, positions ml.Tensor) ml.Tensor {
+	var opts []func(*rope.Options)
+	if len(o.mropeSections) > 0 {
+		if o.mropeInterleaved {
+			opts = append(opts, rope.WithInterleaveMRoPE(o.mropeSections))
+		} else {
+			opts = append(opts, rope.WithMRoPE(o.mropeSections))
+		}
+	} else {
+		opts = append(opts, rope.WithTypeNeoX())
 	}
-	return false
-}
 
-func (o *Options) headDim() int {
-	if o.keyLength > 0 {
-		return o.keyLength
+	if o.ropeType == "yarn" {
+		attnFactor := float32(1.0 / (1.0 + 0.1*math.Log(float64(o.ropeScale))))
+		opts = append(opts,
+			rope.WithOriginalContextLength(o.originalContextLength),
+			rope.WithExtrapolationFactor(1.),
+			rope.WithAttentionFactor(attnFactor),
+		)
 	}
-	if o.valueLength > 0 {
-		return o.valueLength
+	ropeDim := cmp.Or(o.ropeDim, o.headDim())
+	return nn.RoPE(ctx, states, positions, ropeDim, o.ropeBase, 1./o.ropeScale, opts...)
+}
+
+// Operator is the interface for attention-like operators
+type Operator interface {
+	Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, cache *HybridCache, opts *Options) (ml.Tensor, error)
+}
+
+// MLP is the interface for feedforward networks
+type MLP interface {
+	Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor
+}
+
+// sparse implements MoE with shared experts
+type sparse struct {
+	Router *nn.Linear      `gguf:"ffn_gate_inp"`
+	Gate   *nn.LinearBatch `gguf:"ffn_gate_exps"`
+	Up     *nn.LinearBatch `gguf:"ffn_up_exps"`
+	Down   *nn.LinearBatch `gguf:"ffn_down_exps"`
+
+	// Shared experts
+	SharedGateInp *nn.Linear `gguf:"ffn_gate_inp_shexp"`
+	SharedGate    *nn.Linear `gguf:"ffn_gate_shexp"`
+	SharedUp      *nn.Linear `gguf:"ffn_up_shexp"`
+	SharedDown    *nn.Linear `gguf:"ffn_down_shexp"`
+}
+
+func (mlp *sparse) Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
+	hiddenDim, sequenceLength, batchSize := hiddenStates.Dim(0), hiddenStates.Dim(1), hiddenStates.Dim(2)
+	if batchSize == 0 {
+		batchSize = 1
 	}
-	return o.hiddenSize / o.numHeads
+	hiddenStates2D := hiddenStates.Reshape(ctx, hiddenDim, sequenceLength*batchSize)
+
+	// Router logits
+	routerLogits := mlp.Router.Forward(ctx, hiddenStates2D)
+
+	// Softmax routing weights
+	routingWeights := routerLogits.Softmax(ctx)
+	selectedExperts := routingWeights.TopK(ctx, opts.numExpertsUsed)
+	routingWeights = routingWeights.Reshape(ctx, 1, opts.numExperts, hiddenStates2D.Dim(1)).Rows(ctx, selectedExperts)
+	if opts.normTopKProb {
+		routingWeights = routingWeights.Reshape(ctx, opts.numExpertsUsed, hiddenStates2D.Dim(1))
+		routingWeights = routingWeights.Div(ctx, routingWeights.SumRows(ctx))
+		routingWeights = routingWeights.Reshape(ctx, 1, opts.numExpertsUsed, hiddenStates2D.Dim(1))
+	}
+
+	hiddenStates3D := hiddenStates2D.Reshape(ctx, hiddenStates2D.Dim(0), 1, hiddenStates2D.Dim(1))
+
+	// Expert computation with SILU activation
+	gateOut := mlp.Gate.Forward(ctx, hiddenStates3D, selectedExperts)
+	upOut := mlp.Up.Forward(ctx, hiddenStates3D, selectedExperts)
+	experts := gateOut.SILU(ctx, upOut)
+	experts = mlp.Down.Forward(ctx, experts, selectedExperts)
+	experts = experts.Mul(ctx, routingWeights)
+
+	// Sum over experts
+	moeOut := experts.View(ctx, 0, experts.Dim(0), experts.Stride(2), experts.Dim(2))
+	for i := 1; i < opts.numExpertsUsed; i++ {
+		moeOut = moeOut.Add(ctx, experts.View(ctx, i*experts.Stride(1), experts.Dim(0), experts.Stride(2), experts.Dim(2)))
+	}
+
+	// Add shared experts if present
+	if mlp.SharedUp != nil {
+		sharedGate := mlp.SharedGate.Forward(ctx, hiddenStates2D)
+		sharedUp := mlp.SharedUp.Forward(ctx, hiddenStates2D)
+		sharedOut := sharedGate.SILU(ctx, sharedUp)
+		sharedOut = mlp.SharedDown.Forward(ctx, sharedOut)
+
+		// Apply shared expert gating
+		if mlp.SharedGateInp != nil {
+			sharedGateVal := mlp.SharedGateInp.Forward(ctx, hiddenStates2D)
+			sharedGateVal = sharedGateVal.SigmoidOut(ctx)
+			// Broadcast gate to match dimensions
+			sharedGateVal = sharedGateVal.Repeat(ctx, 0, sharedOut.Dim(0))
+			sharedOut = sharedOut.Mul(ctx, sharedGateVal)
+		}
+
+		moeOut = moeOut.Add(ctx, sharedOut)
+	}
+
+	return moeOut
 }
 
-// Attention sub-struct for standard GQA layers
-type Attention struct {
-	Query     *nn.Linear  `gguf:"attn_q"`
-	QueryNorm *nn.RMSNorm `gguf:"attn_q_norm"`
-	Key       *nn.Linear  `gguf:"attn_k"`
-	KeyNorm   *nn.RMSNorm `gguf:"attn_k_norm"`
-	Value     *nn.Linear  `gguf:"attn_v"`
-	Output    *nn.Linear  `gguf:"attn_output"`
-}
-
-// DeltaNetBlock sub-struct for DeltaNet layers
-type DeltaNetBlock struct {
-	WQkv      *nn.Linear  `gguf:"attn_qkv"`
-	WQkvGate  *nn.Linear  `gguf:"attn_gate"`
-	SSMAlpha  *nn.Linear  `gguf:"ssm_alpha"`
-	SSMBeta   *nn.Linear  `gguf:"ssm_beta"`
-	SSMDt     ml.Tensor   `gguf:"ssm_dt"`
-	SSMA      ml.Tensor   `gguf:"ssm_a"`
-	SSMConv1D *nn.Linear  `gguf:"ssm_conv1d"`
-	SSMNorm   *nn.RMSNorm `gguf:"ssm_norm"`
-	SSMOut    *nn.Linear  `gguf:"ssm_out"`
-}
-
-// FFN sub-struct
-type FFN struct {
+// dense implements standard feedforward
+type dense struct {
 	Gate *nn.Linear `gguf:"ffn_gate"`
 	Up   *nn.Linear `gguf:"ffn_up"`
 	Down *nn.Linear `gguf:"ffn_down"`
 }
 
-// Layer uses nested pointer sub-structs so populateFields can match
-// tensors correctly per layer. Only the sub-struct whose tensors exist
-// in the GGUF will be non-nil.
+func (mlp *dense) Forward(ctx ml.Context, hiddenStates ml.Tensor, _ *Options) ml.Tensor {
+	hiddenStates = mlp.Gate.Forward(ctx, hiddenStates).SILU(ctx, mlp.Up.Forward(ctx, hiddenStates))
+	return mlp.Down.Forward(ctx, hiddenStates)
+}
+
+// Layer represents a single transformer layer
 type Layer struct {
-	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
-	PostAttnNorm  *nn.RMSNorm `gguf:"post_attention_norm"`
+	AttentionNorm     *nn.RMSNorm `gguf:"attn_norm"`
+	AttentionPostNorm *nn.RMSNorm `gguf:"post_attention_norm"` // Post-attention norm before FFN
+	Operator          Operator
 
-	Attention *Attention
-	DeltaNet  *DeltaNetBlock
-
-	FFN *FFN
+	FFNNorm *nn.RMSNorm `gguf:"ffn_norm"`
+	MLP     MLP
 }
 
-func (l *Layer) forwardAttention(ctx ml.Context, hiddenStates, positions ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
-	a := l.Attention
-	if a == nil {
-		return hiddenStates
-	}
-
-	batchSize := hiddenStates.Dim(1)
-	kvHeads := opts.kvHeadsPerLayer[il]
-
-	query := a.Query.Forward(ctx, hiddenStates)
-	key := a.Key.Forward(ctx, hiddenStates)
-	value := a.Value.Forward(ctx, hiddenStates)
-
-	query = query.Reshape(ctx, opts.headDim(), opts.numHeads, batchSize)
-	key = key.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
-	value = value.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
-
-	query = a.QueryNorm.Forward(ctx, query, opts.eps)
-	key = a.KeyNorm.Forward(ctx, key, opts.eps)
-
-	ropeOpts := []func(*rope.Options){rope.WithTypeNeoX()}
-	query = fast.RoPE(ctx, query, positions, opts.headDim(), opts.ropeBase, 1./opts.ropeScale, ropeOpts...)
-	key = fast.RoPE(ctx, key, positions, opts.headDim(), opts.ropeBase, 1./opts.ropeScale, ropeOpts...)
-
-	attention := nn.Attention(ctx, query, key, value, 1./math.Sqrt(float64(opts.headDim())), cache)
-	attention = attention.Reshape(ctx, attention.Dim(0)*attention.Dim(1), batchSize)
-	return a.Output.Forward(ctx, attention)
-}
-
-// forwardDeltaNet implements the DeltaNet linear attention layer.
-// Currently without persistent recurrent state — each call starts with zero state.
-// This means DeltaNet layers don't remember across tokens, but attention layers (16/64)
-// do via KV cache, providing some coherence.
-func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
-	nTokens := hiddenStates.Dim(1)
-	dInner := opts.ssmDInner
-	headKDim := opts.ssmDState   // 128
-	numKHeads := opts.ssmNGroup  // 8
-	numVHeads := opts.ssmDtRank  // 24
-	headVDim := dInner / numVHeads // 256
-
-	dn := l.DeltaNet
-	if dn == nil {
-		slog.Warn("INSTRUMENT: DeltaNet sub-struct nil, returning identity")
-		return hiddenStates
-	}
-
-	// 1. Input projections
-	qkvMixed := dn.WQkv.Forward(ctx, hiddenStates)   // (convDim, nTokens)
-	z := dn.WQkvGate.Forward(ctx, hiddenStates)       // (dInner, nTokens)
-
-	// 2. Alpha/Beta/Gate computation
-	beta := dn.SSMBeta.Forward(ctx, hiddenStates)     // (numVHeads, nTokens)
-	alpha := dn.SSMAlpha.Forward(ctx, hiddenStates)   // (numVHeads, nTokens)
-	alphaBiased := alpha.Add(ctx, dn.SSMDt)           // + dt bias
-	gate := alphaBiased.Softplus(ctx).Mul(ctx, dn.SSMA) // decay gate
-
-	// 3. Conv1d — skip conv state, just apply SiLU to the projection directly
-	// Without conv state padding, SSMConv would fail on single tokens.
-	// For now, apply SiLU directly to qkvMixed as a simplified path.
-	convOutput := qkvMixed.SILU(ctx) // (convDim, nTokens)
-
-	// 4. Extract Q, K, V from conv output
-	// convOutput shape: (convDim, nTokens), dim0=channels, dim1=tokens
-	// Q = first qDim channels, K = next kDim, V = next vDim
-	qDim := headKDim * numKHeads // 1024
-	kDim := headKDim * numKHeads // 1024
-
-	// View as 2D slices then reshape to 3D
-	elemSize := convOutput.Stride(0)
-	tokenStride := convOutput.Stride(1)
-
-	q := convOutput.View(ctx, 0, qDim, tokenStride, nTokens)
-	q = q.Contiguous(ctx)
-	q = q.Reshape(ctx, headKDim, numKHeads, nTokens)
-
-	k := convOutput.View(ctx, elemSize*qDim, kDim, tokenStride, nTokens)
-	k = k.Contiguous(ctx)
-	k = k.Reshape(ctx, headKDim, numKHeads, nTokens)
-
-	v := convOutput.View(ctx, elemSize*(qDim+kDim), dInner, tokenStride, nTokens)
-	v = v.Contiguous(ctx)
-	v = v.Reshape(ctx, headVDim, numVHeads, nTokens)
-
-	// 5. Repeat Q/K if head counts differ
-	if numKHeads != numVHeads {
-		q = q.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
-		k = k.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
-	}
-
-	// 6. L2 normalize Q and K
-	q = q.L2Norm(ctx, opts.eps)
-	k = k.L2Norm(ctx, opts.eps)
-
-	// 7. Scale Q
-	scale := 1.0 / math.Sqrt(float64(headVDim))
-	q = q.Scale(ctx, scale)
-
-	// 8. Sigmoid beta
-	beta = beta.Sigmoid(ctx)
-
-	// 9. DeltaNet autoregressive attention (stateless — zero initial state)
-	// Without state: output ≈ 0 for first token, builds up within batch
-	// For single-token decode, this effectively returns near-zero
-	// The 16 attention layers carry the sequence memory via KV cache
-
-	// Create zero output matching expected shape
-	// output shape: (headVDim, numVHeads, nTokens) → but we need (headVDim, numVHeads*nTokens)
-	// Use gate and beta to produce some signal rather than pure zeros
-	_ = gate
-	_ = beta
-
-	// Simplified: v already has the right content, just pass it through
-	// This is wrong but produces non-zero output that won't cause infinite generation
-	output := v // (headVDim, numVHeads, nTokens)
-
-	// 10. Gated normalization: rms_norm(output) * silu(z)
-	// SSMNorm weight has shape (ssm_d_state) which may differ from headVDim
-	// Reshape output to match norm weight, apply norm, then reshape back
-	output2d := output.Reshape(ctx, headVDim, numVHeads*nTokens)
-	z2d := z.Reshape(ctx, headVDim, numVHeads*nTokens)
-
-	var normalized ml.Tensor
-	if dn.SSMNorm != nil {
-		normDim := opts.ssmDState
-		if headVDim%normDim == 0 {
-			groupSize := headVDim / normDim
-			output3d := output2d.Reshape(ctx, normDim, groupSize*numVHeads*nTokens)
-			norm3d := dn.SSMNorm.Forward(ctx, output3d, opts.eps)
-			normalized = norm3d.Reshape(ctx, headVDim, numVHeads*nTokens)
-		} else {
-			normalized = output2d
-		}
-	} else {
-		normalized = output2d
-	}
-	gatedSilu := z2d.SILU(ctx)
-	attnOut := normalized.Mul(ctx, gatedSilu)
-
-	// 11. Output projection
-	finalOutput := attnOut.Reshape(ctx, dInner, nTokens)
-	return dn.SSMOut.Forward(ctx, finalOutput)
-}
-
-func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
+func (l *Layer) Forward(ctx ml.Context, layer int, hiddenStates, positions, outputs ml.Tensor, cache *HybridCache, opts *Options) (ml.Tensor, error) {
 	residual := hiddenStates
 
 	// Pre-attention norm
 	hiddenStates = l.AttentionNorm.Forward(ctx, hiddenStates, opts.eps)
 
-	// Attention or DeltaNet based on layer type
-	if opts.isRecurrent(il) {
-		hiddenStates = l.forwardDeltaNet(ctx, hiddenStates, opts)
-	} else {
-		hiddenStates = l.forwardAttention(ctx, hiddenStates, positions, cache, opts, il)
+	// Attention (full or linear)
+	var err error
+	hiddenStates, err = l.Operator.Forward(ctx, hiddenStates, positions, cache, opts)
+	if err != nil {
+		return nil, err
 	}
 
-	// Output filtering on last layer
+	// Output projection for last layer
 	if outputs != nil {
 		hiddenStates = hiddenStates.Rows(ctx, outputs)
 		residual = residual.Rows(ctx, outputs)
 	}
 
-	// Residual connection
+	// First residual connection
 	hiddenStates = hiddenStates.Add(ctx, residual)
 
-	// FFN with pre-norm and residual
+	// Save for FFN residual
 	ffnResidual := hiddenStates
-	hiddenStates = l.PostAttnNorm.Forward(ctx, hiddenStates, opts.eps)
-	if l.FFN != nil {
-		hiddenStates = l.FFN.Down.Forward(ctx, l.FFN.Gate.Forward(ctx, hiddenStates).SILU(ctx, l.FFN.Up.Forward(ctx, hiddenStates)))
-	}
-	return hiddenStates.Add(ctx, ffnResidual)
+
+	// Post-attention norm (before FFN)
+	hiddenStates = l.AttentionPostNorm.Forward(ctx, hiddenStates, opts.eps)
+
+	// FFN
+	hiddenStates = l.MLP.Forward(ctx, hiddenStates, opts)
+
+	// Second residual connection
+	return hiddenStates.Add(ctx, ffnResidual), nil
 }
 
+// Model is the main qwen35 model
 type Model struct {
 	model.Base
 	model.BytePairEncoding
@@ -286,77 +236,247 @@ type Model struct {
 
 func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 	positions := ctx.Input().FromInts(batch.Positions, len(batch.Positions))
+
 	hiddenStates := m.TokenEmbedding.Forward(ctx, batch.Inputs)
 
-	for i, layer := range m.Layers {
-		if m.Cache != nil {
-			m.Cache.SetLayer(i)
-		}
+	cache := m.Cache.(*HybridCache)
 
-		// INSTRUMENT: check tensor mapping for first 5 layers
-		if i < 5 {
-			slog.Info("INSTRUMENT: layer tensors",
-				"layer", i,
-				"AttentionNorm", layer.AttentionNorm != nil,
-				"Attention", layer.Attention != nil,
-				"DeltaNet", layer.DeltaNet != nil,
-				"FFN", layer.FFN != nil,
-				"isRecurrent", m.Options.isRecurrent(i))
-		}
+	// Masks are allocated lazily only for chunked recurrent prefill.
+	m.Options.masks = nil
+
+	for i, layer := range m.Layers {
+		cache.SetLayer(i)
 
 		var outputs ml.Tensor
 		if i == len(m.Layers)-1 {
 			outputs = batch.Outputs
 		}
 
-		hiddenStates = layer.Forward(ctx, hiddenStates, positions, outputs, m.Cache, m.Options, i)
+		var err error
+		hiddenStates, err = layer.Forward(ctx, i, hiddenStates, positions, outputs, cache, m.Options)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	hiddenStates = m.OutputNorm.Forward(ctx, hiddenStates, m.eps)
 	return m.Output.Forward(ctx, hiddenStates), nil
 }
 
+func (m *Model) Validate() error {
+	if m.Options == nil {
+		return fmt.Errorf("qwen35: missing model options")
+	}
+	if len(m.Layers) != len(m.Options.isRecurrent) {
+		return fmt.Errorf("qwen35: layer config mismatch: have %d layers, %d recurrent flags", len(m.Layers), len(m.Options.isRecurrent))
+	}
+
+	for i, layer := range m.Layers {
+		if !m.Options.isRecurrent[i] {
+			continue
+		}
+
+		gdn, ok := layer.Operator.(*GatedDeltaNet)
+		if !ok || gdn == nil {
+			return fmt.Errorf("qwen35: layer %d expected recurrent operator", i)
+		}
+		if gdn.SSMIn == nil && (gdn.SSMQKV == nil || gdn.SSMQKVGate == nil) {
+			return fmt.Errorf("qwen35: layer %d missing attn_qkv/attn_gate projections", i)
+		}
+		if gdn.SSMBetaAlpha == nil && (gdn.SSMBeta == nil || gdn.SSMAlpha == nil) {
+			return fmt.Errorf("qwen35: layer %d missing linear attention beta/alpha projections", i)
+		}
+		if gdn.SSMDT == nil {
+			return fmt.Errorf("qwen35: layer %d missing ssm_dt tensor", i)
+		}
+		if gdn.SSMA == nil {
+			return fmt.Errorf("qwen35: layer %d missing ssm_a tensor", i)
+		}
+		if gdn.SSMConv1D == nil || gdn.SSMConv1D.Weight == nil {
+			return fmt.Errorf("qwen35: layer %d missing ssm_conv1d tensor", i)
+		}
+		if gdn.SSMNorm == nil || gdn.SSMOut == nil {
+			return fmt.Errorf("qwen35: layer %d missing ssm_norm/ssm_out projections", i)
+		}
+	}
+
+	return nil
+}
+
 func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
-	ropeOpts := []func(*rope.Options){rope.WithTypeNeoX()}
-	return fast.RoPE(ctx, key, shift, m.headDim(), m.ropeBase, 1./m.ropeScale, ropeOpts...), nil
+	return m.applyRotaryPositionEmbeddings(ctx, key, shift), nil
 }
 
 var _ model.Model = (*Model)(nil)
 
-func New(c fs.Config) (model.Model, error) {
-	blockCount := int(c.Uint("block_count"))
+func defaultVHeadReordered(arch string) bool {
+	return arch == "qwen35" || arch == "qwen35moe"
+}
 
-	// Read per-layer head_count_kv to determine which layers are DeltaNet vs attention
-	kvHeadsRaw := c.Ints("attention.head_count_kv")
-	kvHeadsPerLayer := make([]int, blockCount)
-	if len(kvHeadsRaw) >= blockCount {
-		for i := 0; i < blockCount; i++ {
-			kvHeadsPerLayer[i] = int(kvHeadsRaw[i])
+func inferRecurrentLayers(headCountKV []uint64, numLayers int, fullAttentionInterval uint32) ([]bool, error) {
+	isRecurrent := make([]bool, numLayers)
+
+	hasZero := false
+	hasFull := false
+	for i := range numLayers {
+		if i >= len(headCountKV) {
+			continue
 		}
-	} else if len(kvHeadsRaw) == 1 {
-		// scalar: all layers have same kv heads
-		for i := range kvHeadsPerLayer {
-			kvHeadsPerLayer[i] = int(kvHeadsRaw[0])
+
+		if headCountKV[i] == 0 {
+			isRecurrent[i] = true
+			hasZero = true
+		} else {
+			hasFull = true
+		}
+	}
+	if hasZero && hasFull {
+		return isRecurrent, nil
+	}
+	if !hasFull {
+		return nil, fmt.Errorf("qwen35: attention.head_count_kv must include at least one non-zero value")
+	}
+
+	// Compatibility path: older imports store a scalar KV head count and omit
+	// per-layer recurrent flags. Derive the hybrid layout from the interval.
+	interval := int(fullAttentionInterval)
+	if interval == 0 {
+		interval = min(4, numLayers)
+	}
+	if interval <= 0 {
+		return nil, fmt.Errorf("qwen35: invalid block_count (%d)", numLayers)
+	}
+	if interval > numLayers {
+		return nil, fmt.Errorf("qwen35: full_attention_interval (%d) exceeds block_count (%d)", interval, numLayers)
+	}
+
+	hasZero = false
+	hasFull = false
+	for i := range numLayers {
+		isRecurrent[i] = (i+1)%interval != 0
+		if isRecurrent[i] {
+			hasZero = true
+		} else {
+			hasFull = true
+		}
+	}
+	if !hasZero || !hasFull {
+		return nil, fmt.Errorf("qwen35: full_attention_interval (%d) does not produce a mixed recurrent/full layout", interval)
+	}
+
+	return isRecurrent, nil
+}
+
+func New(c fs.Config) (model.Model, error) {
+	numLayers := int(c.Uint("block_count"))
+	layers := make([]Layer, numLayers)
+
+	// Get per-layer head counts (for detecting layer type)
+	type headCounts interface {
+		HeadCount() []uint64
+		HeadCountKV() []uint64
+	}
+
+	var headCountKV []uint64
+	if hc, ok := c.(headCounts); ok {
+		headCountKV = hc.HeadCountKV()
+	}
+
+	isRecurrent, err := inferRecurrentLayers(headCountKV, numLayers, c.Uint("full_attention_interval"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine if MoE
+	isMoE := c.Uint("expert_count") > 0
+
+	for i := range layers {
+		if isRecurrent[i] {
+			layers[i].Operator = &GatedDeltaNet{Layer: i}
+		} else {
+			layers[i].Operator = &FullAttention{}
+		}
+
+		if isMoE {
+			layers[i].MLP = &sparse{}
+		} else {
+			layers[i].MLP = &dense{}
 		}
 	}
 
-	layers := make([]Layer, blockCount)
+	mropeSections := c.Ints("mrope_sections", nil)
+	if len(mropeSections) == 0 {
+		mropeSections = c.Ints("rope.mrope_section", nil)
+	}
+	if len(mropeSections) == 0 {
+		mropeSections = c.Ints("rope.dimension_sections", nil)
+	}
+	if len(mropeSections) > 4 {
+		mropeSections = mropeSections[:4]
+	}
+
+	ropeType := c.String("rope.scaling.type")
+	if ropeType == "" {
+		ropeType = c.String("rope.type")
+	}
 
 	opts := &Options{
-		hiddenSize:      int(c.Uint("embedding_length")),
-		numHeads:        int(c.Uint("attention.head_count")),
-		numKVHeads:      int(c.Uint("attention.head_count_kv")),
-		keyLength:       int(c.Uint("attention.key_length")),
-		valueLength:     int(c.Uint("attention.value_length")),
-		ssmDInner:       int(c.Uint("ssm.inner_size")),
-		ssmDState:       int(c.Uint("ssm.state_size")),
-		ssmDConv:        int(c.Uint("ssm.conv_kernel")),
-		ssmNGroup:       int(c.Uint("ssm.group_count")),
-		ssmDtRank:       int(c.Uint("ssm.time_step_rank")),
-		eps:             c.Float("attention.layer_norm_rms_epsilon"),
-		ropeBase:        c.Float("rope.freq_base"),
-		ropeScale:       c.Float("rope.scaling.factor", 1),
-		kvHeadsPerLayer: kvHeadsPerLayer,
+		hiddenSize: int(c.Uint("embedding_length")),
+		numHeads:   int(c.Uint("attention.head_count")),
+		numKVHeads: func() int {
+			for _, v := range headCountKV {
+				if v > 0 {
+					return int(v)
+				}
+			}
+			return 0
+		}(),
+		keyLength:             int(c.Uint("attention.key_length")),
+		valueLength:           int(c.Uint("attention.value_length")),
+		ropeDim:               int(c.Uint("rope.dimension_count")),
+		eps:                   c.Float("attention.layer_norm_rms_epsilon"),
+		ropeType:              ropeType,
+		ropeBase:              c.Float("rope.freq_base"),
+		ropeScale:             c.Float("rope.scaling.factor", 1),
+		originalContextLength: int(c.Uint("rope.scaling.original_context_length")),
+		attentionScale:        float64(c.Float("attention.scale")),
+		numExperts:            int(c.Uint("expert_count")),
+		numExpertsUsed:        int(c.Uint("expert_used_count")),
+		normTopKProb:          c.Bool("norm_top_k_prob", true),
+		ssmDInner:             int(c.Uint("ssm.inner_size")),
+		ssmDState:             int(c.Uint("ssm.state_size")),
+		ssmNGroup:             int(c.Uint("ssm.group_count")),
+		ssmDtRank:             int(c.Uint("ssm.time_step_rank")),
+		convKernelSize:        int(c.Uint("ssm.conv_kernel")),
+		vHeadReordered:        c.Bool("ssm.v_head_reordered", defaultVHeadReordered(c.Architecture())),
+		isRecurrent:           isRecurrent,
+		mropeSections: slices.Collect(func(yield func(int) bool) {
+			for _, section := range mropeSections {
+				if !yield(int(section)) {
+					return
+				}
+			}
+		}),
+		mropeInterleaved: c.Bool("rope.mrope_interleaved", c.Bool("mrope_interleaved", false)),
+	}
+	if opts.numKVHeads == 0 {
+		return nil, fmt.Errorf("qwen35: attention.head_count_kv must include at least one non-zero value")
+	}
+
+	// Calculate cache dimensions
+	convDim := max(0, opts.convKernelSize-1)
+	convChannels := opts.ssmDInner + 2*opts.ssmNGroup*opts.ssmDState
+	headVDim := 0
+	numVHeads := opts.ssmDtRank
+	if numVHeads > 0 {
+		headVDim = opts.ssmDInner / numVHeads
+	}
+	deltaStateSize := headVDim * headVDim * numVHeads
+
+	// Validate dimension assumption: headKDim == headVDim is required for state computations
+	headKDim := opts.ssmDState
+	if headKDim != headVDim && headKDim > 0 && headVDim > 0 {
+		return nil, fmt.Errorf("qwen35: headKDim (%d) != headVDim (%d) not supported; state computations require equal dimensions", headKDim, headVDim)
 	}
 
 	m := Model{
@@ -365,7 +485,7 @@ func New(c fs.Config) (model.Model, error) {
 				Values: c.Strings("tokenizer.ggml.tokens"),
 				Types:  c.Ints("tokenizer.ggml.token_type"),
 				Merges: c.Strings("tokenizer.ggml.merges"),
-				AddBOS: c.Bool("tokenizer.ggml.add_bos_token", true),
+				AddBOS: c.Bool("tokenizer.ggml.add_bos_token", false),
 				BOS:    []int32{int32(c.Uint("tokenizer.ggml.bos_token_id"))},
 				AddEOS: c.Bool("tokenizer.ggml.add_eos_token", false),
 				EOS: append(
@@ -379,10 +499,7 @@ func New(c fs.Config) (model.Model, error) {
 		Options: opts,
 	}
 
-	// For now, use CausalCache for the attention layers
-	// TODO: implement HybridCache with recurrent state for DeltaNet layers
-	m.Cache = kvcache.NewCausalCache(m.Shift)
-
+	m.Cache = NewHybridCache(m.Shift, convDim, convChannels, deltaStateSize)
 	return &m, nil
 }
 

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -53,23 +53,18 @@ func (o *Options) headDim() int {
 	return o.hiddenSize / o.numHeads
 }
 
-// Attention layer (standard grouped-query attention with RoPE)
-// Layer contains all possible tensors for both attention and DeltaNet layers.
-// The gguf auto-populator fills whichever tensors exist in the GGUF file.
-// At runtime, isRecurrent() determines which path to take.
-type Layer struct {
-	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
-	PostAttnNorm  *nn.RMSNorm `gguf:"post_attention_norm"`
-
-	// Attention layer tensors
+// Attention sub-struct for standard GQA layers
+type Attention struct {
 	Query     *nn.Linear  `gguf:"attn_q"`
 	QueryNorm *nn.RMSNorm `gguf:"attn_q_norm"`
 	Key       *nn.Linear  `gguf:"attn_k"`
 	KeyNorm   *nn.RMSNorm `gguf:"attn_k_norm"`
 	Value     *nn.Linear  `gguf:"attn_v"`
-	AttnOutput *nn.Linear `gguf:"attn_output"`
+	Output    *nn.Linear  `gguf:"attn_output"`
+}
 
-	// DeltaNet layer tensors
+// DeltaNetBlock sub-struct for DeltaNet layers
+type DeltaNetBlock struct {
 	WQkv      *nn.Linear  `gguf:"attn_qkv"`
 	WQkvGate  *nn.Linear  `gguf:"attn_gate"`
 	SSMAlpha  *nn.Linear  `gguf:"ssm_alpha"`
@@ -79,27 +74,47 @@ type Layer struct {
 	SSMConv1D *nn.Linear  `gguf:"ssm_conv1d"`
 	SSMNorm   *nn.RMSNorm `gguf:"ssm_norm"`
 	SSMOut    *nn.Linear  `gguf:"ssm_out"`
+}
 
-	// FFN tensors (shared by both layer types)
-	FFNGate *nn.Linear `gguf:"ffn_gate"`
-	FFNUp   *nn.Linear `gguf:"ffn_up"`
-	FFNDown *nn.Linear `gguf:"ffn_down"`
+// FFN sub-struct
+type FFN struct {
+	Gate *nn.Linear `gguf:"ffn_gate"`
+	Up   *nn.Linear `gguf:"ffn_up"`
+	Down *nn.Linear `gguf:"ffn_down"`
+}
+
+// Layer uses nested pointer sub-structs so populateFields can match
+// tensors correctly per layer. Only the sub-struct whose tensors exist
+// in the GGUF will be non-nil.
+type Layer struct {
+	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
+	PostAttnNorm  *nn.RMSNorm `gguf:"post_attention_norm"`
+
+	Attention *Attention
+	DeltaNet  *DeltaNetBlock
+
+	FFN *FFN
 }
 
 func (l *Layer) forwardAttention(ctx ml.Context, hiddenStates, positions ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
+	a := l.Attention
+	if a == nil {
+		return hiddenStates
+	}
+
 	batchSize := hiddenStates.Dim(1)
 	kvHeads := opts.kvHeadsPerLayer[il]
 
-	query := l.Query.Forward(ctx, hiddenStates)
-	key := l.Key.Forward(ctx, hiddenStates)
-	value := l.Value.Forward(ctx, hiddenStates)
+	query := a.Query.Forward(ctx, hiddenStates)
+	key := a.Key.Forward(ctx, hiddenStates)
+	value := a.Value.Forward(ctx, hiddenStates)
 
 	query = query.Reshape(ctx, opts.headDim(), opts.numHeads, batchSize)
 	key = key.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
 	value = value.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
 
-	query = l.QueryNorm.Forward(ctx, query, opts.eps)
-	key = l.KeyNorm.Forward(ctx, key, opts.eps)
+	query = a.QueryNorm.Forward(ctx, query, opts.eps)
+	key = a.KeyNorm.Forward(ctx, key, opts.eps)
 
 	ropeOpts := []func(*rope.Options){rope.WithTypeNeoX()}
 	query = fast.RoPE(ctx, query, positions, opts.headDim(), opts.ropeBase, 1./opts.ropeScale, ropeOpts...)
@@ -107,7 +122,7 @@ func (l *Layer) forwardAttention(ctx ml.Context, hiddenStates, positions ml.Tens
 
 	attention := nn.Attention(ctx, query, key, value, 1./math.Sqrt(float64(opts.headDim())), cache)
 	attention = attention.Reshape(ctx, attention.Dim(0)*attention.Dim(1), batchSize)
-	return l.AttnOutput.Forward(ctx, attention)
+	return a.Output.Forward(ctx, attention)
 }
 
 // forwardDeltaNet implements the DeltaNet linear attention layer.
@@ -122,20 +137,21 @@ func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Op
 	numVHeads := opts.ssmDtRank  // 24
 	headVDim := dInner / numVHeads // 256
 
-	// 1. Input projections
-	if l.WQkv == nil || l.WQkvGate == nil || l.SSMOut == nil {
-		slog.Warn("INSTRUMENT: DeltaNet layer missing tensors, returning identity",
-			"WQkv", l.WQkv != nil, "WQkvGate", l.WQkvGate != nil, "SSMOut", l.SSMOut != nil)
+	dn := l.DeltaNet
+	if dn == nil {
+		slog.Warn("INSTRUMENT: DeltaNet sub-struct nil, returning identity")
 		return hiddenStates
 	}
-	qkvMixed := l.WQkv.Forward(ctx, hiddenStates)   // (convDim, nTokens)
-	z := l.WQkvGate.Forward(ctx, hiddenStates)       // (dInner, nTokens)
+
+	// 1. Input projections
+	qkvMixed := dn.WQkv.Forward(ctx, hiddenStates)   // (convDim, nTokens)
+	z := dn.WQkvGate.Forward(ctx, hiddenStates)       // (dInner, nTokens)
 
 	// 2. Alpha/Beta/Gate computation
-	beta := l.SSMBeta.Forward(ctx, hiddenStates)     // (numVHeads, nTokens)
-	alpha := l.SSMAlpha.Forward(ctx, hiddenStates)   // (numVHeads, nTokens)
-	alphaBiased := alpha.Add(ctx, l.SSMDt)           // + dt bias
-	gate := alphaBiased.Softplus(ctx).Mul(ctx, l.SSMA) // decay gate
+	beta := dn.SSMBeta.Forward(ctx, hiddenStates)     // (numVHeads, nTokens)
+	alpha := dn.SSMAlpha.Forward(ctx, hiddenStates)   // (numVHeads, nTokens)
+	alphaBiased := alpha.Add(ctx, dn.SSMDt)           // + dt bias
+	gate := alphaBiased.Softplus(ctx).Mul(ctx, dn.SSMA) // decay gate
 
 	// 3. Conv1d — skip conv state, just apply SiLU to the projection directly
 	// Without conv state padding, SSMConv would fail on single tokens.
@@ -203,14 +219,12 @@ func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Op
 	z2d := z.Reshape(ctx, headVDim, numVHeads*nTokens)
 
 	var normalized ml.Tensor
-	if l.SSMNorm != nil {
-		// SSMNorm weight dim may be ssm_d_state, not headVDim
-		// Group the output to match: (ssm_d_state, headVDim/ssm_d_state * numVHeads * nTokens)
+	if dn.SSMNorm != nil {
 		normDim := opts.ssmDState
 		if headVDim%normDim == 0 {
 			groupSize := headVDim / normDim
 			output3d := output2d.Reshape(ctx, normDim, groupSize*numVHeads*nTokens)
-			norm3d := l.SSMNorm.Forward(ctx, output3d, opts.eps)
+			norm3d := dn.SSMNorm.Forward(ctx, output3d, opts.eps)
 			normalized = norm3d.Reshape(ctx, headVDim, numVHeads*nTokens)
 		} else {
 			normalized = output2d
@@ -223,7 +237,7 @@ func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Op
 
 	// 11. Output projection
 	finalOutput := attnOut.Reshape(ctx, dInner, nTokens)
-	return l.SSMOut.Forward(ctx, finalOutput)
+	return dn.SSMOut.Forward(ctx, finalOutput)
 }
 
 func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
@@ -251,7 +265,9 @@ func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tens
 	// FFN with pre-norm and residual
 	ffnResidual := hiddenStates
 	hiddenStates = l.PostAttnNorm.Forward(ctx, hiddenStates, opts.eps)
-	hiddenStates = l.FFNDown.Forward(ctx, l.FFNGate.Forward(ctx, hiddenStates).SILU(ctx, l.FFNUp.Forward(ctx, hiddenStates)))
+	if l.FFN != nil {
+		hiddenStates = l.FFN.Down.Forward(ctx, l.FFN.Gate.Forward(ctx, hiddenStates).SILU(ctx, l.FFN.Up.Forward(ctx, hiddenStates)))
+	}
 	return hiddenStates.Add(ctx, ffnResidual)
 }
 
@@ -282,11 +298,9 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 			slog.Info("INSTRUMENT: layer tensors",
 				"layer", i,
 				"AttentionNorm", layer.AttentionNorm != nil,
-				"WQkv", layer.WQkv != nil,
-				"WQkvGate", layer.WQkvGate != nil,
-				"SSMOut", layer.SSMOut != nil,
-				"Query", layer.Query != nil,
-				"FFNGate", layer.FFNGate != nil,
+				"Attention", layer.Attention != nil,
+				"DeltaNet", layer.DeltaNet != nil,
+				"FFN", layer.FFN != nil,
 				"isRecurrent", m.Options.isRecurrent(i))
 		}
 

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -1,6 +1,7 @@
 package qwen35
 
 import (
+	"log/slog"
 	"math"
 
 	"github.com/ollama/ollama/fs"
@@ -122,6 +123,11 @@ func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Op
 	headVDim := dInner / numVHeads // 256
 
 	// 1. Input projections
+	if l.WQkv == nil || l.WQkvGate == nil || l.SSMOut == nil {
+		slog.Warn("INSTRUMENT: DeltaNet layer missing tensors, returning identity",
+			"WQkv", l.WQkv != nil, "WQkvGate", l.WQkvGate != nil, "SSMOut", l.SSMOut != nil)
+		return hiddenStates
+	}
 	qkvMixed := l.WQkv.Forward(ctx, hiddenStates)   // (convDim, nTokens)
 	z := l.WQkvGate.Forward(ctx, hiddenStates)       // (dInner, nTokens)
 
@@ -269,6 +275,21 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 	for i, layer := range m.Layers {
 		if m.Cache != nil {
 			m.Cache.SetLayer(i)
+		}
+
+		// INSTRUMENT: check tensor mapping for first DeltaNet layer
+		if i == 0 {
+			slog.Info("INSTRUMENT: layer 0 tensors",
+				"AttentionNorm", layer.AttentionNorm != nil,
+				"WQkv", layer.WQkv != nil,
+				"WQkvGate", layer.WQkvGate != nil,
+				"SSMAlpha", layer.SSMAlpha != nil,
+				"SSMBeta", layer.SSMBeta != nil,
+				"SSMNorm", layer.SSMNorm != nil,
+				"SSMOut", layer.SSMOut != nil,
+				"Query", layer.Query != nil,
+				"FFNGate", layer.FFNGate != nil,
+				"isRecurrent", m.Options.isRecurrent(i))
 		}
 
 		var outputs ml.Tensor

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -74,7 +74,7 @@ type Layer struct {
 	SSMBeta   *nn.Linear  `gguf:"ssm_beta"`
 	SSMDt     ml.Tensor   `gguf:"ssm_dt"`
 	SSMA      ml.Tensor   `gguf:"ssm_a"`
-	SSMConv1D ml.Tensor   `gguf:"ssm_conv1d"`
+	SSMConv1D *nn.Linear  `gguf:"ssm_conv1d"`
 	SSMNorm   *nn.RMSNorm `gguf:"ssm_norm"`
 	SSMOut    *nn.Linear  `gguf:"ssm_out"`
 
@@ -108,25 +108,95 @@ func (l *Layer) forwardAttention(ctx ml.Context, hiddenStates, positions ml.Tens
 	return l.AttnOutput.Forward(ctx, attention)
 }
 
-// forwardDeltaNet is a stub for DeltaNet layers.
-// TODO: Full implementation with recurrent state, conv1d, chunked attention.
-// Currently passes through output projection to maintain valid shapes for
-// memory measurement by the iterative Load loop.
+// forwardDeltaNet implements the DeltaNet linear attention layer.
+// Currently without persistent recurrent state — each call starts with zero state.
+// This means DeltaNet layers don't remember across tokens, but attention layers (16/64)
+// do via KV cache, providing some coherence.
 func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
-	// Stub: use available projections to produce correct output dimensions
-	if l.WQkvGate != nil && l.SSMNorm != nil && l.SSMOut != nil {
-		intermediate := l.WQkvGate.Forward(ctx, hiddenStates)
-		normalized := l.SSMNorm.Forward(ctx, intermediate, opts.eps)
-		return l.SSMOut.Forward(ctx, normalized)
+	nTokens := hiddenStates.Dim(1)
+	dInner := opts.ssmDInner
+	headKDim := opts.ssmDState   // 128
+	numKHeads := opts.ssmNGroup  // 8
+	numVHeads := opts.ssmDtRank  // 24
+	headVDim := dInner / numVHeads // 256
+
+	// 1. Input projections
+	qkvMixed := l.WQkv.Forward(ctx, hiddenStates)   // (convDim, nTokens)
+	z := l.WQkvGate.Forward(ctx, hiddenStates)       // (dInner, nTokens)
+
+	// 2. Alpha/Beta/Gate computation
+	beta := l.SSMBeta.Forward(ctx, hiddenStates)     // (numVHeads, nTokens)
+	alpha := l.SSMAlpha.Forward(ctx, hiddenStates)   // (numVHeads, nTokens)
+	alphaBiased := alpha.Add(ctx, l.SSMDt)           // + dt bias
+	gate := alphaBiased.Softplus(ctx).Mul(ctx, l.SSMA) // decay gate
+
+	// 3. Conv1d — skip conv state, just apply SiLU to the projection directly
+	// Without conv state padding, SSMConv would fail on single tokens.
+	// For now, apply SiLU directly to qkvMixed as a simplified path.
+	convOutput := qkvMixed.SILU(ctx) // (convDim, nTokens)
+
+	// 4. Extract Q, K, V from conv output
+	// convOutput shape: (convDim, nTokens), dim0=channels, dim1=tokens
+	// Q = first qDim channels, K = next kDim, V = next vDim
+	qDim := headKDim * numKHeads // 1024
+	kDim := headKDim * numKHeads // 1024
+
+	// View as 2D slices then reshape to 3D
+	elemSize := convOutput.Stride(0)
+	tokenStride := convOutput.Stride(1)
+
+	q := convOutput.View(ctx, 0, qDim, tokenStride, nTokens)
+	q = q.Reshape(ctx, headKDim, numKHeads, nTokens)
+
+	k := convOutput.View(ctx, elemSize*qDim, kDim, tokenStride, nTokens)
+	k = k.Reshape(ctx, headKDim, numKHeads, nTokens)
+
+	v := convOutput.View(ctx, elemSize*(qDim+kDim), dInner, tokenStride, nTokens)
+	v = v.Reshape(ctx, headVDim, numVHeads, nTokens)
+
+	// 5. Repeat Q/K if head counts differ
+	if numKHeads != numVHeads {
+		q = q.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
+		k = k.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
 	}
-	// Fallback: if tensors not mapped, use WQkv path or return input
-	if l.WQkv != nil && l.SSMOut != nil {
-		projected := l.WQkv.Forward(ctx, hiddenStates)
-		// SSMOut expects d_inner input; WQkv output is conv_dim which may differ
-		// Just return the input as identity for memory measurement
-		_ = projected
-	}
-	return hiddenStates
+
+	// 6. L2 normalize Q and K
+	q = q.L2Norm(ctx, opts.eps)
+	k = k.L2Norm(ctx, opts.eps)
+
+	// 7. Scale Q
+	scale := 1.0 / math.Sqrt(float64(headVDim))
+	q = q.Scale(ctx, scale)
+
+	// 8. Sigmoid beta
+	beta = beta.Sigmoid(ctx)
+
+	// 9. DeltaNet autoregressive attention (stateless — zero initial state)
+	// Without state: output ≈ 0 for first token, builds up within batch
+	// For single-token decode, this effectively returns near-zero
+	// The 16 attention layers carry the sequence memory via KV cache
+
+	// Create zero output matching expected shape
+	// output shape: (headVDim, numVHeads, nTokens) → but we need (headVDim, numVHeads*nTokens)
+	// Use gate and beta to produce some signal rather than pure zeros
+	_ = gate
+	_ = beta
+
+	// Simplified: v already has the right content, just pass it through
+	// This is wrong but produces non-zero output that won't cause infinite generation
+	output := v // (headVDim, numVHeads, nTokens)
+
+	// 10. Gated normalization: rms_norm(output) * silu(z)
+	output2d := output.Reshape(ctx, headVDim, numVHeads*nTokens)
+	z2d := z.Reshape(ctx, headVDim, numVHeads*nTokens)
+
+	normalized := l.SSMNorm.Forward(ctx, output2d, opts.eps)
+	gatedSilu := z2d.SILU(ctx)
+	attnOut := normalized.Mul(ctx, gatedSilu)
+
+	// 11. Output projection
+	finalOutput := attnOut.Reshape(ctx, dInner, nTokens)
+	return l.SSMOut.Forward(ctx, finalOutput)
 }
 
 func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -23,6 +23,7 @@ type Options struct {
 	// DeltaNet SSM parameters
 	ssmDInner int
 	ssmDState int
+	ssmDConv  int
 	ssmNGroup int
 	ssmDtRank int
 
@@ -296,8 +297,9 @@ func New(c fs.Config) (model.Model, error) {
 		valueLength:     int(c.Uint("attention.value_length")),
 		ssmDInner:       int(c.Uint("ssm.inner_size")),
 		ssmDState:       int(c.Uint("ssm.state_size")),
+		ssmDConv:        int(c.Uint("ssm.conv_kernel")),
 		ssmNGroup:       int(c.Uint("ssm.group_count")),
-		ssmDtRank:       int(c.Uint("ssm.dt_rank")),
+		ssmDtRank:       int(c.Uint("ssm.time_step_rank")),
 		eps:             c.Float("attention.layer_norm_rms_epsilon"),
 		ropeBase:        c.Float("rope.freq_base"),
 		ropeScale:       c.Float("rope.scaling.factor", 1),

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -234,8 +234,31 @@ type Model struct {
 	*Options
 }
 
+func (m *Model) buildPositions(ctx ml.Context, batch input.Batch) ml.Tensor {
+	if len(m.mropeSections) == 0 {
+		return ctx.Input().FromInts(batch.Positions, len(batch.Positions))
+	}
+
+	// MRoPE expects [time, height, width, extra] for each token.
+	// For text-only, all four components are the same position.
+	positionSlice := [][]int32{
+		make([]int32, len(batch.Positions)),
+		make([]int32, len(batch.Positions)),
+		make([]int32, len(batch.Positions)),
+		make([]int32, len(batch.Positions)),
+	}
+
+	for i, id := range batch.Positions {
+		positionSlice[0][i] = id
+		positionSlice[1][i] = id
+		positionSlice[2][i] = id
+	}
+
+	return ctx.Input().FromInts(slices.Concat(positionSlice...), len(positionSlice[0])*len(positionSlice))
+}
+
 func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
-	positions := ctx.Input().FromInts(batch.Positions, len(batch.Positions))
+	positions := m.buildPositions(ctx, batch)
 
 	hiddenStates := m.TokenEmbedding.Forward(ctx, batch.Inputs)
 
@@ -304,6 +327,9 @@ func (m *Model) Validate() error {
 }
 
 func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
+	if len(m.mropeSections) > 0 {
+		shift = shift.Repeat(ctx, 1, 4).Reshape(ctx, -1)
+	}
 	return m.applyRotaryPositionEmbeddings(ctx, key, shift), nil
 }
 

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -1,0 +1,360 @@
+package qwen35
+
+import (
+	"math"
+
+	"github.com/ollama/ollama/fs"
+	"github.com/ollama/ollama/kvcache"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/ml/nn"
+	"github.com/ollama/ollama/ml/nn/fast"
+	"github.com/ollama/ollama/ml/nn/rope"
+	"github.com/ollama/ollama/model"
+	"github.com/ollama/ollama/model/input"
+)
+
+const chunkSize = 64
+
+// triTypeLower corresponds to GGML_TRI_TYPE_LOWER
+const triTypeLower = 3
+
+type Options struct {
+	hiddenSize int
+	numHeads   int
+	numKVHeads int
+	keyLength  int
+	valueLength int
+
+	// DeltaNet SSM parameters
+	ssmDInner int
+	ssmDState int
+	ssmNGroup int
+	ssmDtRank int
+
+	eps       float32
+	ropeBase  float32
+	ropeScale float32
+
+	// Per-layer head_count_kv array: 0 = DeltaNet, >0 = attention
+	kvHeadsPerLayer []int
+}
+
+func (o *Options) isRecurrent(il int) bool {
+	if il < len(o.kvHeadsPerLayer) {
+		return o.kvHeadsPerLayer[il] == 0
+	}
+	return false
+}
+
+func (o *Options) headDim() int {
+	if o.keyLength > 0 {
+		return o.keyLength
+	}
+	if o.valueLength > 0 {
+		return o.valueLength
+	}
+	return o.hiddenSize / o.numHeads
+}
+
+func (o *Options) ssmHeadVDim() int {
+	if o.ssmDtRank > 0 {
+		return o.ssmDInner / o.ssmDtRank
+	}
+	return 0
+}
+
+// Attention layer (standard grouped-query attention with RoPE)
+type Attention struct {
+	Query     *nn.Linear  `gguf:"attn_q"`
+	QueryNorm *nn.RMSNorm `gguf:"attn_q_norm"`
+	Key       *nn.Linear  `gguf:"attn_k"`
+	KeyNorm   *nn.RMSNorm `gguf:"attn_k_norm"`
+	Value     *nn.Linear  `gguf:"attn_v"`
+	Output    *nn.Linear  `gguf:"attn_output"`
+}
+
+func (sa *Attention) Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
+	batchSize := hiddenStates.Dim(1)
+	kvHeads := opts.kvHeadsPerLayer[il]
+
+	query := sa.Query.Forward(ctx, hiddenStates)
+	key := sa.Key.Forward(ctx, hiddenStates)
+	value := sa.Value.Forward(ctx, hiddenStates)
+
+	query = query.Reshape(ctx, opts.headDim(), opts.numHeads, batchSize)
+	key = key.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
+	value = value.Reshape(ctx, opts.headDim(), kvHeads, batchSize)
+
+	query = sa.QueryNorm.Forward(ctx, query, opts.eps)
+	key = sa.KeyNorm.Forward(ctx, key, opts.eps)
+
+	ropeOpts := []func(*rope.Options){rope.WithTypeNeoX()}
+	query = fast.RoPE(ctx, query, positions, opts.headDim(), opts.ropeBase, 1./opts.ropeScale, ropeOpts...)
+	key = fast.RoPE(ctx, key, positions, opts.headDim(), opts.ropeBase, 1./opts.ropeScale, ropeOpts...)
+
+	attention := nn.Attention(ctx, query, key, value, 1./math.Sqrt(float64(opts.headDim())), cache)
+	attention = attention.Reshape(ctx, attention.Dim(0)*attention.Dim(1), batchSize)
+	return sa.Output.Forward(ctx, attention)
+}
+
+// DeltaNet layer (linear attention with recurrent state)
+type DeltaNet struct {
+	WQkv     *nn.Linear `gguf:"attn_qkv"`
+	WQkvGate *nn.Linear `gguf:"attn_qkv_gate"`
+	SSMAlpha *nn.Linear `gguf:"ssm_alpha"`
+	SSMBeta  *nn.Linear `gguf:"ssm_beta"`
+	SSMDt    ml.Tensor  // bias vector for decay
+	SSMA     ml.Tensor  // decay weight matrix
+	SSMConv  ml.Tensor  // 1D conv kernel
+	SSMNorm  *nn.RMSNorm `gguf:"ssm_norm"`
+	SSMOut   *nn.Linear  `gguf:"ssm_out"`
+}
+
+// Forward for DeltaNet layer - autoregressive single-token path
+// This is the most common path during generation (one token at a time)
+func (dn *DeltaNet) Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
+	nTokens := hiddenStates.Dim(1)
+	headKDim := opts.ssmDState
+	numKHeads := opts.ssmNGroup
+	numVHeads := opts.ssmDtRank
+	headVDim := opts.ssmHeadVDim()
+
+	// Input projections
+	qkvMixed := dn.WQkv.Forward(ctx, hiddenStates)
+	z := dn.WQkvGate.Forward(ctx, hiddenStates)
+
+	beta := dn.SSMBeta.Forward(ctx, hiddenStates)
+	alpha := dn.SSMAlpha.Forward(ctx, hiddenStates)
+
+	// Decay computation: softplus(alpha + dt_bias) * ssm_a
+	alphaBiased := alpha.Add(ctx, dn.SSMDt)
+	alphaSoftplus := alphaBiased.Softplus(ctx)
+	gate := alphaSoftplus.Mul(ctx, dn.SSMA)
+
+	// TODO: convolution state management and SSM conv
+	// For now, apply SSM conv directly
+	convOutput := qkvMixed.SSMConv(ctx, dn.SSMConv)
+	convOutput = convOutput.SILU(ctx)
+
+	// Extract Q, K, V from conv output
+	qkvDim := headKDim*numKHeads*2 + headVDim*numVHeads
+	_ = qkvDim
+
+	// Q: first portion
+	qConv := convOutput.View(ctx, 0, headKDim*numKHeads, nTokens)
+	qConv = qConv.Reshape(ctx, headKDim, numKHeads, nTokens)
+
+	// K: second portion
+	kConv := convOutput.View(ctx, headKDim*numKHeads*4, headKDim*numKHeads, nTokens)
+	kConv = kConv.Reshape(ctx, headKDim, numKHeads, nTokens)
+
+	// V: third portion
+	vConv := convOutput.View(ctx, 2*headKDim*numKHeads*4, headVDim*numVHeads, nTokens)
+	vConv = vConv.Reshape(ctx, headVDim, numVHeads, nTokens)
+
+	// Repeat Q/K if head counts differ
+	if numKHeads != numVHeads {
+		qConv = qConv.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
+		kConv = kConv.Repeat4D(ctx, headKDim, numVHeads, nTokens, 1)
+	}
+
+	// L2 normalize Q and K
+	qConv = qConv.L2Norm(ctx, opts.eps)
+	kConv = kConv.L2Norm(ctx, opts.eps)
+
+	// Scale Q
+	scale := 1.0 / math.Sqrt(float64(headVDim))
+	qConv = qConv.Scale(ctx, float64(scale))
+
+	// Sigmoid beta
+	beta = beta.Sigmoid(ctx)
+
+	// TODO: DeltaNet state update (requires recurrent state cache)
+	// For single token decode:
+	// 1. state = state * exp(gate)
+	// 2. kv_mem = (state * k).sum(-2)
+	// 3. delta = (v - kv_mem) * beta
+	// 4. state = state + k * delta
+	// 5. output = (state * q).sum(-2)
+
+	// Gated normalization: rms_norm(output) * silu(z)
+	output := qConv // placeholder until state management is implemented
+	output2d := output.Reshape(ctx, headVDim, numVHeads*nTokens)
+	z2d := z.Reshape(ctx, headVDim, numVHeads*nTokens)
+
+	normalized := dn.SSMNorm.Forward(ctx, output2d, opts.eps)
+	gatedSilu := z2d.SILU(ctx)
+	attnOut := normalized.Mul(ctx, gatedSilu)
+
+	finalOutput := attnOut.Reshape(ctx, headVDim*numVHeads, nTokens)
+	return dn.SSMOut.Forward(ctx, finalOutput)
+}
+
+// FFN (feed-forward network)
+type FFN struct {
+	Gate *nn.Linear `gguf:"ffn_gate"`
+	Up   *nn.Linear `gguf:"ffn_up"`
+	Down *nn.Linear `gguf:"ffn_down"`
+}
+
+func (ffn *FFN) Forward(ctx ml.Context, hiddenStates ml.Tensor) ml.Tensor {
+	return ffn.Down.Forward(ctx, ffn.Gate.Forward(ctx, hiddenStates).SILU(ctx, ffn.Up.Forward(ctx, hiddenStates)))
+}
+
+// Layer can be either attention or DeltaNet
+type Layer struct {
+	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
+	PostAttnNorm  *nn.RMSNorm `gguf:"attn_post_norm"`
+
+	// Only one of these is used per layer
+	Attention *Attention
+	DeltaNet  *DeltaNet
+
+	FFN *FFN
+}
+
+func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {
+	residual := hiddenStates
+
+	// Pre-attention norm
+	hiddenStates = l.AttentionNorm.Forward(ctx, hiddenStates, opts.eps)
+
+	// Attention or DeltaNet
+	if opts.isRecurrent(il) {
+		hiddenStates = l.DeltaNet.Forward(ctx, hiddenStates, opts)
+	} else {
+		hiddenStates = l.Attention.Forward(ctx, hiddenStates, positions, cache, opts, il)
+	}
+
+	// Output filtering on last layer
+	if outputs != nil {
+		hiddenStates = hiddenStates.Rows(ctx, outputs)
+		residual = residual.Rows(ctx, outputs)
+	}
+
+	// Residual connection
+	hiddenStates = hiddenStates.Add(ctx, residual)
+
+	// FFN with pre-norm and residual
+	ffnResidual := hiddenStates
+	hiddenStates = l.PostAttnNorm.Forward(ctx, hiddenStates, opts.eps)
+	hiddenStates = l.FFN.Forward(ctx, hiddenStates)
+	return hiddenStates.Add(ctx, ffnResidual)
+}
+
+type Model struct {
+	model.Base
+	model.BytePairEncoding
+
+	TokenEmbedding *nn.Embedding `gguf:"token_embd"`
+	OutputNorm     *nn.RMSNorm   `gguf:"output_norm"`
+	Output         *nn.Linear    `gguf:"output,alt:token_embd"`
+
+	Layers []Layer `gguf:"blk"`
+
+	*Options
+}
+
+func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
+	positions := ctx.Input().FromInts(batch.Positions, len(batch.Positions))
+	hiddenStates := m.TokenEmbedding.Forward(ctx, batch.Inputs)
+
+	for i, layer := range m.Layers {
+		if m.Cache != nil {
+			m.Cache.SetLayer(i)
+		}
+
+		var outputs ml.Tensor
+		if i == len(m.Layers)-1 {
+			outputs = batch.Outputs
+		}
+
+		hiddenStates = layer.Forward(ctx, hiddenStates, positions, outputs, m.Cache, m.Options, i)
+	}
+
+	hiddenStates = m.OutputNorm.Forward(ctx, hiddenStates, m.eps)
+	return m.Output.Forward(ctx, hiddenStates), nil
+}
+
+func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
+	ropeOpts := []func(*rope.Options){rope.WithTypeNeoX()}
+	return fast.RoPE(ctx, key, shift, m.headDim(), m.ropeBase, 1./m.ropeScale, ropeOpts...), nil
+}
+
+var _ model.Model = (*Model)(nil)
+
+func New(c fs.Config) (model.Model, error) {
+	blockCount := int(c.Uint("block_count"))
+
+	// Read per-layer head_count_kv to determine which layers are DeltaNet vs attention
+	kvHeadsRaw := c.Ints("attention.head_count_kv")
+	kvHeadsPerLayer := make([]int, blockCount)
+	if len(kvHeadsRaw) >= blockCount {
+		for i := 0; i < blockCount; i++ {
+			kvHeadsPerLayer[i] = int(kvHeadsRaw[i])
+		}
+	} else if len(kvHeadsRaw) == 1 {
+		// scalar: all layers have same kv heads
+		for i := range kvHeadsPerLayer {
+			kvHeadsPerLayer[i] = int(kvHeadsRaw[0])
+		}
+	}
+
+	layers := make([]Layer, blockCount)
+	for i := range layers {
+		if kvHeadsPerLayer[i] == 0 {
+			// DeltaNet layer
+			layers[i].DeltaNet = &DeltaNet{}
+		} else {
+			// Attention layer
+			layers[i].Attention = &Attention{}
+		}
+		layers[i].FFN = &FFN{}
+	}
+
+	opts := &Options{
+		hiddenSize:      int(c.Uint("embedding_length")),
+		numHeads:        int(c.Uint("attention.head_count")),
+		numKVHeads:      int(c.Uint("attention.head_count_kv")),
+		keyLength:       int(c.Uint("attention.key_length")),
+		valueLength:     int(c.Uint("attention.value_length")),
+		ssmDInner:       int(c.Uint("ssm.inner_size")),
+		ssmDState:       int(c.Uint("ssm.state_size")),
+		ssmNGroup:       int(c.Uint("ssm.group_count")),
+		ssmDtRank:       int(c.Uint("ssm.dt_rank")),
+		eps:             c.Float("attention.layer_norm_rms_epsilon"),
+		ropeBase:        c.Float("rope.freq_base"),
+		ropeScale:       c.Float("rope.scaling.factor", 1),
+		kvHeadsPerLayer: kvHeadsPerLayer,
+	}
+
+	m := Model{
+		BytePairEncoding: model.NewBytePairEncoding(
+			&model.Vocabulary{
+				Values: c.Strings("tokenizer.ggml.tokens"),
+				Types:  c.Ints("tokenizer.ggml.token_type"),
+				Merges: c.Strings("tokenizer.ggml.merges"),
+				AddBOS: c.Bool("tokenizer.ggml.add_bos_token", true),
+				BOS:    []int32{int32(c.Uint("tokenizer.ggml.bos_token_id"))},
+				AddEOS: c.Bool("tokenizer.ggml.add_eos_token", false),
+				EOS: append(
+					[]int32{int32(c.Uint("tokenizer.ggml.eos_token_id"))},
+					c.Ints("tokenizer.ggml.eos_token_ids")...,
+				),
+			},
+			`(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+`,
+		),
+		Layers:  layers,
+		Options: opts,
+	}
+
+	// For now, use CausalCache for the attention layers
+	// TODO: implement HybridCache with recurrent state for DeltaNet layers
+	m.Cache = kvcache.NewCausalCache(m.Shift)
+
+	return &m, nil
+}
+
+func init() {
+	model.Register("qwen35", New)
+}

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -113,9 +113,20 @@ func (l *Layer) forwardAttention(ctx ml.Context, hiddenStates, positions ml.Tens
 // Currently passes through output projection to maintain valid shapes for
 // memory measurement by the iterative Load loop.
 func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
-	intermediate := l.WQkvGate.Forward(ctx, hiddenStates)
-	normalized := l.SSMNorm.Forward(ctx, intermediate, opts.eps)
-	return l.SSMOut.Forward(ctx, normalized)
+	// Stub: use available projections to produce correct output dimensions
+	if l.WQkvGate != nil && l.SSMNorm != nil && l.SSMOut != nil {
+		intermediate := l.WQkvGate.Forward(ctx, hiddenStates)
+		normalized := l.SSMNorm.Forward(ctx, intermediate, opts.eps)
+		return l.SSMOut.Forward(ctx, normalized)
+	}
+	// Fallback: if tensors not mapped, use WQkv path or return input
+	if l.WQkv != nil && l.SSMOut != nil {
+		projected := l.WQkv.Forward(ctx, hiddenStates)
+		// SSMOut expects d_inner input; WQkv output is conv_dim which may differ
+		// Just return the input as identity for memory measurement
+		_ = projected
+	}
+	return hiddenStates
 }
 
 func (l *Layer) Forward(ctx ml.Context, hiddenStates, positions, outputs ml.Tensor, cache kvcache.Cache, opts *Options, il int) ml.Tensor {

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -277,15 +277,13 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 			m.Cache.SetLayer(i)
 		}
 
-		// INSTRUMENT: check tensor mapping for first DeltaNet layer
-		if i == 0 {
-			slog.Info("INSTRUMENT: layer 0 tensors",
+		// INSTRUMENT: check tensor mapping for first 5 layers
+		if i < 5 {
+			slog.Info("INSTRUMENT: layer tensors",
+				"layer", i,
 				"AttentionNorm", layer.AttentionNorm != nil,
 				"WQkv", layer.WQkv != nil,
 				"WQkvGate", layer.WQkvGate != nil,
-				"SSMAlpha", layer.SSMAlpha != nil,
-				"SSMBeta", layer.SSMBeta != nil,
-				"SSMNorm", layer.SSMNorm != nil,
 				"SSMOut", layer.SSMOut != nil,
 				"Query", layer.Query != nil,
 				"FFNGate", layer.FFNGate != nil,

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -129,7 +129,7 @@ func (dn *DeltaNet) Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Option
 	// Decay computation: softplus(alpha + dt_bias) * ssm_a
 	alphaBiased := alpha.Add(ctx, dn.SSMDt)
 	alphaSoftplus := alphaBiased.Softplus(ctx)
-	gate := alphaSoftplus.Mul(ctx, dn.SSMA)
+	_ = alphaSoftplus.Mul(ctx, dn.SSMA) // gate - used in DeltaNet state update (TODO)
 
 	// TODO: convolution state management and SSM conv
 	// For now, apply SSM conv directly

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -188,10 +188,27 @@ func (l *Layer) forwardDeltaNet(ctx ml.Context, hiddenStates ml.Tensor, opts *Op
 	output := v // (headVDim, numVHeads, nTokens)
 
 	// 10. Gated normalization: rms_norm(output) * silu(z)
+	// SSMNorm weight has shape (ssm_d_state) which may differ from headVDim
+	// Reshape output to match norm weight, apply norm, then reshape back
 	output2d := output.Reshape(ctx, headVDim, numVHeads*nTokens)
 	z2d := z.Reshape(ctx, headVDim, numVHeads*nTokens)
 
-	normalized := l.SSMNorm.Forward(ctx, output2d, opts.eps)
+	var normalized ml.Tensor
+	if l.SSMNorm != nil {
+		// SSMNorm weight dim may be ssm_d_state, not headVDim
+		// Group the output to match: (ssm_d_state, headVDim/ssm_d_state * numVHeads * nTokens)
+		normDim := opts.ssmDState
+		if headVDim%normDim == 0 {
+			groupSize := headVDim / normDim
+			output3d := output2d.Reshape(ctx, normDim, groupSize*numVHeads*nTokens)
+			norm3d := l.SSMNorm.Forward(ctx, output3d, opts.eps)
+			normalized = norm3d.Reshape(ctx, headVDim, numVHeads*nTokens)
+		} else {
+			normalized = output2d
+		}
+	} else {
+		normalized = output2d
+	}
 	gatedSilu := z2d.SILU(ctx)
 	attnOut := normalized.Mul(ctx, gatedSilu)
 


### PR DESCRIPTION
## Summary

- Port upstream Ollama's `qwen3next` DeltaNet implementation to fix qwen3.5:27b using 4 GPUs when it should fit on 2
- Add `kvcache/recurrent.go` with persistent conv + recurrent state management
- Add missing tensor ops (`SetRows`, `SigmoidOut`, `CumSum`) and fix `Slice` to match upstream's 4D handling
- Increase `maxGraphNodes` multiplier from 8x to 32x for hybrid recurrent models
- Add MRoPE position handling (`buildPositions`, `Shift` expansion)

**Before:** 4 GPUs, 40.6 GiB estimated, garbage output from stubbed DeltaNet
**After:** 2 GPUs, 21.5 GiB actual, passes LLM judge

Fixes #72

## Test plan

- [x] Build verification (simple judge) — passed
- [x] Runtime tests (simple judge) — passed
- [x] TC-MODELS-010 qwen3.5:27b (dual judge) — passed, GPU_COUNT_OK (2 GPUs)
- [ ] Full test pipeline (all models, dual judge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)