### PR TITLE
Phase 3: SupportsFlashAttentionInNewEngine allowlist (closes #124)

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -875,10 +875,11 @@ func (f GGML) SupportsKVCacheType(cacheType string) bool {
 	return slices.Contains([]string{"q8_0", "q4_0"}, cacheType)
 }
 
-// SupportsFlashAttention checks if the model supports flash attention via the
-// llama.cpp engine path. Returns false for architectures that route through the
-// new Ollama engine — those are handled separately by
-// SupportsFlashAttentionInNewEngine.
+// SupportsFlashAttention checks the legacy FA gate: passes if the architecture
+// is not in the per-arch deny list (gemma2, qwen35) and head counts match.
+// Most architectures — including new-engine ones like gemma3, gptoss, qwen3vl —
+// pass this gate. Architectures in the deny list can opt into FA via
+// SupportsFlashAttentionInNewEngine after empirical validation.
 func (f GGML) SupportsFlashAttention() bool {
 	_, isEmbedding := f.KV()[fmt.Sprintf("%s.pooling_type", f.KV().Architecture())]
 	if isEmbedding {

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -875,7 +875,10 @@ func (f GGML) SupportsKVCacheType(cacheType string) bool {
 	return slices.Contains([]string{"q8_0", "q4_0"}, cacheType)
 }
 
-// SupportsFlashAttention checks if the model supports flash attention
+// SupportsFlashAttention checks if the model supports flash attention via the
+// llama.cpp engine path. Returns false for architectures that route through the
+// new Ollama engine — those are handled separately by
+// SupportsFlashAttentionInNewEngine.
 func (f GGML) SupportsFlashAttention() bool {
 	_, isEmbedding := f.KV()[fmt.Sprintf("%s.pooling_type", f.KV().Architecture())]
 	if isEmbedding {
@@ -885,7 +888,7 @@ func (f GGML) SupportsFlashAttention() bool {
 	arch := f.KV().Architecture()
 
 	// qwen35 is hybrid (DeltaNet + attention) and needs the OllamaEngine;
-	// flash attention is handled by the FlashAttention() allowlist instead
+	// flash attention is handled via SupportsFlashAttentionInNewEngine instead.
 	if slices.Contains([]string{"gemma2", "qwen35"}, arch) {
 		return false
 	}
@@ -894,6 +897,36 @@ func (f GGML) SupportsFlashAttention() bool {
 	headCountK := f.KV().EmbeddingHeadCountK()
 	headCountV := f.KV().EmbeddingHeadCountV()
 	return headCountK != 0 && headCountV != 0 && headCountK == headCountV
+}
+
+// SupportsFlashAttentionInNewEngine returns true for architectures whose
+// new-engine implementation has been empirically validated to produce correct
+// output on K80 (compute 3.7) with flash attention enabled.
+//
+// This is checked alongside SupportsFlashAttention as an OR — i.e., a model is
+// FA-eligible if either gate allows it. The two gates serve different paths:
+//
+//   - SupportsFlashAttention is the legacy llama.cpp engine path (head-count
+//     check + per-arch deny list).
+//   - SupportsFlashAttentionInNewEngine is the new engine's allowlist of
+//     architectures verified via the test-fa-k80.yml workflow per
+//     docs/research/k80-fa-model-coverage.md.
+//
+// Adding new architectures requires empirical validation per the methodology
+// in issue #123 (FA-off baseline vs FA-on output, on the K80 runner).
+func (f GGML) SupportsFlashAttentionInNewEngine() bool {
+	// ollama37 (issue #124, part of #121).
+	return slices.Contains([]string{
+		"gemma3",  // validated #108 (gemma3:4b on PR #117 validation runs)
+		"gptoss",  // validated #123 Phase 2 (gpt-oss:20b run 24978297254)
+		"qwen3vl", // validated #123 Phase 2 (qwen3-vl:8b run 24978521066)
+		// "qwen3vlmoe" — same Go package as qwen3vl; presumed safe but
+		// untested. Add when a qwen3-vl:30b benchmark validates it.
+		// "qwen35" — currently in SupportsFlashAttention deny list. Adding
+		// here would bypass the deny but requires empirical validation of
+		// hybrid SSM+attention output correctness with FA enabled. See
+		// docs/traces/qwen35-flash-attention-gate.md.
+	}, f.KV().Architecture())
 }
 
 // FlashAttention checks if the model should enable flash attention

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -295,9 +295,11 @@ func estimateGPULayers(gpus []ml.DeviceInfo, f *ggml.GGML, projectors []string, 
 		slog.Warn("model missing blk.0 layer size")
 	}
 
+	// Mirrors the gate in llm/server.go: FA is supported if either the legacy
+	// path (head-count check) or the new-engine allowlist (ollama37 #124) accepts.
 	useFlashAttention := envconfig.FlashAttention(f.FlashAttention()) &&
 		ml.FlashAttentionSupported(gpus) &&
-		f.SupportsFlashAttention()
+		(f.SupportsFlashAttention() || f.SupportsFlashAttentionInNewEngine())
 
 	var kvct string
 	if useFlashAttention {

--- a/llm/server.go
+++ b/llm/server.go
@@ -244,7 +244,11 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		fa = false
 	}
 
-	if fa && !f.SupportsFlashAttention() {
+	// FA-eligible if either gate accepts: legacy llama.cpp head-count check OR
+	// new-engine empirical allowlist (ollama37 #124). Models like qwen35 that
+	// the deny list explicitly rejects can still enable FA via the new engine
+	// once empirically validated and added to SupportsFlashAttentionInNewEngine.
+	if fa && !f.SupportsFlashAttention() && !f.SupportsFlashAttentionInNewEngine() {
 		slog.Warn("flash attention enabled but not supported by model")
 		fa = false
 	}


### PR DESCRIPTION
## Summary

Phase 3 of #121. Adds the missing bypass mechanism for the legacy llama.cpp deny list at \`fs/ggml/ggml.go:889\` (which contains \`gemma2\` and \`qwen35\`), so new-engine architectures can opt into FA via an explicit allowlist after empirical validation.

## What changes

3 files, +43 / -4:

| File | Change |
|---|---|
| \`fs/ggml/ggml.go\` | New method \`SupportsFlashAttentionInNewEngine()\` with seeded allowlist \`{gemma3, gptoss, qwen3vl}\`. Each entry has a citation to the empirical run that validated it. Doc-comment on \`SupportsFlashAttention\` updated to reference the split. |
| \`llm/server.go:247\` | Gate now checks both methods. Model's FA stays denied only if BOTH the legacy head-count gate rejects AND the new-engine allowlist excludes it. |
| \`llm/memory.go:300\` | Same OR check for memory estimation consistency. |

## Behavior change scope

**None for current models.** The seeded allowlist contains architectures (gemma3, gptoss, qwen3vl) that already pass the legacy head-count check, so the bypass is redundant for them today. The mechanism is in place for future use:

- Adding \`qwen35\` after empirical validation of hybrid SSM+attention output correctness (separate follow-up)
- Adding \`gemma2\` if it ever enters our test lineup
- Adding \`qwen3vlmoe\` after qwen3-vl:30b validation

This is intentional — the alternative (eagerly adding qwen35 to the allowlist now) would enable FA for it without empirical proof, risking silent correctness regressions. Phase 2 explicitly deferred qwen35 validation.

## Why no unit test

\`SupportsFlashAttention\` itself has no unit test in this codebase. The methods are simple list lookups; their correctness is verifiable by reading the code. The meaningful regression test is the \`test-fa-k80.yml\` workflow which exercises the runtime path.

## Test plan

- [x] Diff is minimal (3 files, +43 / -4)
- [x] Behavior unchanged for currently-tested models (allowlisted arches already passed the legacy gate)
- [x] Allowlist seed entries each cite their validating run
- [x] Doc comments cross-reference docs/research/k80-fa-model-coverage.md
- [ ] Re-run test-fa-k80.yml on gpt-oss:20b after merge — confirm \`enabling flash attention\` log still fires + no \`not supported by model\` warning

## What this enables for future PRs

- Add qwen35 to the allowlist with one line + a benchmark run (no need to touch the deny list or call sites)
- Add new architectures with the same one-line + validation pattern

Closes #124 (and the #121 portal — Phase 3 was the last open phase)