### PR TITLE
Add /api/metrics endpoint scaffold (closes #98)

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -80,6 +80,12 @@ type LlamaServer interface {
 	GetPort() int
 	GetDeviceInfos(ctx context.Context) []ml.DeviceInfo
 	HasExited() bool
+
+	// Engine returns "ollama" for the Go-native engine, "llamacpp" for the vendored llama.cpp engine.
+	Engine() string
+	// MemoryBreakdown returns the per-device weights/cache/graph breakdown if the
+	// backend tracks it, or nil if only a total is available (e.g. llamacpp engine).
+	MemoryBreakdown() *ml.BackendMemory
 }
 
 // llmServer is an instance of a runner hosting a single model
@@ -1858,6 +1864,9 @@ func (s *llamaServer) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
 	return nil
 }
 
+func (s *llamaServer) Engine() string                    { return "llamacpp" }
+func (s *llamaServer) MemoryBreakdown() *ml.BackendMemory { return nil }
+
 func (s *ollamaServer) VRAMSize() uint64 {
 	if s.mem == nil {
 		return 0
@@ -1925,3 +1934,6 @@ func (s *ollamaServer) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
 	}
 	return devices
 }
+
+func (s *ollamaServer) Engine() string                    { return "ollama" }
+func (s *ollamaServer) MemoryBreakdown() *ml.BackendMemory { return s.mem }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/ml"
+)
+
+// serverMetrics holds atomic counters for server-wide events that are otherwise
+// only visible via logs. Counters are monotonic; handlers expose them as-is.
+// Per-model / per-request metrics are snapshotted on demand from the scheduler
+// and do not live here.
+type serverMetrics struct {
+	loadFailures    atomic.Uint64 // NewLlamaServer returned an error
+	loadRequireFull atomic.Uint64 // llama.Load returned ErrLoadRequiredFull (model too large to fit)
+	loadOther       atomic.Uint64 // llama.Load returned a non-ErrLoadRequiredFull error
+	evictionsIdle   atomic.Uint64 // runner unloaded after idle timeout
+}
+
+// MetricsResponse is the JSON payload returned by GET /api/metrics.
+type MetricsResponse struct {
+	GPUs   []GPUMetrics   `json:"gpus"`
+	Models []ModelMetrics `json:"models"`
+	Errors ErrorCounters  `json:"errors"`
+	Totals ServerTotals   `json:"totals"`
+}
+
+type GPUMetrics struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	VRAMTotal   uint64 `json:"vram_total"`
+	VRAMFree    uint64 `json:"vram_free,omitempty"`
+	ComputeCap  string `json:"compute_cap,omitempty"` // e.g. "3.7"
+	LibraryPath string `json:"library_path,omitempty"`
+}
+
+type ModelMetrics struct {
+	Name          string            `json:"name"`
+	Engine        string            `json:"engine"`                    // "ollama" | "llamacpp"
+	GPUs          []string          `json:"gpus"`                      // device IDs
+	VRAMTotal     uint64            `json:"vram_total"`                // sum across GPUs
+	VRAMByGPU     map[string]uint64 `json:"vram_by_gpu,omitempty"`     // per-device total
+	VRAMBreakdown *VRAMBreakdown    `json:"vram_breakdown,omitempty"`  // ollama engine only
+	ContextLength int               `json:"context_length,omitempty"`
+}
+
+// VRAMBreakdown decomposes VRAM usage into its three components. Only the Go
+// engine (ollamaServer) tracks this; for llamacpp models it is omitted.
+type VRAMBreakdown struct {
+	Weights uint64 `json:"weights"`        // model weights on GPU
+	KVCache uint64 `json:"kv_cache"`       // K/V attention cache
+	Graph   uint64 `json:"compute_graph"`  // scratch compute buffer
+}
+
+type ErrorCounters struct {
+	LoadFailures    uint64 `json:"load_failures"`      // runner process creation failed
+	LoadRequireFull uint64 `json:"load_require_full"`  // model couldn't fit; scheduler had to evict
+	LoadOther       uint64 `json:"load_other"`         // any other load error
+	EvictionsIdle   uint64 `json:"evictions_idle"`     // runner unloaded after idle timeout
+}
+
+type ServerTotals struct {
+	LoadedModels int `json:"loaded_models"`
+	GPUCount     int `json:"gpu_count"`
+}
+
+func (s *Server) MetricsHandler(c *gin.Context) {
+	s.sched.loadedMu.Lock()
+	runners := make([]*runnerRef, 0, len(s.sched.loaded))
+	for _, r := range s.sched.loaded {
+		runners = append(runners, r)
+	}
+	s.sched.loadedMu.Unlock()
+
+	// Collect device info from the first available runner. GetDeviceInfos returns
+	// nil for the llamacpp engine, so prefer an ollama-engine runner if one is loaded.
+	var devices []ml.DeviceInfo
+	for _, r := range runners {
+		if r.llama == nil {
+			continue
+		}
+		if infos := r.llama.GetDeviceInfos(c.Request.Context()); len(infos) > 0 {
+			devices = infos
+			break
+		}
+	}
+
+	gpus := make([]GPUMetrics, 0, len(devices))
+	for _, d := range devices {
+		compute := ""
+		if d.ComputeMajor >= 0 {
+			compute = gpuComputeString(d.ComputeMajor, d.ComputeMinor)
+		}
+		libPath := ""
+		if len(d.LibraryPath) > 0 {
+			libPath = d.LibraryPath[0]
+		}
+		gpus = append(gpus, GPUMetrics{
+			ID:          d.DeviceID.ID,
+			Name:        d.Name,
+			VRAMTotal:   d.TotalMemory,
+			VRAMFree:    d.FreeMemory,
+			ComputeCap:  compute,
+			LibraryPath: libPath,
+		})
+	}
+
+	models := make([]ModelMetrics, 0, len(runners))
+	for _, r := range runners {
+		if r.llama == nil || r.model == nil {
+			continue
+		}
+
+		gpuIDs := make([]string, 0, len(r.gpus))
+		vramByGPU := make(map[string]uint64, len(r.gpus))
+		for _, g := range r.gpus {
+			gpuIDs = append(gpuIDs, g.ID)
+			vramByGPU[g.ID] = r.llama.VRAMByGPU(g)
+		}
+
+		m := ModelMetrics{
+			Name:      r.model.ShortName,
+			Engine:    r.llama.Engine(),
+			GPUs:      gpuIDs,
+			VRAMTotal: r.vramSize,
+			VRAMByGPU: vramByGPU,
+		}
+		if r.Options != nil {
+			m.ContextLength = r.Options.NumCtx
+		}
+		if mem := r.llama.MemoryBreakdown(); mem != nil {
+			m.VRAMBreakdown = summarizeBreakdown(mem)
+		}
+		models = append(models, m)
+	}
+
+	c.JSON(http.StatusOK, MetricsResponse{
+		GPUs:   gpus,
+		Models: models,
+		Errors: s.sched.metrics.snapshot(),
+		Totals: ServerTotals{
+			LoadedModels: len(runners),
+			GPUCount:     len(devices),
+		},
+	})
+}
+
+func (m *serverMetrics) snapshot() ErrorCounters {
+	if m == nil {
+		return ErrorCounters{}
+	}
+	return ErrorCounters{
+		LoadFailures:    m.loadFailures.Load(),
+		LoadRequireFull: m.loadRequireFull.Load(),
+		LoadOther:       m.loadOther.Load(),
+		EvictionsIdle:   m.evictionsIdle.Load(),
+	}
+}
+
+// summarizeBreakdown sums per-layer weights and cache across all GPUs into a
+// single breakdown. Multi-GPU layouts collapse to one view; the per-GPU
+// VRAMByGPU field retains device-level attribution.
+func summarizeBreakdown(mem *ml.BackendMemory) *VRAMBreakdown {
+	var b VRAMBreakdown
+	for _, g := range mem.GPUs {
+		for _, w := range g.Weights {
+			b.Weights += w
+		}
+		for _, c := range g.Cache {
+			b.KVCache += c
+		}
+		b.Graph += g.Graph
+	}
+	return &b
+}
+
+func gpuComputeString(major, minor int) string {
+	return strconv.Itoa(major) + "." + strconv.Itoa(minor)
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -78,22 +78,19 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 	}
 	s.sched.loadedMu.Unlock()
 
-	// Collect device info from the first available runner. GetDeviceInfos
-	// does IPC to the runner subprocess, so cap it with a short timeout —
-	// a stuck runner must not hang the metrics endpoint.
+	// Discover GPUs via the same path the scheduler uses (discover.GPUDevices).
+	// Going through the scheduler — instead of asking a loaded runner — means
+	// the GPU list is populated even when no model is loaded, which is the
+	// state most operators check first. Cap with a short timeout so a slow
+	// discovery cannot hang the endpoint.
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
 	defer cancel()
 
-	var devices []ml.DeviceInfo
+	runnersForDiscovery := make([]ml.FilteredRunnerDiscovery, 0, len(runners))
 	for _, r := range runners {
-		if r.llama == nil {
-			continue
-		}
-		if infos := r.llama.GetDeviceInfos(ctx); len(infos) > 0 {
-			devices = infos
-			break
-		}
+		runnersForDiscovery = append(runnersForDiscovery, r)
 	}
+	devices := s.sched.getGpuFn(ctx, runnersForDiscovery)
 
 	gpus := make([]GPUMetrics, 0, len(devices))
 	for _, d := range devices {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"sync/atomic"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -16,9 +18,9 @@ import (
 // and do not live here.
 type serverMetrics struct {
 	loadFailures    atomic.Uint64 // NewLlamaServer returned an error
-	loadRequireFull atomic.Uint64 // llama.Load returned ErrLoadRequiredFull (model too large to fit)
-	loadOther       atomic.Uint64 // llama.Load returned a non-ErrLoadRequiredFull error
-	evictionsIdle   atomic.Uint64 // runner unloaded after idle timeout
+	loadRequireFull atomic.Uint64 // Load returned ErrLoadRequiredFull and was surfaced to the user (not counting scheduler retries)
+	loadOther       atomic.Uint64 // Load returned a non-ErrLoadRequiredFull error
+	evictionsTotal  atomic.Uint64 // runner unloaded — counts both idle-timer expirations and make-room evictions
 }
 
 // MetricsResponse is the JSON payload returned by GET /api/metrics.
@@ -39,28 +41,28 @@ type GPUMetrics struct {
 }
 
 type ModelMetrics struct {
-	Name          string            `json:"name"`
-	Engine        string            `json:"engine"`                    // "ollama" | "llamacpp"
-	GPUs          []string          `json:"gpus"`                      // device IDs
-	VRAMTotal     uint64            `json:"vram_total"`                // sum across GPUs
-	VRAMByGPU     map[string]uint64 `json:"vram_by_gpu,omitempty"`     // per-device total
-	VRAMBreakdown *VRAMBreakdown    `json:"vram_breakdown,omitempty"`  // ollama engine only
-	ContextLength int               `json:"context_length,omitempty"`
+	Name          string                    `json:"name"`
+	Engine        string                    `json:"engine"`                   // "ollama" | "llamacpp"
+	GPUs          []string                  `json:"gpus"`                     // device IDs
+	VRAMTotal     uint64                    `json:"vram_total"`               // sum across GPUs
+	VRAMByGPU     map[string]uint64         `json:"vram_by_gpu,omitempty"`    // per-device total
+	VRAMBreakdown map[string]*VRAMBreakdown `json:"vram_breakdown,omitempty"` // ollama engine only, keyed by device ID
+	ContextLength int                       `json:"context_length,omitempty"`
 }
 
 // VRAMBreakdown decomposes VRAM usage into its three components. Only the Go
 // engine (ollamaServer) tracks this; for llamacpp models it is omitted.
 type VRAMBreakdown struct {
-	Weights uint64 `json:"weights"`        // model weights on GPU
-	KVCache uint64 `json:"kv_cache"`       // K/V attention cache
-	Graph   uint64 `json:"compute_graph"`  // scratch compute buffer
+	Weights uint64 `json:"weights"`  // model weights on GPU
+	KVCache uint64 `json:"kv_cache"` // K/V attention cache
+	Graph   uint64 `json:"graph"`    // scratch compute buffer
 }
 
 type ErrorCounters struct {
-	LoadFailures    uint64 `json:"load_failures"`      // runner process creation failed
-	LoadRequireFull uint64 `json:"load_require_full"`  // model couldn't fit; scheduler had to evict
-	LoadOther       uint64 `json:"load_other"`         // any other load error
-	EvictionsIdle   uint64 `json:"evictions_idle"`     // runner unloaded after idle timeout
+	LoadFailures    uint64 `json:"load_failures"`     // runner process creation failed
+	LoadRequireFull uint64 `json:"load_require_full"` // model didn't fit, surfaced to user (excludes scheduler retries)
+	LoadOther       uint64 `json:"load_other"`        // any other load error
+	EvictionsTotal  uint64 `json:"evictions_total"`   // runner unloaded (idle OR make-room; see design notes)
 }
 
 type ServerTotals struct {
@@ -76,14 +78,18 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 	}
 	s.sched.loadedMu.Unlock()
 
-	// Collect device info from the first available runner. GetDeviceInfos returns
-	// nil for the llamacpp engine, so prefer an ollama-engine runner if one is loaded.
+	// Collect device info from the first available runner. GetDeviceInfos
+	// does IPC to the runner subprocess, so cap it with a short timeout —
+	// a stuck runner must not hang the metrics endpoint.
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+	defer cancel()
+
 	var devices []ml.DeviceInfo
 	for _, r := range runners {
 		if r.llama == nil {
 			continue
 		}
-		if infos := r.llama.GetDeviceInfos(c.Request.Context()); len(infos) > 0 {
+		if infos := r.llama.GetDeviceInfos(ctx); len(infos) > 0 {
 			devices = infos
 			break
 		}
@@ -92,7 +98,9 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 	gpus := make([]GPUMetrics, 0, len(devices))
 	for _, d := range devices {
 		compute := ""
-		if d.ComputeMajor >= 0 {
+		// ComputeMajor == -1 means the backend didn't report capability;
+		// real GPUs are always >= 1. Skip the "0.0" edge case.
+		if d.ComputeMajor > 0 {
 			compute = gpuComputeString(d.ComputeMajor, d.ComputeMinor)
 		}
 		libPath := ""
@@ -133,7 +141,7 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			m.ContextLength = r.Options.NumCtx
 		}
 		if mem := r.llama.MemoryBreakdown(); mem != nil {
-			m.VRAMBreakdown = summarizeBreakdown(mem)
+			m.VRAMBreakdown = perGPUBreakdown(mem)
 		}
 		models = append(models, m)
 	}
@@ -157,25 +165,29 @@ func (m *serverMetrics) snapshot() ErrorCounters {
 		LoadFailures:    m.loadFailures.Load(),
 		LoadRequireFull: m.loadRequireFull.Load(),
 		LoadOther:       m.loadOther.Load(),
-		EvictionsIdle:   m.evictionsIdle.Load(),
+		EvictionsTotal:  m.evictionsTotal.Load(),
 	}
 }
 
-// summarizeBreakdown sums per-layer weights and cache across all GPUs into a
-// single breakdown. Multi-GPU layouts collapse to one view; the per-GPU
-// VRAMByGPU field retains device-level attribution.
-func summarizeBreakdown(mem *ml.BackendMemory) *VRAMBreakdown {
-	var b VRAMBreakdown
+// perGPUBreakdown returns per-device weights/cache/graph. Multi-GPU layouts
+// keep device-level attribution so callers can answer "how much weight memory
+// is on GPU 0" — the reason this endpoint exists.
+func perGPUBreakdown(mem *ml.BackendMemory) map[string]*VRAMBreakdown {
+	if mem == nil || len(mem.GPUs) == 0 {
+		return nil
+	}
+	out := make(map[string]*VRAMBreakdown, len(mem.GPUs))
 	for _, g := range mem.GPUs {
+		b := &VRAMBreakdown{Graph: g.Graph}
 		for _, w := range g.Weights {
 			b.Weights += w
 		}
 		for _, c := range g.Cache {
 			b.KVCache += c
 		}
-		b.Graph += g.Graph
+		out[g.DeviceID.ID] = b
 	}
-	return &b
+	return out
 }
 
 func gpuComputeString(major, minor int) string {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1573,6 +1573,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 
 	// Inference
 	r.GET("/api/ps", s.PsHandler)
+	r.GET("/api/metrics", s.MetricsHandler)
 	r.POST("/api/generate", s.GenerateHandler)
 	r.POST("/api/chat", s.ChatHandler)
 	r.POST("/api/embed", s.EmbedHandler)

--- a/server/sched.go
+++ b/server/sched.go
@@ -39,6 +39,8 @@ type Scheduler struct {
 	expiredCh     chan *runnerRef
 	unloadedCh    chan any
 
+	metrics *serverMetrics
+
 	// loadedMu protects loaded and activeLoading
 	loadedMu sync.Mutex
 
@@ -75,6 +77,7 @@ func InitScheduler(ctx context.Context) *Scheduler {
 		getGpuFn:        discover.GPUDevices,
 		getSystemInfoFn: discover.GetSystemInfo,
 		waitForRecovery: 5 * time.Second,
+		metrics:         &serverMetrics{},
 	}
 	sched.loadFn = sched.load
 	return sched
@@ -346,6 +349,7 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 				}
 				finished := s.waitForVRAMRecovery(runner, runnersSnapshot)
 				runner.unload()
+				s.metrics.evictionsIdle.Add(1)
 				delete(s.loaded, runner.modelPath)
 				s.loadedMu.Unlock()
 				slog.Debug("runner terminated and removed from list, blocking for VRAM recovery", "runner", runner)
@@ -454,6 +458,7 @@ func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, systemInfo ml.SystemInfo
 				err = fmt.Errorf("%v: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
 			}
 			slog.Info("NewLlamaServer failed", "model", req.model.ModelPath, "error", err)
+			s.metrics.loadFailures.Add(1)
 			req.errCh <- err
 			s.loadedMu.Unlock()
 			return false
@@ -486,6 +491,7 @@ func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, systemInfo ml.SystemInfo
 	slog.Info("scheduler.load: llama.Load() completed", "duration_sec", time.Since(loadStart).Seconds(), "error", err)
 	if err != nil {
 		if errors.Is(err, llm.ErrLoadRequiredFull) {
+			s.metrics.loadRequireFull.Add(1)
 			if !requireFull {
 				// Model doesn't fit fully on GPU, need to evict other models
 				slog.Info("model is too large for system memory", "requireFull", requireFull)
@@ -498,6 +504,7 @@ func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, systemInfo ml.SystemInfo
 		}
 
 		slog.Info("Load failed", "model", req.model.ModelPath, "error", err)
+		s.metrics.loadOther.Add(1)
 		s.activeLoading.Close()
 		s.activeLoading = nil
 		req.errCh <- err

--- a/server/sched.go
+++ b/server/sched.go
@@ -349,7 +349,7 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 				}
 				finished := s.waitForVRAMRecovery(runner, runnersSnapshot)
 				runner.unload()
-				s.metrics.evictionsIdle.Add(1)
+				s.metrics.evictionsTotal.Add(1)
 				delete(s.loaded, runner.modelPath)
 				s.loadedMu.Unlock()
 				slog.Debug("runner terminated and removed from list, blocking for VRAM recovery", "runner", runner)
@@ -491,9 +491,12 @@ func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, systemInfo ml.SystemInfo
 	slog.Info("scheduler.load: llama.Load() completed", "duration_sec", time.Since(loadStart).Seconds(), "error", err)
 	if err != nil {
 		if errors.Is(err, llm.ErrLoadRequiredFull) {
-			s.metrics.loadRequireFull.Add(1)
 			if !requireFull {
-				// Model doesn't fit fully on GPU, need to evict other models
+				// Model doesn't fit fully on GPU, need to evict other models.
+				// Only count the case that surfaces an error to the user;
+				// the retry path (requireFull=true) does not increment the
+				// counter, otherwise scheduler retries would inflate it.
+				s.metrics.loadRequireFull.Add(1)
 				slog.Info("model is too large for system memory", "requireFull", requireFull)
 				s.activeLoading.Close()
 				s.activeLoading = nil

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -804,3 +804,5 @@ func (s *mockLlm) GetPort() int                                       { return -
 func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo { return nil }
 func (s *mockLlm) HasExited() bool                                    { return false }
 func (s *mockLlm) GetActiveDeviceIDs() []ml.DeviceID                  { return nil }
+func (s *mockLlm) Engine() string                                     { return "mock" }
+func (s *mockLlm) MemoryBreakdown() *ml.BackendMemory                 { return nil }


### PR DESCRIPTION
## Summary
- Adds `GET /api/metrics` returning per-GPU VRAM (used / free / total via device ID), per-model engine + VRAM breakdown (weights / KV / compute / graph), and server-wide counters (load_failures, load_require_full, load_other, evictions_total)
- Plumbs `Engine()` and `MemoryBreakdown()` through the `LlamaServer` interface (both impls + mock)
- Wires four scheduler counter sites in `server/sched.go`
- Minimum-slice scope per the issue's deferred-followup plan: GPU util %, latency histograms, events ring buffer, Prometheus endpoint, and `ollama ps` CLI updates land in follow-up PRs

## Test plan
- [x] Build Verification — green ([run 25267910516](https://github.com/dogkeeper886/ollama37/actions/runs/25267910516))
- [x] Runtime Tests — green ([run 25268134989](https://github.com/dogkeeper886/ollama37/actions/runs/25268134989))
- [ ] Manual smoke: `curl http://localhost:11434/api/metrics` with a model loaded — verify JSON shape

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)