### PR TITLE
Add Docker image auto-publish on release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,91 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build (e.g. v2.03)"
+        required: true
+        type: string
+
+env:
+  DOCKERHUB_REPO: dogkeeper886/ollama37
+
+jobs:
+  publish:
+    name: Build & Push Docker Image
+    runs-on: self-hosted
+    environment: cicd-1
+
+    steps:
+      - name: Determine version tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          # Strip leading 'v' for the version number (v2.03 -> 2.03)
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building version: ${VERSION} (tag: ${TAG})"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
+      - name: Build Docker image
+        run: |
+          cd docker
+          OLLAMA_VERSION=${{ steps.version.outputs.version }} \
+            make build-runtime-no-cache
+
+      - name: Tag for Docker Hub
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Tag with version and latest
+          docker tag ollama37:latest ${DOCKERHUB_REPO}:${TAG}
+          docker tag ollama37:latest ${DOCKERHUB_REPO}:latest
+
+          echo "Tagged:"
+          echo "  ${DOCKERHUB_REPO}:${TAG}"
+          echo "  ${DOCKERHUB_REPO}:latest"
+
+      - name: Push to Docker Hub
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          docker push ${DOCKERHUB_REPO}:${TAG}
+          docker push ${DOCKERHUB_REPO}:latest
+
+          echo "Pushed:"
+          echo "  ${DOCKERHUB_REPO}:${TAG}"
+          echo "  ${DOCKERHUB_REPO}:latest"
+
+      - name: Generate summary
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Docker Image Published
+
+          **Version:** ${TAG}
+
+          \`\`\`bash
+          docker pull ${DOCKERHUB_REPO}:${TAG}
+          docker pull ${DOCKERHUB_REPO}:latest
+          \`\`\`
+          EOF
+
+      - name: Clean up local tags
+        if: always()
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          docker rmi ${DOCKERHUB_REPO}:${TAG} 2>/dev/null || true
+          docker rmi ${DOCKERHUB_REPO}:latest 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add `release-docker.yml` workflow that builds and pushes Docker image to Docker Hub
- Triggers automatically on GitHub release publish
- Also supports manual `workflow_dispatch` with a tag input
- Uses existing `docker/Makefile` build process and runner-local Docker Hub credentials

Closes #94

## Test plan

- [ ] Trigger manually via workflow_dispatch with `v2.03` tag
- [ ] Verify image appears on Docker Hub as `dogkeeper886/ollama37:v2.03` and `:latest`
- [ ] Verify next release auto-triggers the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)