### PR TITLE
Productize K80 perf defaults: FA on + q8_0 KV cache (closes #136)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,3 +9,24 @@
 # Ollama version to embed in the binary
 # This version is displayed by 'ollama --version' and in logs
 OLLAMA_VERSION=2.0.1
+
+# --- Runtime tuning (optional; container reads these via docker compose) ---
+# Defaults are tuned for K80 hardware. Override here only if you know what
+# you're doing.
+
+# Flash attention. ON by default — gives a small speed bump (~3% tok/s) and
+# meaningful VRAM headroom (~13% on a 9B model) on K80.
+# Set to "0" to disable (useful for A/B debugging).
+# OLLAMA_FLASH_ATTENTION=0
+
+# KV cache element type. Default "q8_0" cuts KV memory by ~47% with marginal
+# quality cost (chat/code unaffected; precision-sensitive workloads — math,
+# strict deterministic generation — may notice). Already higher precision
+# than the Q4 weights it's reading from.
+# Set to "f16" for full precision if you have VRAM to spare.
+# Set to "q4_0" only after KV rotation lands (see #102) — quality without
+# rotation degrades noticeably for q4_0 KV.
+# OLLAMA_KV_CACHE_TYPE=f16
+
+# Verbose server logging.
+# OLLAMA_DEBUG=1

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -17,6 +17,9 @@ OLLAMA_VERSION=2.0.1
 # Flash attention. ON by default — gives a small speed bump (~3% tok/s) and
 # meaningful VRAM headroom (~13% on a 9B model) on K80.
 # Set to "0" to disable (useful for A/B debugging).
+# Note: if you disable FA, also set OLLAMA_KV_CACHE_TYPE=f16 below —
+# V-cache quantization requires flash attention, so q8_0 + FA off will
+# fail to load.
 # OLLAMA_FLASH_ATTENTION=0
 
 # KV cache element type. Default "q8_0" cuts KV memory by ~47% with marginal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_DEBUG=${OLLAMA_DEBUG:-}
+      # K80 perf defaults — see docker/.env.example to override.
+      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-1}
+      - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-q8_0}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Roll out two K80-validated performance flags through \`docker/docker-compose.yml\` so existing and new users benefit by default:

- **\`OLLAMA_FLASH_ATTENTION\` defaults to 1** — was off (or model-default; inconsistent across arches). PR #117 productized the K80 path; benchmarks show +3% tok/s and -13% VRAM on gpt-oss:20b.
- **\`OLLAMA_KV_CACHE_TYPE\` defaults to \`q8_0\`** — was unset (= f16). Cuts KV cache memory by ~47% with marginal quality cost (chat/code unaffected). Already higher precision than the Q4 weights it's reading from, so f16 KV was over-provisioned.

Both are passthroughs — users can override via \`.env\` without modifying compose:

```bash
# Disable FA (debugging/A-B)
OLLAMA_FLASH_ATTENTION=0

# Full-precision KV (precision-sensitive workloads)
OLLAMA_KV_CACHE_TYPE=f16
```

## Files

- \`docker/docker-compose.yml\` — add two env passthroughs with K80-tuned defaults.
- \`docker/.env.example\` — document both knobs, the trade-offs, and forward note about q4_0 (deferred until KV rotation lands per #102).

## Test plan

- [x] \`docker compose config\` — defaults expand correctly: \`OLLAMA_FLASH_ATTENTION=1\`, \`OLLAMA_KV_CACHE_TYPE=q8_0\`.
- [x] Build Verification — green ([25274178050](https://github.com/dogkeeper886/ollama37/actions/runs/25274178050))
- [x] Runtime Tests — green ([25274803193](https://github.com/dogkeeper886/ollama37/actions/runs/25274803193)). Container healthy with new defaults; 4 K80s detected.
- [ ] **Full pipeline on main after merge** — inference + models suites will exercise the new defaults across the full model lineup. Surfaces any per-model regression with FA on / q8_0 KV.

## Effect for existing users

After pulling the new image and \`docker compose up\`:
- Get FA on by default. Models that flip-flopped on this previously now consistently use it.
- Get q8_0 KV. Outputs may differ slightly vs prior versions due to quantization noise. Power users can revert via \`.env\`.

Worth a release-note callout. Reversible in one .env line.

## Out of scope

- \`OLLAMA_KV_ROTATE\` — separate, in flight as #102 / PR #133. Will become irrelevant as a flag once productized.
- Bumping KV default to \`q4_0\` — depends on rotation landing first. Tracked as follow-up to #102.

Closes #136
Related to #117 (FA productization) and #102 (KV rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)