### PR TITLE
Fix profile image: ship full CUDA toolkit so nvprof finds injection libs

### DIFF
--- a/docker/profile/Dockerfile
+++ b/docker/profile/Dockerfile
@@ -2,21 +2,23 @@
 # Adds nvprof (CUDA 11.4 profiler) to the runtime image for K80 kernel profiling.
 # Used by .github/workflows/test-profile.yml — not for production.
 #
-# Size delta: ~200 MB on top of ollama37:latest (nvprof + CUPTI + deps).
+# Size delta: ~3-4 GB on top of ollama37:latest (full CUDA 11.4 toolkit).
+# Targeted copies of just nvprof + CUPTI proved insufficient — nvprof loads
+# additional injection libraries at runtime (libaccinj64, libcuinj64, etc.)
+# whose paths are baked into nvprof's binary. Easier to ship the whole toolkit
+# than to reverse-engineer the dependency closure.
 
 FROM ollama37-builder AS nvprof_source
 
 FROM ollama37:latest
 
-# Copy nvprof and CUPTI from the builder image (which already has cuda-toolkit-11-4)
-# Avoids the need to install dnf + the NVIDIA repo into the minimal runtime image.
-COPY --from=nvprof_source /usr/local/cuda-11.4/bin/nvprof /usr/local/cuda-11.4/bin/nvprof
-COPY --from=nvprof_source /usr/local/cuda-11.4/extras/CUPTI /usr/local/cuda-11.4/extras/CUPTI
-COPY --from=nvprof_source /usr/local/cuda-11.4/lib64/libcupti.so* /usr/lib64/
-COPY --from=nvprof_source /usr/local/cuda-11.4/lib64/libcupti_static.a /usr/lib64/
+# Copy the entire CUDA 11.4 toolkit from the builder image. Includes nvprof,
+# all profiling injection libraries (libaccinj64, libcuinj64), CUPTI, and
+# the rest. Image size is irrelevant for a one-off profiling tool.
+COPY --from=nvprof_source /usr/local/cuda-11.4 /usr/local/cuda-11.4
 
 ENV PATH="$PATH:/usr/local/cuda-11.4/bin"
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda-11.4/extras/CUPTI/lib64"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda-11.4/lib64:/usr/local/cuda-11.4/extras/CUPTI/lib64"
 
 # Override entrypoint so the workflow can wrap ollama with nvprof
 ENTRYPOINT []


### PR DESCRIPTION
## Summary

First Part B workflow run ([24947459931](https://github.com/dogkeeper886/ollama37/actions/runs/24947459931)) failed because nvprof couldn't find its runtime dependencies. The container started, exited within seconds, and the artifact contained only:

\`\`\`
Warning: unable to locate profiling library, GPU profiling skipped
Error: unable to locate OpenACC profiling library libaccinj64.so.11.4.
\`\`\`

My initial Dockerfile cherry-picked just \`nvprof\` + CUPTI shared libs, but nvprof loads additional injection libraries at runtime (\`libaccinj64\`, \`libcuinj64\`, etc.) via paths baked into its binary. Easier to ship the whole CUDA 11.4 toolkit than reverse-engineer the closure.

## Trade-off

Image size goes from ~1 GB → ~4 GB. Acceptable for a one-off profiling image that's never deployed to production.

## Test plan

- [ ] Merge
- [ ] Re-trigger \`test-profile.yml\` on main
- [ ] Confirm nvprof produces a non-empty CSV with kernel timings (not just an error)
- [ ] Cleanup steps still work (production ollama37 recovers, artifacts uploaded)

Refs #105