### PR TITLE
Fix issues caught in self-review of evolve commit 0d60bfe9

### DIFF
--- a/.claude/skills/lint-ci/SKILL.md
+++ b/.claude/skills/lint-ci/SKILL.md
@@ -18,13 +18,17 @@ Catch errors in `.github/workflows/*.yml` before pushing. The dev environment ca
 
 The pattern that bit us most often: bare object keys that collide with jq reserved words (`label`, `break`, `try`, `catch`, `reduce`, `foreach`, `as`, `def`, `if`, `then`, `else`, `end`, `and`, `or`, `not`, `import`, `include`, `module`, `null`, `true`, `false`).
 
-For each `jq -n '{...}'` template in a workflow, dry-run it with placeholder values:
+For each `jq -n '{...}'` template in a workflow, dry-run it with placeholder values. `jq -n` (`--null-input`) takes no stdin — just the args and the object literal:
 
 ```bash
-echo '{"foo": $foo, "bar": $bar}' | jq -n --arg foo test --arg bar test '<paste object literal here>'
+# Replace the workflow's --arg / --argjson values with placeholders, then run.
+# Example: if the workflow has
+#   jq -n --arg model "$MODEL" --argjson num_predict "$NUM_PREDICT" '{ model: $model, num_predict: $num_predict }'
+# dry-run as:
+jq -n --arg model test --argjson num_predict 1 '{ "model": $model, "num_predict": $num_predict }'
 ```
 
-If jq prints the object: ✓. If it errors with `unexpected <word>`: that key is a reserved word — quote it (`"foo": $foo` instead of `foo: $foo`).
+If jq prints the object: ✓. If it errors with `unexpected <word>`: that key is a reserved word — quote it (`"model": $model` instead of `model: $model`).
 
 ### `shellcheck` for `run:` blocks (install via package manager or docker)
 
@@ -32,18 +36,13 @@ Catches: redirect-order bugs (`cmd 2>&1 > file`), unquoted variables, missing er
 
 ```bash
 # If installed locally:
-shellcheck path/to/extracted-script.sh
+shellcheck script.sh
 
 # Or via docker, no install:
-docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable path/to/extracted-script.sh
+docker run --rm -v "$PWD:/mnt" --workdir /mnt koalaman/shellcheck:stable script.sh
 ```
 
-To run on a workflow's `run:` blocks, extract them first:
-
-```bash
-yq '.jobs[].steps[].run // empty' .github/workflows/test-fa-k80.yml > /tmp/extracted.sh
-shellcheck /tmp/extracted.sh
-```
+To shellcheck a workflow's `run:` blocks, the simplest path is to copy each block into a `.sh` file and run shellcheck on it. Workflow YAML doesn't have a clean automated extractor in standard tooling — `yq` (Go) or `yq` (Python) versions both work but neither is guaranteed installed. If you want automation, install `yq` from `mikefarah/yq` and run `yq '.jobs[].steps[].run // ""' workflow.yml > extracted.sh` first.
 
 ### `actionlint` for workflow structure (install or docker)
 

--- a/docs/traces/engine-selection.md
+++ b/docs/traces/engine-selection.md
@@ -55,7 +55,7 @@ NewLlamaServer(...)
   │   │
   │   └── log "engine selected" debug line
   │
-  └── if textProcessor == nil:                         # not in either condition above
+  └── if textProcessor == nil:                         # not eligible OR new-engine attempt failed
       └── llama.LoadModelFromFile(...)                 # legacy llama.cpp engine
 ```
 
@@ -69,7 +69,7 @@ NewLlamaServer(...)
 | qwen35 | yes | yes | new |
 | qwen3vl / qwen3vlmoe | yes | yes | new |
 | gptoss / gpt-oss | yes | yes | new |
-| **qwen2** | yes (handles `qwen2`, `qwen3moe`-not-actually) | **NO** | **llama.cpp** |
+| **qwen2** | yes | **NO** | **llama.cpp** |
 | **llama** | yes | **NO** | **llama.cpp** |
 | **deepseek2** | yes | **NO** | **llama.cpp** |
 
@@ -79,8 +79,8 @@ The audit error in Phase 1 was assuming the first column implied the third. It d
 
 In container logs, look for either of these log paths:
 
-- `level=DEBUG source=server.go:160 msg="engine selected" engine=ollama arch=...`
-- `level=DEBUG source=server.go:160 msg="engine selected" engine=llama_compat arch=... reason=...`
+- `level=DEBUG source=server.go:163 msg="engine selected" engine=ollama arch=...`
+- `level=DEBUG source=server.go:161 msg="engine selected" engine=llama_compat arch=... reason=...`
 
 Or distinguish by the load-request log:
 


### PR DESCRIPTION
## Summary

Six issues caught in self-review of commit \`0d60bfe9\` (the direct-pushed evolve actions). All small, all fixable without behavior change.

## Issues fixed

### \`docs/traces/engine-selection.md\`

1. **Wrong line numbers** for the \"engine selected\" log: cited \`source=server.go:160\` (a comment), but actual log lines are \`:161\` (llama_compat) and \`:163\` (ollama). Updated.
2. **Misleading comment** on the \`textProcessor == nil\` branch — it's true if either the if-block didn't execute OR if \`NewTextProcessor\` errored. Comment said \"not in either condition above\" which only captures the first case. Updated to \"not eligible OR new-engine attempt failed\".
3. **Confusing parenthetical** in the per-arch table: \`qwen2 | yes (handles \\\`qwen2\\\`, \\\`qwen3moe\\\`-not-actually) | NO | llama.cpp\` — the parenthetical was an unfinished thought (qwen3moe is registered in the qwen3 package, not qwen2). Removed.

### \`.claude/skills/lint-ci/SKILL.md\`

4. **Broken jq -n example** — used \`echo '{...}' | jq -n --arg foo test ...\` but \`jq -n\` is \`--null-input\` and ignores stdin entirely. Replaced with a realistic example showing how to take a workflow's actual jq invocation and substitute placeholder args.
5. **Docker shellcheck path mismatch** — \`docker run -v \"\$PWD:/mnt\" ... script.sh\` mounts at \`/mnt\` but the relative path doesn't resolve there. Added \`--workdir /mnt\`.
6. **Undocumented \`yq\` dependency** — example used \`yq '.jobs[].steps[].run // empty' ...\` which assumes \`yq\` is installed (it isn't standard). Replaced with a note that automated extraction needs \`mikefarah/yq\` and the simplest path is to copy blocks manually.

## Process correction

Commit \`0d60bfe9\` was direct-pushed to main under the home CLAUDE.md \"docs-only direct push\" rule. Per user feedback, **substantive content** (new skill files, new trace docs, multi-section CLAUDE.md additions) **should go via branch + PR even if technically docs-only**. The direct-push exception is for typos and small fixes. Saved as project memory \`feedback_branch_pr_for_substantive.md\`.

This PR is following that practice.

## Test plan

- [x] All 6 issues addressed
- [x] No behavior change — only doc accuracy fixes
- [x] Diff is minimal: 2 files, +14 / -15

## Impact

Anyone reading the affected artifacts gets accurate info: correct line numbers in the trace, working examples in the lint-ci skill.