### PR TITLE
KV rotation: always-on for compatible head dims (closes #102)

### DIFF
--- a/.github/workflows/test-kv-rotate.yml
+++ b/.github/workflows/test-kv-rotate.yml
@@ -1,12 +1,11 @@
-name: KV Rotation ON-Path Smoke
+name: KV Rotation Smoke
 
-# Smoke test for the KV rotation code path introduced in #102 / PR #133.
-# CI workflows run the container from docker-compose, where OLLAMA_KV_ROTATE
-# is unset, so the rotation code is compiled but never executed. This
-# workflow spins up the container with -e OLLAMA_KV_ROTATE=1 (matching the
-# pattern in test-fa-k80.yml), runs a deterministic inference against a
-# small ollamarunner-served model with a head_dim multiple of 64, and
-# verifies the output is coherent. Pairs with #135.
+# Smoke test for the KV rotation code path landed in #102 / PR #133.
+# Rotation is structurally always-on (no env gate) when head_dim is a
+# multiple of 64 and a cache is in use. This workflow exercises the full
+# K80 killer combo (FA on + q8_0 KV) against a model that triggers
+# rotation (gemma3:4b, head_dim=256), and asserts the output is coherent
+# and the container has no panics or CUDA errors. Pairs with #135.
 
 on:
   workflow_dispatch:
@@ -46,7 +45,7 @@ jobs:
             sleep 1
           done
 
-      - name: Run inference with OLLAMA_KV_ROTATE=1
+      - name: Run inference (FA on + q8_0 KV; rotation activates structurally)
         id: infer
         run: |
           set -e
@@ -55,7 +54,7 @@ jobs:
           OUT=/tmp/kv-rotate-test
           rm -rf "$OUT" && mkdir -p "$OUT"
 
-          echo "=== Starting container with OLLAMA_KV_ROTATE=1, FA=1, KV=q8_0 ==="
+          echo "=== Starting container with FA=1, KV=q8_0 (rotation auto-on for head_dim%64==0) ==="
           docker run -d --rm \
             --name ollama37-kvrotate-test \
             --runtime nvidia \
@@ -66,7 +65,6 @@ jobs:
             -e OLLAMA_DEBUG=1 \
             -e OLLAMA_FLASH_ATTENTION=1 \
             -e OLLAMA_KV_CACHE_TYPE=q8_0 \
-            -e OLLAMA_KV_ROTATE=1 \
             -v ollama-data:/root/.ollama \
             -p 11434:11434 \
             ollama37:latest
@@ -136,15 +134,7 @@ jobs:
             exit 1
           fi
 
-          echo "--- 4. logs should NOT contain the 'incompatible head_dim' warning ---"
-          # gemma3:4b has head_dim=256, multiple of 64 → rotation should activate
-          if grep -q 'KV rotation disabled for this model' "$OUT/container-logs.log"; then
-            echo "::error::Rotation disabled warning fired — gate failed unexpectedly"
-            grep 'KV rotation' "$OUT/container-logs.log"
-            exit 1
-          fi
-
-          echo "All assertions pass — KV rotation ON-path works on $(jq -r '.model' $OUT/response.json)"
+          echo "All assertions pass — rotation works on $(jq -r '.model' $OUT/response.json)"
 
       - name: Restore docker-compose container
         if: always()

--- a/docs/design/kv-rotation.md
+++ b/docs/design/kv-rotation.md
@@ -1,140 +1,110 @@
 # KV Cache Rotation — Design Notes
 
 **Issue:** [#102](https://github.com/dogkeeper886/ollama37/issues/102)
-**Status:** Phase 1 ollamarunner integration landed in `ml/nn/attention.go`. llamarunner cherry-pick of upstream commit `744c0c73` is the next deliverable, tracked separately.
+**Status:** Phase 1 ollamarunner integration landed always-on for compatible head dims. llamarunner cherry-pick of upstream commit `744c0c73` is the next deliverable, tracked separately in #134.
 
 ## Goal
 
-Apply a fixed orthogonal rotation (Sylvester Hadamard matrix, normalized by 1/√n) to Q/K/V activations before they enter the KV cache, so that existing quantized KV types (`q4_0`, `q8_0`) recover most of the fp16-vs-quantized quality gap.
+Apply a fixed orthogonal rotation (Sylvester Hadamard matrix, normalized by 1/√n) to Q/K/V activations before they enter the KV cache. This smooths per-coordinate distributions so that existing quantized KV types (`q4_0`, `q8_0`) recover most of the fp16-vs-quantized quality gap.
 
-Mirrors ggml-org/llama.cpp#21038 (commit `744c0c73`, merged 2026-04-01), which showed this alone closes the PPL gap on Qwen3.5-4B between `q4_0` KV and `fp16` to +0.22%.
+Mirrors ggml-org/llama.cpp#21038 (commit `744c0c73`, merged 2026-04-01), which showed the rotation alone closes the PPL gap on Qwen3.5-4B between `q4_0` KV and `fp16` to +0.22 %.
 
 ## What's landed
 
-- `envconfig.KVRotate` — `OLLAMA_KV_ROTATE=1` opt-in flag (default off).
-- `ml/nn/hadamard.go` — pure-Go normalized Hadamard matrix generator + `IsHadamardCompatible(headDim)` gate, package-level cached `hadamard64` slice, `blockRotate` helper, and one-shot incompatible-head warning (`noteIncompatibleHeadDim`).
-- `ml/nn/hadamard_test.go` — orthogonality, normalization, symmetry, power-of-2 validation.
-- `ml/nn/attention.go` — `AttentionWithSinks` gates rotation on `envconfig.KVRotate() && cache != nil && IsHadamardCompatible(query.Dim(0))`; rotates Q/K/V before `cache.Put`, undoes rotation on the attention output.
+- `ml/nn/hadamard.go` — pure-Go normalized Hadamard matrix generator + `IsHadamardCompatible(headDim)` gate, package-level cached `hadamard64` slice, `blockRotate` helper, and `hadamardTensor(ctx)` to materialize the matrix on the active backend.
+- `ml/nn/hadamard_test.go` — orthogonality (every n in 1..128), normalization, symmetry, power-of-2 panic, and `IsHadamardCompatible` cases.
+- `ml/nn/attention.go` — `AttentionWithSinks` rotates Q/K/V before `cache.Put` and undoes the rotation on the attention output. Always-on when `cache != nil && IsHadamardCompatible(query.Dim(0))` — no env flag.
+- `.github/workflows/test-kv-rotate.yml` — smoke workflow that runs the K80 killer combo (FA on + q8_0 KV) against a head_dim-256 model and asserts coherent output.
 
-## Known limitations
+## Why no env flag
 
-- **Stickiness**: `envconfig.KVRotate()` reads the env each call, so toggling the variable mid-process would mix rotated and unrotated cache entries. In practice env vars don't change at runtime, so this is a documentation issue rather than a bug. If we ever need true stickiness, snapshot the gate at runner-init time and pass through.
-- **Head-dim asymmetry**: the gate checks `query.Dim(0)`. If V's head dim differs from Q/K (rare but possible in some MoE/cross-attention designs), rotation would still apply and could break the un-rotation step. Add an explicit V-side check if such a model is ever supported.
+The env-gated approach was scaffolding that briefly let us merge the code without committing to flipping it on. After end-to-end smoke validation showed the rotation produces correct output, the flag became dead weight — same trajectory as `OLLAMA_FLASH_ATTENTION_K80` (PR #112 → productized in PR #117, flag deleted).
 
-## Pending integration details (reference)
+The transform is exact in fp32 (orthogonal: H·Hᵀ = I; symmetric: H = Hᵀ ⇒ H·H = I). When KV is fp16, rotation is small overhead with zero quality benefit — but mathematically it's still a no-op. The cost is bounded (one 64×64 matmul per Q/K/V/output per layer per forward pass), so paying it unconditionally is the simpler design.
 
-### Tensor layout convention
+## Tensor layout convention
 
-`ml.Tensor` in ollama follows ggml column-major ordering. Shapes for attention
-inputs post-RoPE are:
+`ml.Tensor` follows ggml column-major ordering. Shapes for attention inputs post-RoPE are:
 
 - Q: `[head_dim, heads, seq_len_q]` — `Dim(0)` is head dim
 - K: `[head_dim, kv_heads, seq_len_k]`
-- V: `[head_dim, kv_heads, seq_len_k]` (or permuted via `PermutedV`; see
-  `kvcache/causal.go:621-625` — the rotation path must match this convention)
+- V: `[head_dim, kv_heads, seq_len_k]` (or permuted via `PermutedV`; see `kvcache/causal.go:617,622,624`)
 
-The `blockRotate` helper rotates along `Dim(0)` (head dim).
+`blockRotate` rotates along `Dim(0)` (head dim).
 
-### Ordering: rotation must happen AFTER RoPE
+## Ordering: rotation must happen AFTER RoPE
 
-**Critical foot-gun.** Rotation must be applied *after* RoPE has been applied
-to Q and K. Applying the Hadamard before RoPE scrambles the position-dependent
-rotation RoPE introduces, and the resulting transform is not recoverable.
-Upstream llama.cpp commit `744c0c73` applies H after `ggml_rope`; we do the
-same.
+**Critical foot-gun.** Rotation must be applied *after* RoPE has been applied to Q and K. Applying the Hadamard before RoPE scrambles the position-dependent rotation RoPE introduces, and the resulting transform is not recoverable. Upstream llama.cpp commit `744c0c73` applies H after `ggml_rope`; we do the same — `AttentionWithSinks` runs after the model's RoPE step, so this ordering is enforced by where the function sits in the call graph.
 
-Concretely: in the caller's forward pass, the order is
-`q → rope(q) → blockRotate(q)` and likewise for K. V has no RoPE, so just
-`v → blockRotate(v)`.
+## Math
 
-### ollamarunner path — `ml/nn/attention.go`
+```
+Q' = Q · H   (rotated query for THIS turn)
+K' = K · H   (rotated key, written to cache)
+V' = V · H   (rotated value, written to cache)
 
-The current `AttentionWithSinks` function (roughly):
+Attention scores: Q' · (K')ᵀ
+                = (Q·H) · (K·H)ᵀ
+                = Q · H · Hᵀ · Kᵀ
+                = Q · I · Kᵀ                 (orthogonality: H·Hᵀ = I)
+                = Q · Kᵀ                     ← scores preserved exactly
 
-```go
-if key != nil && value != nil {
-    cache.Put(ctx, key, value)
-}
-key, value, mask = cache.Get(ctx)
-// ... attention math using query, key, value
+Output:           softmax(Q'·(K')ᵀ / √d) · V'
+                = softmax(Q·Kᵀ / √d) · V · H
+                = (raw_output) · H
+
+Undo:             out = (raw_output · H) · H
+                       = raw_output · I       (symmetry: H·H = I for Sylvester)
 ```
 
-Rotation wraps this:
+Across turns, K/V from previous decode steps are stored rotated; the rotation gate is structural (depends only on head_dim and cache presence) so all writes use the same transform consistently.
 
-```go
-rotate := envconfig.KVRotate() && IsHadamardCompatible(query.Dim(0))
-
-if rotate && key != nil && value != nil {
-    H := hadamardTensor(ctx, 64)        // [64, 64] fp32, precomputed/cached
-    query = blockRotate(ctx, query, H)  // applied along head dim, block-64 diagonal
-    key   = blockRotate(ctx, key,   H)
-    value = blockRotate(ctx, value, H)
-    cache.Put(ctx, key, value)          // cache now stores rotated K, V
-} else if key != nil && value != nil {
-    cache.Put(ctx, key, value)
-}
-
-key, value, mask = cache.Get(ctx)
-// attention math unchanged — dot products are preserved under orthogonal rotation
-
-if rotate {
-    // V rotation propagates to the attention output; undo on the way out.
-    out = blockRotate(ctx, out, H)      // H is symmetric, so Hᵀ = H
-}
-```
-
-### `blockRotate` helper
+## blockRotate — block-diagonal application
 
 For head dim `d = 64·k`, applying `H_64` block-diagonally to a `[d, heads, seq]` tensor:
 
 1. Reshape `[d, heads, seq]` → `[64, k·heads, seq]`.
-2. Mulmat with `H_64`: result is `[64, k·heads, seq]`.
+2. `Mulmat` with `H_64`: result is `[64, k·heads, seq]`.
 3. Reshape back to `[d, heads, seq]`.
 
-This is the same trick upstream uses for V (fixed 64×64) applied to Q/K as well, at the cost of slightly less aggressive rotation than upstream's "largest pow-2 divisor" choice. The unified 64-wide rotation simplifies the tensor reshape bookkeeping.
+This is the same trick upstream uses for V (fixed 64×64) applied to Q/K as well, at the cost of slightly less aggressive rotation than upstream's "largest pow-2 divisor" choice. The unified 64-wide rotation simplifies the tensor reshape bookkeeping. If MVP results show this matters, we can match upstream's per-head choice in a follow-up.
 
-### Caching the Hadamard tensor
+## Hadamard tensor materialization
 
-Regenerating the matrix on every forward pass is wasteful. Options:
+The `hadamard64` float slice is computed once at package init. Per call, `hadamardTensor(ctx)` does a small CPU→GPU upload (16 KiB) — cheap enough not to bother caching the tensor across calls (each call may target a different backend context with its own allocator).
 
-- **Per-context cache**: attach a `map[int]ml.Tensor` to the runner or a package-level `sync.Map`. Key by size (64 only in MVP).
-- **Model-init-time**: add the Hadamard as a synthetic weight in the model structure. More invasive but matches upstream's "precomputed once per model" approach.
+## Compatibility
 
-For MVP: per-backend-context cache (option 1). Upgrade later if it becomes a hot path.
+- **Compatible head dims**: any multiple of 64 (≥ 64). Covers gemma3 (256), qwen3-vl (128), gpt-oss (64), most modern transformers.
+- **Excluded head dims**: 80, 96, 112 — some Llama-1/2 variants, MPT-7B. Rotation is silently skipped for these (gate returns false). No warning is emitted because it's a structural property of the model, not a user request that we're failing to honor.
+- **No cache**: rotation skipped (no quantization step to benefit from; rotating Q without rotating K would produce garbage).
 
-### Gating
+## Performance
 
-- Rotation applies only when **both** `OLLAMA_KV_ROTATE=1` **and** `IsHadamardCompatible(head_dim)` are true.
-- Mismatched configurations (flag on, head_dim unsupported) log once at model load:
-  ```
-  slog.Info("kv rotation requested but head_dim is not a multiple of 64; disabling", "head_dim", d)
-  ```
-- Rotation state is sticky for the lifetime of a runner. Toggling the env var while a model is loaded does not mix rotated and unrotated cache entries.
+Per attention call, rotation adds:
 
-### llamarunner path
+- 1 small upload per attention call (16 KiB CPU→GPU)
+- 4 matmuls: Q rotation, K rotation, V rotation, output un-rotation
+- Each matmul is `[64, k·heads·seq] @ [64, 64]`
 
-Out of scope for Phase 1 implementation. Follow-up: either cherry-pick upstream commit `744c0c73` as `llama/patches/00NN-rotate-activations-for-better-quantization.patch` or bump the vendored `llama/llama.cpp/` past that commit. Track in a separate issue.
+For decode (batch=1, seq=1) on a 32-layer model: ~100-200 µs per token added on K80 — negligible.
+For prefill (seq=2048): maybe 50-100 ms total — noticeable but within the design-doc target (<10 % overhead vs un-rotated).
 
-## Testing plan
+## llamarunner path
 
-### Unit (no runtime needed)
+Out of scope for Phase 1 implementation. Tracked in #134. Either cherry-pick upstream commit `744c0c73` as `llama/patches/00NN-rotate-activations-for-better-quantization.patch` or bump the vendored `llama/llama.cpp/` past that commit. Cherry-pick is preferred unless there's a separate reason to bump the vendor tree.
 
-- [x] Hadamard generator: orthogonality, normalization, symmetry — landed in `hadamard_test.go`.
-- [ ] `blockRotate` round-trip: `blockRotate(blockRotate(x, H), H) ≈ x` in fp32. Needs ml.Tensor test harness.
+## Testing
 
-### Integration (K80, build env required)
-
-- [ ] Model round-trip: generate with `OLLAMA_KV_ROTATE=0` and `=1`, compare perplexity on wikitext-2. Target: `q4_0` KV with rotation ≤ +0.3% PPL vs fp16.
-- [ ] Overhead: decode tok/s for fp16 / q4_0 / q4_0+rotate. Target: rotation overhead < 10% on K80 `fattn-vec` path.
-- [ ] Regression: `cicd/tests/testcases/` suites pass with rotation on.
-
-### Validation against metrics
-
-Once #98's `/api/metrics` endpoint lands, use the VRAM breakdown to verify KV cache size is unchanged (rotation doesn't affect quant bit-width — only quality). Useful sanity check.
+- **Unit (landed)**: Hadamard generator orthogonality, normalization, symmetry, power-of-2 panic. `hadamard_test.go`.
+- **Integration smoke (landed)**: `.github/workflows/test-kv-rotate.yml` — FA on + q8_0 KV against gemma3:4b, asserts non-empty coherent response, no panics, no CUDA errors.
+- **Perplexity (deferred)**: `q4_0` KV with rotation vs fp16 baseline on wikitext-2. Target: ≤ +0.3 % PPL delta. Needs offline tooling not yet in CI.
+- **Overhead (deferred)**: decode tok/s comparison fp16 / q4_0 / q4_0+rotate on K80. Target: rotation overhead < 10 %.
 
 ## Out of scope for Phase 1
 
-- TBQ3_0 / TBQ4_0 types (Phase 2, only if rotation + `q4_0` isn't sufficient).
+- TBQ3_0 / TBQ4_0 quant types (Phase 2, only if rotation + `q4_0` isn't sufficient).
 - QJL residual correction.
-- Asymmetric K/V type configuration (needs Cache API change — separate issue).
-- Per-head rotation selection (upstream picks largest pow-2; we conservatively use 64).
+- Asymmetric K/V type configuration (needs Cache API change — separate issue, #107).
+- Per-head rotation selection (upstream picks largest pow-2 divisor of head_dim; we conservatively use 64).
+- Bumping default KV cache type to `q4_0` — viable now that rotation is structural; tracked as a follow-up to PR #137.

--- a/docs/design/kv-rotation.md
+++ b/docs/design/kv-rotation.md
@@ -17,6 +17,30 @@ Mirrors ggml-org/llama.cpp#21038 (commit `744c0c73`, merged 2026-04-01), which s
 
 ## What's pending (the actual integration)
 
+### Tensor layout convention
+
+`ml.Tensor` in ollama follows ggml column-major ordering. Shapes for attention
+inputs post-RoPE are:
+
+- Q: `[head_dim, heads, seq_len_q]` — `Dim(0)` is head dim
+- K: `[head_dim, kv_heads, seq_len_k]`
+- V: `[head_dim, kv_heads, seq_len_k]` (or permuted via `PermutedV`; see
+  `kvcache/causal.go:621-625` — the rotation path must match this convention)
+
+The `blockRotate` helper rotates along `Dim(0)` (head dim).
+
+### Ordering: rotation must happen AFTER RoPE
+
+**Critical foot-gun.** Rotation must be applied *after* RoPE has been applied
+to Q and K. Applying the Hadamard before RoPE scrambles the position-dependent
+rotation RoPE introduces, and the resulting transform is not recoverable.
+Upstream llama.cpp commit `744c0c73` applies H after `ggml_rope`; we do the
+same.
+
+Concretely: in the caller's forward pass, the order is
+`q → rope(q) → blockRotate(q)` and likewise for K. V has no RoPE, so just
+`v → blockRotate(v)`.
+
 ### ollamarunner path — `ml/nn/attention.go`
 
 The current `AttentionWithSinks` function (roughly):

--- a/docs/design/kv-rotation.md
+++ b/docs/design/kv-rotation.md
@@ -1,0 +1,110 @@
+# KV Cache Rotation — Design Notes
+
+**Issue:** [#102](https://github.com/dogkeeper886/ollama37/issues/102)
+**Status:** In progress — scaffold committed, `attention.go` integration pending build-env availability.
+
+## Goal
+
+Apply a fixed orthogonal rotation (Sylvester Hadamard matrix, normalized by 1/√n) to Q/K/V activations before they enter the KV cache, so that existing quantized KV types (`q4_0`, `q8_0`) recover most of the fp16-vs-quantized quality gap.
+
+Mirrors ggml-org/llama.cpp#21038 (commit `744c0c73`, merged 2026-04-01), which showed this alone closes the PPL gap on Qwen3.5-4B between `q4_0` KV and `fp16` to +0.22%.
+
+## What's landed
+
+- `envconfig.KVRotate` — `OLLAMA_KV_ROTATE=1` opt-in flag (default off).
+- `ml/nn/hadamard.go` — pure-Go normalized Hadamard matrix generator + `IsHadamardCompatible(headDim)` gate.
+- `ml/nn/hadamard_test.go` — orthogonality, normalization, symmetry, power-of-2 validation.
+
+## What's pending (the actual integration)
+
+### ollamarunner path — `ml/nn/attention.go`
+
+The current `AttentionWithSinks` function (roughly):
+
+```go
+if key != nil && value != nil {
+    cache.Put(ctx, key, value)
+}
+key, value, mask = cache.Get(ctx)
+// ... attention math using query, key, value
+```
+
+Rotation wraps this:
+
+```go
+rotate := envconfig.KVRotate() && IsHadamardCompatible(query.Dim(0))
+
+if rotate && key != nil && value != nil {
+    H := hadamardTensor(ctx, 64)        // [64, 64] fp32, precomputed/cached
+    query = blockRotate(ctx, query, H)  // applied along head dim, block-64 diagonal
+    key   = blockRotate(ctx, key,   H)
+    value = blockRotate(ctx, value, H)
+    cache.Put(ctx, key, value)          // cache now stores rotated K, V
+} else if key != nil && value != nil {
+    cache.Put(ctx, key, value)
+}
+
+key, value, mask = cache.Get(ctx)
+// attention math unchanged — dot products are preserved under orthogonal rotation
+
+if rotate {
+    // V rotation propagates to the attention output; undo on the way out.
+    out = blockRotate(ctx, out, H)      // H is symmetric, so Hᵀ = H
+}
+```
+
+### `blockRotate` helper
+
+For head dim `d = 64·k`, applying `H_64` block-diagonally to a `[d, heads, seq]` tensor:
+
+1. Reshape `[d, heads, seq]` → `[64, k·heads, seq]`.
+2. Mulmat with `H_64`: result is `[64, k·heads, seq]`.
+3. Reshape back to `[d, heads, seq]`.
+
+This is the same trick upstream uses for V (fixed 64×64) applied to Q/K as well, at the cost of slightly less aggressive rotation than upstream's "largest pow-2 divisor" choice. The unified 64-wide rotation simplifies the tensor reshape bookkeeping.
+
+### Caching the Hadamard tensor
+
+Regenerating the matrix on every forward pass is wasteful. Options:
+
+- **Per-context cache**: attach a `map[int]ml.Tensor` to the runner or a package-level `sync.Map`. Key by size (64 only in MVP).
+- **Model-init-time**: add the Hadamard as a synthetic weight in the model structure. More invasive but matches upstream's "precomputed once per model" approach.
+
+For MVP: per-backend-context cache (option 1). Upgrade later if it becomes a hot path.
+
+### Gating
+
+- Rotation applies only when **both** `OLLAMA_KV_ROTATE=1` **and** `IsHadamardCompatible(head_dim)` are true.
+- Mismatched configurations (flag on, head_dim unsupported) log once at model load:
+  ```
+  slog.Info("kv rotation requested but head_dim is not a multiple of 64; disabling", "head_dim", d)
+  ```
+- Rotation state is sticky for the lifetime of a runner. Toggling the env var while a model is loaded does not mix rotated and unrotated cache entries.
+
+### llamarunner path
+
+Out of scope for Phase 1 implementation. Follow-up: either cherry-pick upstream commit `744c0c73` as `llama/patches/00NN-rotate-activations-for-better-quantization.patch` or bump the vendored `llama/llama.cpp/` past that commit. Track in a separate issue.
+
+## Testing plan
+
+### Unit (no runtime needed)
+
+- [x] Hadamard generator: orthogonality, normalization, symmetry — landed in `hadamard_test.go`.
+- [ ] `blockRotate` round-trip: `blockRotate(blockRotate(x, H), H) ≈ x` in fp32. Needs ml.Tensor test harness.
+
+### Integration (K80, build env required)
+
+- [ ] Model round-trip: generate with `OLLAMA_KV_ROTATE=0` and `=1`, compare perplexity on wikitext-2. Target: `q4_0` KV with rotation ≤ +0.3% PPL vs fp16.
+- [ ] Overhead: decode tok/s for fp16 / q4_0 / q4_0+rotate. Target: rotation overhead < 10% on K80 `fattn-vec` path.
+- [ ] Regression: `cicd/tests/testcases/` suites pass with rotation on.
+
+### Validation against metrics
+
+Once #98's `/api/metrics` endpoint lands, use the VRAM breakdown to verify KV cache size is unchanged (rotation doesn't affect quant bit-width — only quality). Useful sanity check.
+
+## Out of scope for Phase 1
+
+- TBQ3_0 / TBQ4_0 types (Phase 2, only if rotation + `q4_0` isn't sufficient).
+- QJL residual correction.
+- Asymmetric K/V type configuration (needs Cache API change — separate issue).
+- Per-head rotation selection (upstream picks largest pow-2; we conservatively use 64).

--- a/docs/design/kv-rotation.md
+++ b/docs/design/kv-rotation.md
@@ -1,7 +1,7 @@
 # KV Cache Rotation — Design Notes
 
 **Issue:** [#102](https://github.com/dogkeeper886/ollama37/issues/102)
-**Status:** In progress — scaffold committed, `attention.go` integration pending build-env availability.
+**Status:** Phase 1 ollamarunner integration landed in `ml/nn/attention.go`. llamarunner cherry-pick of upstream commit `744c0c73` is the next deliverable, tracked separately.
 
 ## Goal
 
@@ -12,10 +12,16 @@ Mirrors ggml-org/llama.cpp#21038 (commit `744c0c73`, merged 2026-04-01), which s
 ## What's landed
 
 - `envconfig.KVRotate` — `OLLAMA_KV_ROTATE=1` opt-in flag (default off).
-- `ml/nn/hadamard.go` — pure-Go normalized Hadamard matrix generator + `IsHadamardCompatible(headDim)` gate.
+- `ml/nn/hadamard.go` — pure-Go normalized Hadamard matrix generator + `IsHadamardCompatible(headDim)` gate, package-level cached `hadamard64` slice, `blockRotate` helper, and one-shot incompatible-head warning (`noteIncompatibleHeadDim`).
 - `ml/nn/hadamard_test.go` — orthogonality, normalization, symmetry, power-of-2 validation.
+- `ml/nn/attention.go` — `AttentionWithSinks` gates rotation on `envconfig.KVRotate() && cache != nil && IsHadamardCompatible(query.Dim(0))`; rotates Q/K/V before `cache.Put`, undoes rotation on the attention output.
 
-## What's pending (the actual integration)
+## Known limitations
+
+- **Stickiness**: `envconfig.KVRotate()` reads the env each call, so toggling the variable mid-process would mix rotated and unrotated cache entries. In practice env vars don't change at runtime, so this is a documentation issue rather than a bug. If we ever need true stickiness, snapshot the gate at runner-init time and pass through.
+- **Head-dim asymmetry**: the gate checks `query.Dim(0)`. If V's head dim differs from Q/K (rare but possible in some MoE/cross-attention designs), rotation would still apply and could break the un-rotation step. Add an explicit V-side check if such a model is ever supported.
+
+## Pending integration details (reference)
 
 ### Tensor layout convention
 

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -211,6 +211,10 @@ var (
 	VisionMaxPixels = Uint("OLLAMA_VISION_MAX_PIXELS", 0)
 	// Auth enables authentication between the Ollama client and server
 	UseAuth = Bool("OLLAMA_AUTH")
+	// KVRotate enables Walsh-Hadamard rotation of Q/K/V before KV-cache
+	// quantization, recovering most of the fp16-vs-quantized quality gap.
+	// See docs/design/kv-rotation.md. Off by default during rollout.
+	KVRotate = Bool("OLLAMA_KV_ROTATE")
 )
 
 func String(s string) func() string {
@@ -298,6 +302,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_VISION_MAX_PIXELS": {"OLLAMA_VISION_MAX_PIXELS", VisionMaxPixels(), "Max image dimension for vision reservation (default: auto, 2048 with flash, 512 without)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_KV_ROTATE":         {"OLLAMA_KV_ROTATE", KVRotate(), "Apply Walsh-Hadamard rotation to Q/K/V before KV-cache quantization (improves q4/q8 KV quality on K80; off by default)"},
 		"OLLAMA_REMOTES":           {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
 
 		// Informational

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -302,7 +302,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_VISION_MAX_PIXELS": {"OLLAMA_VISION_MAX_PIXELS", VisionMaxPixels(), "Max image dimension for vision reservation (default: auto, 2048 with flash, 512 without)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
-		"OLLAMA_KV_ROTATE":         {"OLLAMA_KV_ROTATE", KVRotate(), "Apply Walsh-Hadamard rotation to Q/K/V before KV-cache quantization (improves q4/q8 KV quality on K80; off by default)"},
+		"OLLAMA_KV_ROTATE":         {"OLLAMA_KV_ROTATE", KVRotate(), "Apply Walsh-Hadamard rotation to Q/K/V before KV-cache quantization (improves q4_0/q8_0 KV quality; no effect on fp16 KV; off by default)"},
 		"OLLAMA_REMOTES":           {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
 
 		// Informational

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -211,10 +211,6 @@ var (
 	VisionMaxPixels = Uint("OLLAMA_VISION_MAX_PIXELS", 0)
 	// Auth enables authentication between the Ollama client and server
 	UseAuth = Bool("OLLAMA_AUTH")
-	// KVRotate enables Walsh-Hadamard rotation of Q/K/V before KV-cache
-	// quantization, recovering most of the fp16-vs-quantized quality gap.
-	// See docs/design/kv-rotation.md. Off by default during rollout.
-	KVRotate = Bool("OLLAMA_KV_ROTATE")
 )
 
 func String(s string) func() string {
@@ -302,7 +298,6 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_VISION_MAX_PIXELS": {"OLLAMA_VISION_MAX_PIXELS", VisionMaxPixels(), "Max image dimension for vision reservation (default: auto, 2048 with flash, 512 without)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
-		"OLLAMA_KV_ROTATE":         {"OLLAMA_KV_ROTATE", KVRotate(), "Apply Walsh-Hadamard rotation to Q/K/V before KV-cache quantization (improves q4_0/q8_0 KV quality; no effect on fp16 KV; off by default)"},
 		"OLLAMA_REMOTES":           {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
 
 		// Informational

--- a/ml/nn/attention.go
+++ b/ml/nn/attention.go
@@ -3,7 +3,6 @@ package nn
 import (
 	"fmt"
 
-	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/kvcache"
 	"github.com/ollama/ollama/ml"
 )
@@ -29,20 +28,18 @@ func Attention(ctx ml.Context, query, key, value ml.Tensor, scale float64, cache
 func AttentionWithSinks(ctx ml.Context, query, key, value, sinks ml.Tensor, scale float64, cache kvcache.Cache) ml.Tensor {
 	ctx.Forward(query)
 
-	// Walsh-Hadamard rotation gate. When OLLAMA_KV_ROTATE=1 and the head dim
-	// supports the MVP block-64 layout, rotate Q/K/V before the cache write
-	// and undo on the attention output. Math: orthogonal H satisfies
-	// (QH)(KH)^T = QK^T so attention scores are preserved; V·H propagates
-	// through the output, so multiplying out by H restores it (Sylvester H
-	// is symmetric ⇒ H·H = I). See docs/design/kv-rotation.md.
+	// Walsh-Hadamard rotation: rotate Q/K/V before the cache write and undo
+	// on the attention output. Math: orthogonal H satisfies (QH)(KH)^T = QK^T
+	// so attention scores are preserved; V·H propagates through the output,
+	// so multiplying out by H restores it (Sylvester H is symmetric ⇒ H·H = I).
+	// See docs/design/kv-rotation.md.
 	//
-	// Gated on cache != nil because rotated K/V only makes sense if it ends
-	// up in the cache (so reads come back rotated and Q can be rotated to
-	// match). Without a cache there's no quantization step to benefit from.
-	rotate := envconfig.KVRotate() && cache != nil && IsHadamardCompatible(query.Dim(0))
-	if envconfig.KVRotate() && cache != nil && !IsHadamardCompatible(query.Dim(0)) {
-		noteIncompatibleHeadDim(query.Dim(0))
-	}
+	// Always-on when the head dim supports the MVP block-64 layout AND we have
+	// a cache (rotated K/V only makes sense if it lands in the cache). The
+	// transform is exact in fp32; the win comes when the cache is quantized
+	// (q4_0/q8_0), where the rotation smooths per-coordinate distributions
+	// before quant noise hits, recovering most of the fp16 quality gap.
+	rotate := cache != nil && IsHadamardCompatible(query.Dim(0))
 
 	var hadamard ml.Tensor
 	if rotate {

--- a/ml/nn/attention.go
+++ b/ml/nn/attention.go
@@ -3,6 +3,7 @@ package nn
 import (
 	"fmt"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/kvcache"
 	"github.com/ollama/ollama/ml"
 )
@@ -27,6 +28,28 @@ func Attention(ctx ml.Context, query, key, value ml.Tensor, scale float64, cache
 
 func AttentionWithSinks(ctx ml.Context, query, key, value, sinks ml.Tensor, scale float64, cache kvcache.Cache) ml.Tensor {
 	ctx.Forward(query)
+
+	// Walsh-Hadamard rotation gate. When OLLAMA_KV_ROTATE=1 and the head dim
+	// supports the MVP block-64 layout, rotate Q/K/V before the cache write
+	// and undo on the attention output. Math: orthogonal H satisfies
+	// (QH)(KH)^T = QK^T so attention scores are preserved; V·H propagates
+	// through the output, so multiplying out by H restores it (Sylvester H
+	// is symmetric ⇒ H·H = I). See docs/design/kv-rotation.md.
+	//
+	// Gated on cache != nil because rotated K/V only makes sense if it ends
+	// up in the cache (so reads come back rotated and Q can be rotated to
+	// match). Without a cache there's no quantization step to benefit from.
+	rotate := envconfig.KVRotate() && cache != nil && IsHadamardCompatible(query.Dim(0))
+	if envconfig.KVRotate() && cache != nil && !IsHadamardCompatible(query.Dim(0)) {
+		noteIncompatibleHeadDim(query.Dim(0))
+	}
+
+	var hadamard ml.Tensor
+	if rotate {
+		hadamard = hadamardTensor(ctx)
+		query = blockRotate(ctx, query, hadamard)
+	}
+
 	if key != nil && value != nil {
 		if query.Dim(0) != key.Dim(0) {
 			panic(fmt.Errorf("d_k in attention operation does not match between query(%v) and key(%v)", query.Dim(0), key.Dim(0)))
@@ -38,6 +61,11 @@ func AttentionWithSinks(ctx ml.Context, query, key, value, sinks ml.Tensor, scal
 
 		if key.Dim(2) != value.Dim(2) {
 			panic(fmt.Errorf("seq_len_k in attention operation does not match between key(%v) and value(%v)", key.Dim(2), value.Dim(2)))
+		}
+
+		if rotate {
+			key = blockRotate(ctx, key, hadamard)
+			value = blockRotate(ctx, value, hadamard)
 		}
 
 		ctx.Forward(key, value)
@@ -53,10 +81,11 @@ func AttentionWithSinks(ctx ml.Context, query, key, value, sinks ml.Tensor, scal
 		key, value, mask = cache.Get(ctx)
 	}
 
+	var out ml.Tensor
 	// Only use the fast SDPA implementation if we have a cache, since that's what
 	// will do any expected backend-specific transformations for us
 	if sdpa, ok := query.(ml.ScaledDotProductAttention); ok && cache != nil {
-		return sdpa.ScaledDotProductAttention(ctx, key, value, mask, sinks, scale)
+		out = sdpa.ScaledDotProductAttention(ctx, key, value, mask, sinks, scale)
 	} else {
 		query = query.Permute(ctx, 0, 2, 1, 3)
 		key = key.Permute(ctx, 0, 2, 1, 3)
@@ -71,6 +100,13 @@ func AttentionWithSinks(ctx ml.Context, query, key, value, sinks ml.Tensor, scal
 		kq = kq.Softmax(ctx)
 
 		kqv := value.Mulmat(ctx, kq)
-		return kqv.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx)
+		out = kqv.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx)
 	}
+
+	if rotate {
+		// V was stored rotated; the attention output picks up that rotation
+		// linearly. Undo with one more H multiply along the head dim.
+		out = blockRotate(ctx, out, hadamard)
+	}
+	return out
 }

--- a/ml/nn/hadamard.go
+++ b/ml/nn/hadamard.go
@@ -1,9 +1,7 @@
 package nn
 
 import (
-	"log/slog"
 	"math"
-	"sync"
 
 	"github.com/ollama/ollama/ml"
 )
@@ -12,24 +10,6 @@ import (
 // MVP rotation integration. Computed once at package init so the per-call
 // cost is just a small CPU→GPU upload, not a regenerate-then-upload.
 var hadamard64 = HadamardMatrix(64)
-
-// incompatibleOnce ensures the "rotation requested but head_dim unsupported"
-// warning fires at most once per (process, head_dim). Without this, every
-// forward pass on an unsupported model would log.
-var incompatibleOnce sync.Map // map[int]*sync.Once
-
-// noteIncompatibleHeadDim emits a single slog.Warn the first time a given
-// head_dim is seen with rotation requested but disabled. Operators see one
-// line at first inference and know rotation silently did nothing for the
-// model they're running.
-func noteIncompatibleHeadDim(headDim int) {
-	o, _ := incompatibleOnce.LoadOrStore(headDim, &sync.Once{})
-	o.(*sync.Once).Do(func() {
-		slog.Warn("OLLAMA_KV_ROTATE=1 but head_dim is not a multiple of 64; KV rotation disabled for this model",
-			"head_dim", headDim,
-		)
-	})
-}
 
 // blockRotate applies the 64×64 Sylvester Hadamard `h` block-diagonally
 // along the head dim of `t`. Input and output shapes are identical; the
@@ -40,8 +20,8 @@ func noteIncompatibleHeadDim(headDim int) {
 // to each contiguous 64-element slice of the head dim independently — the
 // block-diagonal effect comes for free from the reshape.
 //
-// Caller is responsible for the rotation gate (envconfig.KVRotate +
-// IsHadamardCompatible). This helper does no checks of its own.
+// Caller is responsible for the rotation gate (IsHadamardCompatible plus
+// having a non-nil cache). This helper does no checks of its own.
 func blockRotate(ctx ml.Context, t, h ml.Tensor) ml.Tensor {
 	d := t.Dim(0)
 	heads := t.Dim(1)
@@ -105,10 +85,7 @@ func HadamardMatrix(n int) []float32 {
 // fixed 64×64 for V; we unify on 64 for simplicity in the first cut).
 //
 // Models with head_dim ∈ {80, 96, 112} (some Llama-1/2 variants, MPT-7B)
-// are silently excluded by this gate. When the attention.go integration
-// lands, the caller must emit a one-shot slog.Info at model load if
-// OLLAMA_KV_ROTATE=1 is set but this function returns false, so operators
-// know rotation did nothing even though they asked for it.
+// are silently excluded by this gate.
 func IsHadamardCompatible(headDim int) bool {
 	return headDim >= 64 && headDim%64 == 0
 }

--- a/ml/nn/hadamard.go
+++ b/ml/nn/hadamard.go
@@ -3,9 +3,10 @@ package nn
 import "math"
 
 // HadamardMatrix returns a row-major normalized Sylvester Hadamard matrix of
-// size n×n. n must be a power of 2 and ≥ 1. Every element is ±1/√n, the matrix
-// is symmetric, and H·Hᵀ = I so it acts as an orthogonal rotation that
-// preserves dot products.
+// size n×n. n must be a power of 2 and ≥ 1. Every element is ±1/√n, the
+// matrix is symmetric under the Sylvester recursion (not all Hadamard
+// matrices are symmetric — Paley construction, for example, is not), and
+// H·Hᵀ = I so it acts as an orthogonal rotation that preserves dot products.
 //
 // This is the rotation used by llama.cpp PR #21038 (commit 744c0c73) and
 // Google DeepMind's TurboQuant (arXiv:2504.19874) to smooth coordinate
@@ -40,6 +41,12 @@ func HadamardMatrix(n int) []float32 {
 // Hadamard matrices, which is the conservative subset of upstream's choice
 // (upstream uses the largest power-of-2 divisor of head_dim for Q/K and a
 // fixed 64×64 for V; we unify on 64 for simplicity in the first cut).
+//
+// Models with head_dim ∈ {80, 96, 112} (some Llama-1/2 variants, MPT-7B)
+// are silently excluded by this gate. When the attention.go integration
+// lands, the caller must emit a one-shot slog.Info at model load if
+// OLLAMA_KV_ROTATE=1 is set but this function returns false, so operators
+// know rotation did nothing even though they asked for it.
 func IsHadamardCompatible(headDim int) bool {
 	return headDim >= 64 && headDim%64 == 0
 }

--- a/ml/nn/hadamard.go
+++ b/ml/nn/hadamard.go
@@ -1,6 +1,68 @@
 package nn
 
-import "math"
+import (
+	"log/slog"
+	"math"
+	"sync"
+
+	"github.com/ollama/ollama/ml"
+)
+
+// hadamard64 is the normalized 64×64 Sylvester Hadamard matrix used by the
+// MVP rotation integration. Computed once at package init so the per-call
+// cost is just a small CPU→GPU upload, not a regenerate-then-upload.
+var hadamard64 = HadamardMatrix(64)
+
+// incompatibleOnce ensures the "rotation requested but head_dim unsupported"
+// warning fires at most once per (process, head_dim). Without this, every
+// forward pass on an unsupported model would log.
+var incompatibleOnce sync.Map // map[int]*sync.Once
+
+// noteIncompatibleHeadDim emits a single slog.Warn the first time a given
+// head_dim is seen with rotation requested but disabled. Operators see one
+// line at first inference and know rotation silently did nothing for the
+// model they're running.
+func noteIncompatibleHeadDim(headDim int) {
+	o, _ := incompatibleOnce.LoadOrStore(headDim, &sync.Once{})
+	o.(*sync.Once).Do(func() {
+		slog.Warn("OLLAMA_KV_ROTATE=1 but head_dim is not a multiple of 64; KV rotation disabled for this model",
+			"head_dim", headDim,
+		)
+	})
+}
+
+// blockRotate applies the 64×64 Sylvester Hadamard `h` block-diagonally
+// along the head dim of `t`. Input and output shapes are identical; the
+// transform is exact in fp32 (orthogonal, dot-product preserving).
+//
+// Layout: t is [head_dim, heads, seq] in column-major order. Reshape to
+// [64, k·heads, seq] (where k = head_dim/64) so the matmul applies H_64
+// to each contiguous 64-element slice of the head dim independently — the
+// block-diagonal effect comes for free from the reshape.
+//
+// Caller is responsible for the rotation gate (envconfig.KVRotate +
+// IsHadamardCompatible). This helper does no checks of its own.
+func blockRotate(ctx ml.Context, t, h ml.Tensor) ml.Tensor {
+	d := t.Dim(0)
+	heads := t.Dim(1)
+	seq := t.Dim(2)
+	k := d / 64
+
+	// h.Mulmat(reshaped) computes h^T · reshaped along the contracted dim
+	// (the leading 64). Sylvester H is symmetric, so h^T = h, and the
+	// result is the desired h · reshaped.
+	reshaped := t.Reshape(ctx, 64, k*heads, seq)
+	rotated := h.Mulmat(ctx, reshaped)
+	return rotated.Reshape(ctx, d, heads, seq)
+}
+
+// hadamardTensor materializes the cached 64×64 Hadamard slice as a backend
+// tensor in the supplied context. Cheap (16 KiB upload); not worth caching
+// the tensor across calls because each call may target a different backend
+// context with its own allocator.
+func hadamardTensor(ctx ml.Context) ml.Tensor {
+	return ctx.FromFloats(hadamard64, 64, 64)
+}
 
 // HadamardMatrix returns a row-major normalized Sylvester Hadamard matrix of
 // size n×n. n must be a power of 2 and ≥ 1. Every element is ±1/√n, the

--- a/ml/nn/hadamard.go
+++ b/ml/nn/hadamard.go
@@ -1,0 +1,45 @@
+package nn
+
+import "math"
+
+// HadamardMatrix returns a row-major normalized Sylvester Hadamard matrix of
+// size n×n. n must be a power of 2 and ≥ 1. Every element is ±1/√n, the matrix
+// is symmetric, and H·Hᵀ = I so it acts as an orthogonal rotation that
+// preserves dot products.
+//
+// This is the rotation used by llama.cpp PR #21038 (commit 744c0c73) and
+// Google DeepMind's TurboQuant (arXiv:2504.19874) to smooth coordinate
+// distributions before KV cache quantization. See docs/design/kv-rotation.md
+// for the integration plan.
+func HadamardMatrix(n int) []float32 {
+	if n < 1 || n&(n-1) != 0 {
+		panic("nn.HadamardMatrix: n must be a power of 2")
+	}
+	h := make([]float32, n*n)
+	h[0] = 1
+	for size := 1; size < n; size *= 2 {
+		for i := 0; i < size; i++ {
+			for j := 0; j < size; j++ {
+				v := h[i*n+j]
+				h[i*n+(j+size)] = v
+				h[(i+size)*n+j] = v
+				h[(i+size)*n+(j+size)] = -v
+			}
+		}
+	}
+	norm := float32(1.0 / math.Sqrt(float64(n)))
+	for i := range h {
+		h[i] *= norm
+	}
+	return h
+}
+
+// IsHadamardCompatible reports whether a head dimension supports KV cache
+// rotation under the MVP integration: head dim is at least 64 and an exact
+// multiple of 64. Head dims that satisfy this use a block-diagonal of 64×64
+// Hadamard matrices, which is the conservative subset of upstream's choice
+// (upstream uses the largest power-of-2 divisor of head_dim for Q/K and a
+// fixed 64×64 for V; we unify on 64 for simplicity in the first cut).
+func IsHadamardCompatible(headDim int) bool {
+	return headDim >= 64 && headDim%64 == 0
+}

--- a/ml/nn/hadamard.go
+++ b/ml/nn/hadamard.go
@@ -37,11 +37,15 @@ func blockRotate(ctx ml.Context, t, h ml.Tensor) ml.Tensor {
 }
 
 // hadamardTensor materializes the cached 64×64 Hadamard slice as a backend
-// tensor in the supplied context. Cheap (16 KiB upload); not worth caching
-// the tensor across calls because each call may target a different backend
-// context with its own allocator.
+// tensor in the supplied context. Uses ctx.Input() because the bare context
+// during reserveWorstCaseGraph rejects FromFloats with "set Input or Layer
+// before creating tensors"; matches the convention used by every other
+// FromFloats caller in the codebase (e.g. model/models/gemma3/model.go:104,
+// model/models/gemma4/model_audio.go:340). Cheap (16 KiB upload); not worth
+// caching the tensor across calls because each call may target a different
+// backend context with its own allocator.
 func hadamardTensor(ctx ml.Context) ml.Tensor {
-	return ctx.FromFloats(hadamard64, 64, 64)
+	return ctx.Input().FromFloats(hadamard64, 64, 64)
 }
 
 // HadamardMatrix returns a row-major normalized Sylvester Hadamard matrix of

--- a/ml/nn/hadamard_test.go
+++ b/ml/nn/hadamard_test.go
@@ -1,0 +1,94 @@
+package nn
+
+import (
+	"math"
+	"testing"
+)
+
+func TestHadamardMatrix_Sizes(t *testing.T) {
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		h := HadamardMatrix(n)
+		if len(h) != n*n {
+			t.Errorf("n=%d: len=%d want %d", n, len(h), n*n)
+		}
+	}
+}
+
+func TestHadamardMatrix_Normalization(t *testing.T) {
+	n := 64
+	h := HadamardMatrix(n)
+	expected := float32(1.0 / math.Sqrt(float64(n)))
+	for i, v := range h {
+		if math.Abs(float64(v)-float64(expected)) > 1e-6 && math.Abs(float64(v)+float64(expected)) > 1e-6 {
+			t.Fatalf("h[%d] = %v; want ±%v", i, v, expected)
+			return
+		}
+	}
+}
+
+func TestHadamardMatrix_Orthogonal(t *testing.T) {
+	// H · Hᵀ should equal I (identity). Since Sylvester Hadamard is symmetric,
+	// this is equivalent to H · H = I.
+	n := 64
+	h := HadamardMatrix(n)
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			var sum float64
+			for k := 0; k < n; k++ {
+				sum += float64(h[i*n+k]) * float64(h[j*n+k])
+			}
+			want := 0.0
+			if i == j {
+				want = 1.0
+			}
+			if math.Abs(sum-want) > 1e-5 {
+				t.Fatalf("(H·Hᵀ)[%d,%d] = %v; want %v", i, j, sum, want)
+			}
+		}
+	}
+}
+
+func TestHadamardMatrix_Symmetric(t *testing.T) {
+	// Sylvester Hadamard matrices are symmetric: H[i,j] == H[j,i].
+	n := 64
+	h := HadamardMatrix(n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if h[i*n+j] != h[j*n+i] {
+				t.Fatalf("H[%d,%d]=%v != H[%d,%d]=%v", i, j, h[i*n+j], j, i, h[j*n+i])
+			}
+		}
+	}
+}
+
+func TestHadamardMatrix_PowerOfTwoOnly(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for non-power-of-2 size")
+		}
+	}()
+	HadamardMatrix(65)
+}
+
+func TestIsHadamardCompatible(t *testing.T) {
+	cases := []struct {
+		headDim int
+		want    bool
+	}{
+		{32, false},   // below 64
+		{63, false},   // below 64
+		{64, true},    // exact
+		{128, true},   // 2×64
+		{192, true},   // 3×64
+		{80, false},   // not divisible by 64
+		{96, false},   // not divisible by 64
+		{112, false},  // not divisible by 64
+		{256, true},   // 4×64
+	}
+	for _, c := range cases {
+		if got := IsHadamardCompatible(c.headDim); got != c.want {
+			t.Errorf("IsHadamardCompatible(%d) = %v; want %v", c.headDim, got, c.want)
+		}
+	}
+}

--- a/ml/nn/hadamard_test.go
+++ b/ml/nn/hadamard_test.go
@@ -11,6 +11,24 @@ func TestHadamardMatrix_Sizes(t *testing.T) {
 		if len(h) != n*n {
 			t.Errorf("n=%d: len=%d want %d", n, len(h), n*n)
 		}
+		// Length alone is guaranteed by make(); also verify orthogonality
+		// at every size so a Sylvester recursion bug that only surfaces
+		// at, say, n=128 does not slip through.
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				var sum float64
+				for k := 0; k < n; k++ {
+					sum += float64(h[i*n+k]) * float64(h[j*n+k])
+				}
+				want := 0.0
+				if i == j {
+					want = 1.0
+				}
+				if math.Abs(sum-want) > 1e-4 {
+					t.Fatalf("n=%d: (H·Hᵀ)[%d,%d] = %v; want %v", n, i, j, sum, want)
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of TurboQuant follow-up (#101). Adds Walsh-Hadamard rotation of Q/K/V before they're written to the KV cache, smoothing per-coordinate distributions so quantized KV (\`q4_0\`, \`q8_0\`) recovers most of the fp16 quality gap. Mirrors upstream PR ggml-org/llama.cpp#21038.

**No env flag.** Rotation is structurally always-on when \`cache != nil && IsHadamardCompatible(query.Dim(0))\`. The original PR was env-gated as scaffolding; after end-to-end validation that scaffolding is dead weight — same trajectory as PR #117 productized #112 by deleting the K80-specific FA flag.

## What's in this PR

- **\`ml/nn/hadamard.go\`** — Sylvester Hadamard generator + \`IsHadamardCompatible\` gate, package-cached \`hadamard64\` slice, \`blockRotate\` helper, \`hadamardTensor(ctx)\` (uses \`ctx.Input()\` per the codebase convention).
- **\`ml/nn/hadamard_test.go\`** — orthogonality (every n in 1..128), normalization, symmetry, power-of-2 panic, \`IsHadamardCompatible\` table.
- **\`ml/nn/attention.go\`** — \`AttentionWithSinks\` rotates Q/K/V before \`cache.Put\`, undoes rotation on the attention output. Math identity: \`(QH)(KH)^T = QK^T\` so attention scores preserved; V·H propagates linearly through the output, undone with one more multiply (Sylvester H is symmetric ⇒ H·H = I).
- **\`.github/workflows/test-kv-rotate.yml\`** — smoke workflow that exercises the K80 killer combo (FA on + q8_0 KV) against gemma3:4b. Exists on main from PR #139.
- **\`docs/design/kv-rotation.md\`** — full design notes.

## What's NOT in this PR

- **llamarunner path** — out of scope for Phase 1, tracked as #134.
- **Per-model perplexity validation** — needs offline tooling not yet in CI; deferred follow-up.
- **Bumping default KV to q4_0** — viable now that rotation is structural; tracked as a follow-up to PR #137.

## Validation history (the interesting bit)

The first \"green\" smoke run was a **false positive**. Initial design used \`OLLAMA_KV_ROTATE=1\` set in the docker container env. Smoke returned \"Paris\", looked good. But the env var doesn't propagate to the runner subprocess, so \`envconfig.KVRotate()\` in the runner returned \`false\`, the gate skipped, and the un-rotated path produced the answer. Rotation never actually ran.

Productizing (always-on, no env) immediately surfaced two real issues:

1. **\`hadamardTensor\` panicked during \`reserveWorstCaseGraph\`** with \`set Input or Layer before creating tensors\`. Fixed by switching from bare \`ctx.FromFloats(...)\` to \`ctx.Input().FromFloats(...)\` — the convention every other model file uses (gemma3, gemma4, llama4, bert).
2. **The previous validation never exercised rotation.** Productization caught what the env gate was hiding.

Lesson: env flags as \"validate later\" scaffolding can hide bugs by also gating the validation. Always-on flushes them out.

## Test plan

- [x] Build — green ([25280651630](https://github.com/dogkeeper886/ollama37/actions/runs/25280651630))
- [x] Runtime — green ([25280982332](https://github.com/dogkeeper886/ollama37/actions/runs/25280982332))
- [x] Smoke (FA + q8_0 + rotation, rotation actually fires this time) — green ([25280954190](https://github.com/dogkeeper886/ollama37/actions/runs/25280954190)). \"Paris\" through the rotated path.
- [x] Inference suite (regression check on standard configs) — green ([25281268538](https://github.com/dogkeeper886/ollama37/actions/runs/25281268538))

## Layering

The earlier review flagged that importing envconfig from \`ml/nn\` was the first such edge under \`ml/\`. Productizing removed the import entirely — the layering concern resolves itself.

Closes #102
Part of #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)