### PR TITLE
Update audit docs: Phase 2 fattn-vec validation results

### DIFF
--- a/docs/research/k80-fusion-audit.md
+++ b/docs/research/k80-fusion-audit.md
@@ -8,9 +8,11 @@
 
 GGML's CUDA backend already does substantially more graph-level fusion than I expected. Six fusion patterns are in place (RMS_NORM+MUL, RMS_NORM+MUL+ADD, n-way ADD chains, SCALE+TANH+SCALE softcap, two TopK-MoE variants), and the SwiGLU activation+gate is a single fused op via `GGML_OP_GLU`.
 
-**For K80 specifically, the only fusion gap that matters is attention compute** (Q·Kᵀ → scale → softmax → ·V), which goes unfused on K80 because flash attention is gated to compute ≥7 — and that's tracked separately in **#108**. The other gaps I found (MUL_MAT+bias ADD, MUL_MAT+residual ADD, ROPE+KV-cache CPY) are real-but-small: each saves one global-memory round-trip per layer, but the projection matmuls themselves are far heavier than the boundary cost.
+**For K80 specifically, the biggest fusion gap was attention compute** (Q·Kᵀ → scale → softmax → ·V), which went unfused because flash attention was gated to compute ≥7. **That gap is now empirically closed**: PR [#112](https://github.com/dogkeeper886/ollama37/pull/112) added the experimental `OLLAMA_FLASH_ATTENTION_K80` env var, and validation runs (2026-04-26) confirm `fattn-vec` produces correct output on K80 + unlocks Q8_0 KV-cache quantization for **~47% KV memory reduction** (gemma3:4b: 254→135 MiB at 4k context). See §4.1.
 
-**Recommendation: don't open new fusion-implementation issues from this audit.** Focus implementation effort on #108 (fattn-vec on K80) which would close the single biggest gap. If #108 fails, revisit this audit's "smaller gaps" section.
+The other gaps I found (MUL_MAT+bias ADD, MUL_MAT+residual ADD, ROPE+KV-cache CPY) are real-but-small: each saves one global-memory round-trip per layer, but the projection matmuls themselves are far heavier than the boundary cost.
+
+**Recommendation: focus on productizing the FA enablement** (replace the env-var hack with a proper default-on Go-side gate; add K80 test cases). The other fusion gaps remain not-worth-pursuing for now — the FA enablement closed the dominant one and we have empirical confirmation it works.
 
 ## 1. Method
 
@@ -71,17 +73,27 @@ Per layer:
 
 ## 4. Unfused Boundaries (Ranked by K80 Impact)
 
-### 4.1 ⚠️ Attention compute on non-FA path
+### 4.1 ⚠️ Attention compute on non-FA path → ✅ **RESOLVED**
 
-**The single biggest gap on K80.** Without flash attention, attention is decomposed into 4 separate ops per layer per token:
+**Originally the single biggest gap on K80.** Without flash attention, attention is decomposed into 4 separate ops per layer per token:
 - `MUL_MAT(Q · Kᵀ)` → produces `[seq_len, seq_len]` attention scores tensor (large for long context)
 - `SCALE(1/√d_k)` → reads/writes scores
 - `SOFT_MAX` → reads/writes scores
 - `MUL_MAT(scores · V)` → reads scores
 
-For a 32B model with 60 layers and a 4k-context, the unfused attention path adds roughly 60 × 3 = 180 extra global-memory passes over the intermediate scores tensor per forward pass. This is exactly what flash attention was designed to eliminate.
+For a 32B model with 60 layers and a 4k-context, the unfused attention path adds roughly 60 × 3 = 180 extra global-memory passes over the intermediate scores tensor per forward pass.
 
-**Status**: gap is real and matters. **Already tracked in [#108](https://github.com/dogkeeper886/ollama37/issues/108)** (investigate `fattn-vec` viability on K80). Don't double-track here.
+**Update 2026-04-26**: this is empirically resolvable. PR [#112](https://github.com/dogkeeper886/ollama37/pull/112) added an opt-in env var `OLLAMA_FLASH_ATTENTION_K80=1` that allows K80 to pass the FA-supported gate. Empirical validation via workflow runs [24960034243](https://github.com/dogkeeper886/ollama37/actions/runs/24960034243) and [24960260331](https://github.com/dogkeeper886/ollama37/actions/runs/24960260331) (gemma3:4b on K80):
+
+| Configuration | KV cache | FA active | Output |
+|---|---|---|---|
+| FA off, KV f16 (baseline) | 254 MiB | ❌ | "Paris" |
+| FA on, KV f16 | 254 MiB | ✅ | "Paris" (bit-exact match with baseline) |
+| FA on, KV q8_0 | **135 MiB** | ✅ | "Paris" |
+
+`fattn-vec` on K80 (sm_37) produces output indistinguishable from the standard non-FA path — no silent correctness bug. KV cache quantization to Q8_0 (which requires FA) reduces cache footprint by **47%** with no observable correctness regression. This was exactly the prize predicted in `k80-quant-audit.md` §3.
+
+**Status**: empirically validated, productize follow-up tracked separately. `fattn-vec` is the K80 path. The remaining work is replacing the experimental env-var hack with a proper default-on Go-side gate, and adding test cases. This audit doc no longer needs to flag attention as the K80 fusion gap — it isn't, post-#112.
 
 ### 4.2 MUL_MAT + bias ADD
 

--- a/docs/research/k80-quant-audit.md
+++ b/docs/research/k80-quant-audit.md
@@ -96,21 +96,21 @@ So the *vec* variant of flash attention may already be compiled into our K80 bui
 
 These are what should become their own GitHub issues; this audit doesn't implement them.
 
-### Recommendation 1 — Allow asymmetric KV quant (K-only) on K80
+### Recommendation 1 — Allow asymmetric KV quant (K-only) on K80 → ⏬ **DEPRIORITIZED**
 
-**Action**: Modify `llama/llama.go:kvCacheTypeFromStr` and `NewContextParams` to accept independent K and V cache types. Plumb a new env var (e.g., `OLLAMA_K_CACHE_TYPE`) or extend the existing `OLLAMA_KV_CACHE_TYPE` with a `k:q8_0,v:f16` syntax. Default for K80 stays F16/F16 to avoid surprising existing users.
+Originally tracked as [#107](https://github.com/dogkeeper886/ollama37/issues/107). With Recommendation 2 empirically validated below, **symmetric Q8_0 KV quant works on K80** via the FA path and delivers ~47% reduction (vs the ~25% K-only would have given). #107 remains a fallback if FA enablement is ever rolled back, but is no longer the highest-leverage path.
 
-**Expected benefit**: K-cache is roughly half the KV memory. Q8_0 K-cache cuts that half by 2× → ~25% total KV memory reduction at minimal quality cost. Real win on long context.
+### Recommendation 2 — Investigate `fattn-vec` viability on K80 → ✅ **EMPIRICALLY VALIDATED**
 
-**Effort**: ~1 day. Mostly Go plumbing + a context-params API change. No new kernel work.
+Originally tracked as [#108](https://github.com/dogkeeper886/ollama37/issues/108).
 
-**Risk**: Low — llama.cpp explicitly supports asymmetric K/V quant; we're just exposing it.
+**Outcome (2026-04-26)**: `fattn-vec` works on K80. PR [#112](https://github.com/dogkeeper886/ollama37/pull/112) added `OLLAMA_FLASH_ATTENTION_K80=1` opt-in; runs [24960034243](https://github.com/dogkeeper886/ollama37/actions/runs/24960034243) and [24960260331](https://github.com/dogkeeper886/ollama37/actions/runs/24960260331) on the K80 runner show:
 
-### Recommendation 2 — Investigate `fattn-vec` viability on K80
+- FA-on output bit-exact identical to FA-off baseline (gemma3:4b, "What is the capital of France?")
+- KV cache with `OLLAMA_KV_CACHE_TYPE=q8_0` allocates 135 MiB vs 254 MiB f16 baseline — **47% reduction**
+- No CUBLAS errors, no kernel crashes, production container restored cleanly
 
-**Action**: Compile a build with `FlashAttentionSupported` patched to accept compute 3.7, run a single inference test on the K80 runner with FA enabled, validate output against the F16 baseline. If correct, we unlock full FA + Q8_0 V-cache.
-
-**Expected benefit**: If it works, 50% KV memory reduction + flash-attention-style memory-traffic savings on attention. This is the bigger prize.
+The "bigger prize" prediction held. Productize follow-up tracked separately (replace env-var hack with default-on Go-side gate; add K80 test cases to the test framework).
 
 **Effort**: ~1 day to test. Possibly significant follow-up if the kernel needs sm_37-specific patches (e.g., shfl behavior, shared-mem layout).
 


### PR DESCRIPTION
## Summary

Updates the two K80 audit docs with the empirical results from PR #112's Phase 2 validation runs.

## Findings being recorded

Phase 2 of #108 (workflow runs [24960034243](https://github.com/dogkeeper886/ollama37/actions/runs/24960034243) and [24960260331](https://github.com/dogkeeper886/ollama37/actions/runs/24960260331)) confirmed:

1. **`fattn-vec` works on K80** — FA-on output bit-exact matches FA-off baseline for gemma3:4b
2. **Q8_0 KV cache with FA enabled** — 254 MiB → 135 MiB = **47% reduction**
3. **No errors, no crashes, production restored cleanly**

## Doc changes

### `k80-fusion-audit.md`
- §4.1 marked **RESOLVED** with the empirical table
- TL;DR updated to reflect the closed gap and shift productize as the next move

### `k80-quant-audit.md` §4 Recommendations
- Rec 1 (K-only KV quant via #107): **DEPRIORITIZED** — symmetric Q8_0 works and gives 2× the memory win
- Rec 2 (fattn-vec investigation via #108): **EMPIRICALLY VALIDATED** with the run links

## Test plan

- [x] Doc updates accurately reflect run outputs
- [x] Cross-references to PR #112 and run IDs preserved for future verification
- [x] Issue #107 explicitly noted as deprioritized (not closed — fallback if FA enablement is ever rolled back)

Refs #108