### PR TITLE
Add TC-RUNTIME-004: /api/metrics schema and completeness (closes #130)

### DIFF
--- a/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
+++ b/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
@@ -72,16 +72,51 @@ steps:
     rejectPatterns:
       - "totals FAIL"
 
+  - name: gpus[] length matches totals.gpu_count (internal consistency)
+    command: |
+      curl -s http://localhost:11434/api/metrics \
+        | jq -e '(.gpus | length) == .totals.gpu_count' >/dev/null \
+        && echo "gpus length consistent OK" || echo "gpus length consistent FAIL"
+    expectPatterns:
+      - "gpus length consistent OK"
+    rejectPatterns:
+      - "gpus length consistent FAIL"
+
+  - name: gpu_count matches nvidia-smi count (catches dropped GPUs)
+    command: |
+      EXPECTED=$(docker exec ollama37 nvidia-smi -L | wc -l)
+      ACTUAL=$(curl -s http://localhost:11434/api/metrics | jq '.totals.gpu_count')
+      echo "expected=$EXPECTED actual=$ACTUAL"
+      [ "$EXPECTED" = "$ACTUAL" ] && echo "gpu_count match OK" || echo "gpu_count match FAIL"
+    expectPatterns:
+      - "gpu_count match OK"
+    rejectPatterns:
+      - "gpu_count match FAIL"
+
+  - name: Dump full response for inspection
+    command: curl -s http://localhost:11434/api/metrics | jq '.'
+
 criteria: |
   Verify GET /api/metrics returns HTTP 200 with well-formed JSON conforming to
-  the documented schema in server/metrics.go.
+  the documented schema in server/metrics.go, and that GPU enumeration is
+  complete (no dies missed).
 
   Expected response shape:
   - Top-level keys: gpus[], models[], errors{}, totals{}
-  - gpus[]: id (string), name (string), vram_total (number > 0); K80 runner exposes >= 1 GPU
+  - gpus[]: id (string), name (string), vram_total (number > 0)
   - errors{}: load_failures, load_require_full, load_other, evictions_total — all integers
-  - totals{}: gpu_count (>= 1 on K80), loaded_models (>= 0)
+  - totals{}: gpu_count, loaded_models — both numbers
+
+  Completeness checks:
+  - gpus[] length must equal totals.gpu_count (internal consistency)
+  - totals.gpu_count must equal `nvidia-smi -L` count inside the container
+    (catches the failure mode where the endpoint loses GPUs vs. what the
+    driver actually reports — e.g. only enumerating the first runner's view)
 
   models[] may be empty when no model is loaded. Per-model assertions
   (engine label, vram_breakdown, context_length) are deferred to a follow-up
   test that piggybacks on inference-suite setup, per the plan in issue #130.
+
+  Inspect the dumped response (final step) to spot subtler issues —
+  duplicate device IDs, suspicious vram_total values, missing compute_cap,
+  etc. — that the structural assertions cannot express.

--- a/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
+++ b/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
@@ -1,0 +1,87 @@
+id: TC-RUNTIME-004
+name: Metrics Endpoint Schema
+suite: runtime
+priority: 2
+timeout: 60000
+dependencies:
+  - TC-RUNTIME-001
+testlink_id: ""
+issue: "130"
+goal: "Verify GET /api/metrics returns HTTP 200 and well-formed JSON conforming to the documented schema"
+
+steps:
+  - name: Endpoint returns HTTP 200
+    command: |
+      CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:11434/api/metrics)
+      echo "HTTP_CODE:$CODE"
+    expectPatterns:
+      - "HTTP_CODE:200"
+    rejectPatterns:
+      - "HTTP_CODE:[45][0-9][0-9]"
+
+  - name: Top-level schema (gpus, models, errors, totals)
+    command: |
+      curl -s http://localhost:11434/api/metrics | jq -e '
+        (.gpus   | type) == "array"
+        and (.models | type) == "array"
+        and (.errors | type) == "object"
+        and (.totals | type) == "object"
+      ' >/dev/null && echo "schema OK" || echo "schema FAIL"
+    expectPatterns:
+      - "schema OK"
+    rejectPatterns:
+      - "schema FAIL"
+
+  - name: GPU shape (K80 runner exposes >=1 GPU with id, name, vram_total)
+    command: |
+      curl -s http://localhost:11434/api/metrics | jq -e '
+        (.gpus | length) >= 1
+        and (.gpus[0].id         | type) == "string"
+        and (.gpus[0].name       | type) == "string"
+        and (.gpus[0].vram_total | type) == "number"
+        and  .gpus[0].vram_total > 0
+      ' >/dev/null && echo "gpu shape OK" || echo "gpu shape FAIL"
+    expectPatterns:
+      - "gpu shape OK"
+    rejectPatterns:
+      - "gpu shape FAIL"
+
+  - name: Error counters present (load_failures, load_require_full, load_other, evictions_total)
+    command: |
+      curl -s http://localhost:11434/api/metrics | jq -e '
+        (.errors.load_failures     | type) == "number"
+        and (.errors.load_require_full | type) == "number"
+        and (.errors.load_other        | type) == "number"
+        and (.errors.evictions_total   | type) == "number"
+      ' >/dev/null && echo "error counters OK" || echo "error counters FAIL"
+    expectPatterns:
+      - "error counters OK"
+    rejectPatterns:
+      - "error counters FAIL"
+
+  - name: Totals shape (gpu_count >=1, loaded_models >=0)
+    command: |
+      curl -s http://localhost:11434/api/metrics | jq -e '
+        (.totals.gpu_count     | type) == "number"
+        and  .totals.gpu_count    >= 1
+        and (.totals.loaded_models | type) == "number"
+        and  .totals.loaded_models >= 0
+      ' >/dev/null && echo "totals OK" || echo "totals FAIL"
+    expectPatterns:
+      - "totals OK"
+    rejectPatterns:
+      - "totals FAIL"
+
+criteria: |
+  Verify GET /api/metrics returns HTTP 200 with well-formed JSON conforming to
+  the documented schema in server/metrics.go.
+
+  Expected response shape:
+  - Top-level keys: gpus[], models[], errors{}, totals{}
+  - gpus[]: id (string), name (string), vram_total (number > 0); K80 runner exposes >= 1 GPU
+  - errors{}: load_failures, load_require_full, load_other, evictions_total — all integers
+  - totals{}: gpu_count (>= 1 on K80), loaded_models (>= 0)
+
+  models[] may be empty when no model is loaded. Per-model assertions
+  (engine label, vram_breakdown, context_length) are deferred to a follow-up
+  test that piggybacks on inference-suite setup, per the plan in issue #130.


### PR DESCRIPTION
## Summary

Adds an automated runtime test case for the \`/api/metrics\` endpoint shipped in #129, closing the test-coverage gap noted in #130.

Eight steps in TC-RUNTIME-004:
1. HTTP 200 response
2. Top-level schema (\`gpus[]\`, \`models[]\`, \`errors{}\`, \`totals{}\`)
3. GPU shape (\`id\`, \`name\`, \`vram_total\`)
4. Error counters present (all four)
5. Totals shape
6. **Internal consistency**: \`gpus[]\` length == \`totals.gpu_count\`
7. **External truth**: \`totals.gpu_count\` == \`nvidia-smi -L\` count (catches the failure mode where the endpoint loses GPUs vs. the driver)
8. **Full response dump** so the LLM judge can spot subtler issues the structural assertions cannot express

Steps 6–8 were added after a first run revealed that lenient \`length >= 1\` assertions would have passed even if the endpoint returned 1 of 4 K80s — the exact bug class already caught once on the parent branch.

## Test plan

- [x] Build Verification on rebased+fix branch ([25270179892](https://github.com/dogkeeper886/ollama37/actions/runs/25270179892)) ✓
- [x] Runtime Tests on rebased+fix branch ([25270365173](https://github.com/dogkeeper886/ollama37/actions/runs/25270365173)) ✓ — all 4/4 cases pass, including the new TC-004 with all 8 steps green
- [x] Live response captured: \`expected=4 actual=4 gpu_count match OK\`, all 4 K80 dies surfaced with unique UUIDs

## Notes

- \`testlink_id\` field is empty — TestLink MCP tools were not available during creation. Backfill if/when convenient.
- Follow-up #131 tracks the \`name\` field returning \`CUDA0/1/2/3\` rather than \`Tesla K80\`. Acceptance criteria there will extend TC-RUNTIME-004 with a regex assertion.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)