### PR TITLE
Fix benchmark baseline: force OLLAMA_FLASH_ATTENTION=0

### DIFF
--- a/.github/workflows/test-fa-k80.yml
+++ b/.github/workflows/test-fa-k80.yml
@@ -119,6 +119,12 @@ jobs:
               # Post-#116: K80 is in FlashAttentionSupported by default.
               # Just OLLAMA_FLASH_ATTENTION=1 is enough; no separate K80 flag.
               fa_args="-e OLLAMA_FLASH_ATTENTION=1"
+            else
+              # Force FA off explicitly. Models like Gemma3 default
+              # f.FlashAttention()=true, so leaving the env var unset would
+              # let FA enable via model default + #117's K80 gate. We need
+              # an explicit "0" to actually measure a no-FA baseline.
+              fa_args="-e OLLAMA_FLASH_ATTENTION=0"
             fi
 
             local kv_args=""


### PR DESCRIPTION
## Summary

Post-#117, the workflow's \"baseline\" run (FA-off comparison) was no longer measuring what it claimed to measure. With the K80 FA gate now default-on and Gemma3 setting \`f.FlashAttention()=true\` as the model default, leaving \`OLLAMA_FLASH_ATTENTION\` unset causes BoolWithDefault to return true → FA enables in baseline.

First benchmark attempt ([run 24971742599](https://github.com/dogkeeper886/ollama37/actions/runs/24971742599)) confirmed this: baseline and FA runs produced bit-identical 256-token responses with the same KV cache size and same eval duration. Both had FA on.

## Fix

Two extra lines in \`test-fa-k80.yml\`: when \`enable_fa=0\` is requested for the baseline run, explicitly set \`OLLAMA_FLASH_ATTENTION=0\` so BoolWithDefault returns false regardless of model default.

## After merge

I'll re-trigger the benchmark to get the proper A vs B vs C table:
- A: FA off (now actually off), KV f16
- B: FA on, KV f16
- C: FA on, KV q8_0

The B and C numbers I already have from prior runs (16.24 t/s + 254 MiB, and 15.81 t/s + 135 MiB respectively).

## Test plan

- [x] Diff is minimal (2 lines + comment)
- [x] No behavior change for FA-on path
- [ ] CI: trigger workflow with \`baseline_compare=true\` after merge → confirm baseline run now logs \"flash attention enabled but not supported by gpu\" or absence of \"enabling flash attention\"