### PR TITLE
Add OLLAMA_FLASH_ATTENTION_K80 experimental opt-in flag

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -188,6 +188,12 @@ func LogLevel() slog.Level {
 var (
 	// FlashAttention enables the experimental flash attention feature.
 	FlashAttention = BoolWithDefault("OLLAMA_FLASH_ATTENTION")
+	// FlashAttentionK80 is an ollama37-specific experimental flag that, when
+	// set together with OLLAMA_FLASH_ATTENTION, allows compute 3.7 (K80) GPUs
+	// to pass the FA-supported check. The fattn-vec kernel is compiled but
+	// has no Kepler arch guard upstream — so it may work, but is not validated.
+	// Output correctness must be confirmed empirically before relying on this.
+	FlashAttentionK80 = Bool("OLLAMA_FLASH_ATTENTION_K80")
 	// KvCacheType is the quantization type for the K/V cache.
 	KvCacheType = String("OLLAMA_KV_CACHE_TYPE")
 	// NoHistory disables readline history.
@@ -280,6 +286,7 @@ func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
 		"OLLAMA_DEBUG":             {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
 		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
+		"OLLAMA_FLASH_ATTENTION_K80": {"OLLAMA_FLASH_ATTENTION_K80", FlashAttentionK80(), "Experimental: also enable flash attention on K80 (compute 3.7) when OLLAMA_FLASH_ATTENTION=1. Unvalidated — confirm output before relying on this."},
 		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_HOST":              {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},

--- a/ml/device.go
+++ b/ml/device.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/logutil"
 )
@@ -428,10 +429,16 @@ func (a DeviceInfo) IsBetter(b DeviceInfo) bool {
 
 // For each GPU, check if it does NOT support flash attention
 func FlashAttentionSupported(l []DeviceInfo) bool {
+	// ollama37: opt-in experimental override allowing compute 3.7 (K80) to
+	// pass the FA-supported check. The fattn-vec kernel has no arch guard
+	// upstream, so it may work on Kepler — but it's not validated.
+	allowK80 := envconfig.FlashAttentionK80()
+
 	for _, gpu := range l {
 		supportsFA := gpu.Library == "cpu" ||
 			gpu.Name == "Metal" || gpu.Library == "Metal" ||
 			(gpu.Library == "CUDA" && gpu.ComputeMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
+			(gpu.Library == "CUDA" && allowK80 && gpu.ComputeMajor == 3 && gpu.ComputeMinor == 7) ||
 			gpu.Library == "ROCm"
 
 		if !supportsFA {


### PR DESCRIPTION
## Summary

Phase 1 of #108. Adds an opt-in env var \`OLLAMA_FLASH_ATTENTION_K80\` that relaxes the FA-supported gate in \`ml.FlashAttentionSupported\` to also accept compute 3.7 (K80) GPUs. Off by default; existing K80 behavior unchanged.

## What this enables

When set together with \`OLLAMA_FLASH_ATTENTION=1\`:

\`\`\`bash
OLLAMA_FLASH_ATTENTION=1 OLLAMA_FLASH_ATTENTION_K80=1 ollama serve
\`\`\`

K80 GPUs pass the FA-supported check, so the runtime tries to dispatch flash attention. The \`fattn-vec\` kernel (\`fattn-vec.cuh\`) has no architecture guard — only the unconditional \`FLASH_ATTN_AVAILABLE\` define in \`common.cuh:275\` — so it *may* produce correct output on Kepler. The sm_70 gate in \`ml/device.go:434\` is Go-side conservatism that we suspect reflects "upstream never tested vec on Kepler" rather than known incompatibility.

## What this does NOT do

- Does not validate that fattn-vec actually works on K80. **Phase 2** (separate session) runs it on the K80 runner and decides.
- Does not change default behavior. K80 users without the env var still get FA disabled.
- Does not bypass the per-model \`f.SupportsFlashAttention()\` check at \`llm/server.go:247\`. Models that report no FA support will still skip FA.

## Phase 2 validation plan (after merge)

On the K80 runner:

1. Trigger a build with the patch on main.
2. Restart \`ollama37\` container with both env vars set.
3. Issue a deterministic inference (e.g., gemma3:4b, fixed prompt, temperature 0).
4. Compare output against a baseline run with FA disabled.
5. Check container logs for which FA kernel got dispatched (\`fattn-vec\` vs error).
6. If output matches and no errors: try \`OLLAMA_KV_CACHE_TYPE=q8_0\` to verify V-cache quant becomes available.
7. Update issue with findings — either open a productize-it follow-up (proper gate, env-var docs, test cases) or document the failure mode and revert.

## Test plan (this PR)

- [x] Diff is minimal: 2 files, +14 lines
- [x] Default behavior unchanged (allowK80 is false unless env var set)
- [x] Env var follows project conventions (Bool() helper, AsMap entry, comment)
- [x] No new package boundaries crossed except \`ml → envconfig\` (envconfig is a leaf, no cycle)
- [ ] CI build passes (delegated to runner)

## Risk

Low for this PR (off by default). Medium-high for Phase 2 if someone enables both env vars without first validating output — flash attention with broken kernels could produce silently-wrong output. Mitigation: the env var name and docs clearly mark it as experimental and unvalidated.

Refs #108