### PR TITLE
Add nvprof profiling infrastructure for Part B audit (#105)

### DIFF
--- a/.github/workflows/test-profile.yml
+++ b/.github/workflows/test-profile.yml
@@ -41,8 +41,18 @@ jobs:
       - name: Stop existing ollama37 container
         run: |
           docker stop ollama37 || true
-          # Give the GPU a moment to release VRAM
-          sleep 3
+          # Defensive: clear any stale profile container from a prior failed run.
+          docker rm -f ollama37-profile 2>/dev/null || true
+
+          # Poll until VRAM drops below 1 GiB or 30s timeout.
+          for i in $(seq 1 30); do
+            USED=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | head -1 | tr -d ' ')
+            if [ "$USED" -lt 1024 ]; then
+              echo "VRAM released after ${i}s: ${USED} MiB"
+              break
+            fi
+            sleep 1
+          done
           nvidia-smi --query-gpu=memory.used --format=csv,noheader
 
       - name: Run inference under nvprof
@@ -95,6 +105,18 @@ jobs:
             -d "{\"model\":\"$MODEL\",\"prompt\":\"$PROMPT\",\"stream\":false,\"options\":{\"num_predict\":$NUM_PREDICT}}" \
             | tee /tmp/profile/response.json
 
+          # Validate the inference actually produced a response — otherwise the
+          # profile artifact is mostly cudaMalloc noise and not useful.
+          if ! jq -e '.response' /tmp/profile/response.json >/dev/null 2>&1; then
+            echo "::error::inference call did not return a 'response' field"
+            echo "--- response.json ---"
+            cat /tmp/profile/response.json
+            echo "--- container logs ---"
+            docker logs ollama37-profile 2>&1 | tail -50
+            docker stop --time 30 ollama37-profile || true
+            exit 1
+          fi
+
           echo ""
           echo "=== Stopping profile container so nvprof flushes ==="
           # SIGTERM via docker stop; nvprof writes its summary on graceful exit.
@@ -124,6 +146,24 @@ jobs:
           else
             cd docker && docker compose up -d || true
           fi
+
+      - name: Verify production ollama37 recovered
+        if: always()
+        run: |
+          # Wait up to 60s for the production API to come back. Fail loudly if
+          # it doesn't — leaving the runner without a working ollama37 would
+          # break every subsequent test.
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
+              echo "production ollama37 healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::production ollama37 did not recover within 60s — runner needs manual intervention"
+          docker ps -a --filter "name=^ollama37$"
+          docker logs ollama37 2>&1 | tail -50 || true
+          exit 1
 
       - name: Upload profile artifacts
         if: always()

--- a/.github/workflows/test-profile.yml
+++ b/.github/workflows/test-profile.yml
@@ -1,0 +1,134 @@
+name: GPU Profile (nvprof)
+
+# One-off workflow for capturing nvprof kernel timings on the K80 runner.
+# Used for the Part B kernel-fusion audit (issue #105). Not part of the
+# regular test pipeline — invoked manually via workflow_dispatch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model to profile (must already be pulled in ollama-data volume)"
+        required: false
+        default: "gemma3:4b"
+        type: string
+      prompt:
+        description: "Inference prompt"
+        required: false
+        default: "Explain quantum entanglement in three sentences."
+        type: string
+      num_predict:
+        description: "Number of tokens to generate"
+        required: false
+        default: "50"
+        type: string
+
+jobs:
+  profile:
+    name: nvprof inference run
+    runs-on: self-hosted
+    environment: cicd-1
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build profile image
+        run: |
+          docker build -t ollama37-profile:latest -f docker/profile/Dockerfile .
+
+      - name: Stop existing ollama37 container
+        run: |
+          docker stop ollama37 || true
+          # Give the GPU a moment to release VRAM
+          sleep 3
+          nvidia-smi --query-gpu=memory.used --format=csv,noheader
+
+      - name: Run inference under nvprof
+        id: profile
+        run: |
+          mkdir -p /tmp/profile
+          chmod 777 /tmp/profile
+
+          # Start the profile container in the background.
+          # nvprof wraps ollama serve; we issue an inference request, then SIGTERM the
+          # container so nvprof flushes the summary on shutdown.
+          docker run -d --rm \
+            --name ollama37-profile \
+            --runtime nvidia \
+            --gpus all \
+            -e NVIDIA_VISIBLE_DEVICES=all \
+            -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+            -e OLLAMA_HOST=0.0.0.0:11434 \
+            -e OLLAMA_DEBUG=1 \
+            -v ollama-data:/root/.ollama \
+            -v /tmp/profile:/profile \
+            -p 11434:11434 \
+            ollama37-profile:latest \
+            /usr/local/cuda-11.4/bin/nvprof \
+              --csv \
+              --log-file /profile/profile.csv \
+              --print-gpu-summary \
+              /usr/bin/ollama serve
+
+          # Wait for the API to come up (max 60s).
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:11434/ >/dev/null 2>&1; then
+              echo "ollama API ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+          # Confirm API is responding.
+          curl -sf http://localhost:11434/ || (echo "API never came up"; docker logs ollama37-profile; exit 1)
+
+          # Issue a single inference request. Capture response.
+          MODEL="${{ inputs.model }}"
+          PROMPT="${{ inputs.prompt }}"
+          NUM_PREDICT="${{ inputs.num_predict }}"
+
+          echo "=== Inference request: model=$MODEL, num_predict=$NUM_PREDICT ==="
+
+          curl -s http://localhost:11434/api/generate \
+            -d "{\"model\":\"$MODEL\",\"prompt\":\"$PROMPT\",\"stream\":false,\"options\":{\"num_predict\":$NUM_PREDICT}}" \
+            | tee /tmp/profile/response.json
+
+          echo ""
+          echo "=== Stopping profile container so nvprof flushes ==="
+          # SIGTERM via docker stop; nvprof writes its summary on graceful exit.
+          docker stop --time 30 ollama37-profile || true
+
+          # Container is gone (--rm), wait briefly for filesystem flush.
+          sleep 5
+
+          echo "=== Profile artifacts ==="
+          ls -la /tmp/profile/
+
+          if [ -f /tmp/profile/profile.csv ]; then
+            echo ""
+            echo "=== nvprof CSV (first 80 lines) ==="
+            head -80 /tmp/profile/profile.csv
+          else
+            echo "WARNING: no profile.csv produced"
+          fi
+
+      - name: Restart ollama37 container
+        if: always()
+        run: |
+          # Use the docker-compose file to restore the standard runtime container.
+          # If compose isn't available, fall back to docker run.
+          if docker ps -a --filter "name=^ollama37$" --format '{{.Names}}' | grep -q ollama37; then
+            docker start ollama37 || true
+          else
+            cd docker && docker compose up -d || true
+          fi
+
+      - name: Upload profile artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-profile-${{ github.run_id }}
+          path: /tmp/profile/
+          retention-days: 30

--- a/docker/profile/Dockerfile
+++ b/docker/profile/Dockerfile
@@ -1,0 +1,23 @@
+# Ollama37 Profile Image
+# Adds nvprof (CUDA 11.4 profiler) to the runtime image for K80 kernel profiling.
+# Used by .github/workflows/test-profile.yml — not for production.
+#
+# Size delta: ~200 MB on top of ollama37:latest (nvprof + CUPTI + deps).
+
+FROM ollama37-builder AS nvprof_source
+
+FROM ollama37:latest
+
+# Copy nvprof and CUPTI from the builder image (which already has cuda-toolkit-11-4)
+# Avoids the need to install dnf + the NVIDIA repo into the minimal runtime image.
+COPY --from=nvprof_source /usr/local/cuda-11.4/bin/nvprof /usr/local/cuda-11.4/bin/nvprof
+COPY --from=nvprof_source /usr/local/cuda-11.4/extras/CUPTI /usr/local/cuda-11.4/extras/CUPTI
+COPY --from=nvprof_source /usr/local/cuda-11.4/lib64/libcupti.so* /usr/lib64/
+COPY --from=nvprof_source /usr/local/cuda-11.4/lib64/libcupti_static.a /usr/lib64/
+
+ENV PATH="$PATH:/usr/local/cuda-11.4/bin"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda-11.4/extras/CUPTI/lib64"
+
+# Override entrypoint so the workflow can wrap ollama with nvprof
+ENTRYPOINT []
+CMD ["sh", "-c", "echo 'Use docker run with explicit nvprof invocation. See .github/workflows/test-profile.yml.'"]


### PR DESCRIPTION
## Summary

- Adds `docker/profile/Dockerfile` — extends `ollama37:latest` with `nvprof` and CUPTI copied from `ollama37-builder`. ~200 MB delta. Not for production use.
- Adds `.github/workflows/test-profile.yml` — `workflow_dispatch`-only workflow that briefly stops the production `ollama37` container on the runner, runs a single inference under `nvprof`, captures the CSV summary as an artifact, and restarts the normal container.

This is the infrastructure half of Part B (#105). It does not yet write the audit doc — that requires running the workflow, collecting the artifact, and analyzing.

## Why this needs to merge before triggering

GitHub's `workflow_dispatch` trigger requires the workflow file to exist on the default branch, even when triggering against a non-default branch. So the infrastructure has to land first.

## Disruption to the runner

The workflow stops the production `ollama37` container for ~5-10 min while profiling runs, then restarts it (`if: always()` cleanup). Any inference traffic during that window will fail. Worth coordinating if anything else is using the runner.

## Test plan

- [ ] PR merged to main
- [ ] Workflow triggered manually via `gh workflow run test-profile.yml`
- [ ] Run completes, artifact uploaded
- [ ] Profile CSV is non-empty and contains kernel timings
- [ ] Production `ollama37` container is back up and responding after the run

## Follow-up

After this merges and the workflow has been run, a separate PR will add `docs/research/k80-fusion-audit.md` analyzing the captured kernel timings.

Refs #105