### PR TITLE
Add KV rotation ON-path smoke workflow (test infra for #102)

### DIFF
--- a/.github/workflows/test-kv-rotate.yml
+++ b/.github/workflows/test-kv-rotate.yml
@@ -1,0 +1,160 @@
+name: KV Rotation ON-Path Smoke
+
+# Smoke test for the KV rotation code path introduced in #102 / PR #133.
+# CI workflows run the container from docker-compose, where OLLAMA_KV_ROTATE
+# is unset, so the rotation code is compiled but never executed. This
+# workflow spins up the container with -e OLLAMA_KV_ROTATE=1 (matching the
+# pattern in test-fa-k80.yml), runs a deterministic inference against a
+# small ollamarunner-served model with a head_dim multiple of 64, and
+# verifies the output is coherent. Pairs with #135.
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model to test (must be pre-pulled; head_dim must be a multiple of 64)"
+        required: false
+        default: "gemma3:4b"
+        type: string
+      prompt:
+        description: "Inference prompt (deterministic; temp=0)"
+        required: false
+        default: "What is the capital of France? Answer in one word."
+        type: string
+
+jobs:
+  validate:
+    name: KV rotation smoke test
+    runs-on: self-hosted
+    environment: cicd-1
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stop existing ollama37 container
+        run: |
+          docker stop ollama37 || true
+          docker rm -f ollama37-kvrotate-test 2>/dev/null || true
+          for i in $(seq 1 30); do
+            USED=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | head -1 | tr -d ' ')
+            if [ "$USED" -lt 1024 ]; then
+              echo "VRAM released after ${i}s: ${USED} MiB"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run inference with OLLAMA_KV_ROTATE=1
+        id: infer
+        run: |
+          set -e
+          MODEL="${{ inputs.model }}"
+          PROMPT="${{ inputs.prompt }}"
+          OUT=/tmp/kv-rotate-test
+          rm -rf "$OUT" && mkdir -p "$OUT"
+
+          echo "=== Starting container with OLLAMA_KV_ROTATE=1, FA=1, KV=q8_0 ==="
+          docker run -d --rm \
+            --name ollama37-kvrotate-test \
+            --runtime nvidia \
+            --gpus all \
+            -e NVIDIA_VISIBLE_DEVICES=all \
+            -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+            -e OLLAMA_HOST=0.0.0.0:11434 \
+            -e OLLAMA_DEBUG=1 \
+            -e OLLAMA_FLASH_ATTENTION=1 \
+            -e OLLAMA_KV_CACHE_TYPE=q8_0 \
+            -e OLLAMA_KV_ROTATE=1 \
+            -v ollama-data:/root/.ollama \
+            -p 11434:11434 \
+            ollama37:latest
+
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:11434/ >/dev/null 2>&1; then
+              echo "ollama API ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+          if ! curl -sf http://localhost:11434/ >/dev/null 2>&1; then
+            echo "::error::API never came up"
+            docker logs ollama37-kvrotate-test > "$OUT/container-logs.log" 2>&1 || true
+            cat "$OUT/container-logs.log"
+            exit 1
+          fi
+
+          echo "=== Issuing inference ==="
+          curl -s http://localhost:11434/api/generate \
+            -d "$(jq -n \
+                --arg model "$MODEL" \
+                --arg prompt "$PROMPT" \
+                '{model: $model, prompt: $prompt, stream: false,
+                  options: {num_predict: 64, num_ctx: 2048,
+                            temperature: 0, seed: 42}}')" \
+            > "$OUT/response.json"
+
+          docker logs ollama37-kvrotate-test > "$OUT/container-logs.log" 2>&1
+
+          echo "=== Response ==="
+          jq '.' "$OUT/response.json"
+
+          echo "=== Container log tail (50 lines) ==="
+          tail -50 "$OUT/container-logs.log"
+
+          echo "=== Stopping container ==="
+          docker stop --time 10 ollama37-kvrotate-test || true
+
+      - name: Validate response and logs
+        run: |
+          OUT=/tmp/kv-rotate-test
+
+          echo "--- 1. response.json must contain a non-empty .response field ---"
+          if ! jq -e '.response | length > 0' "$OUT/response.json" >/dev/null; then
+            echo "::error::Empty or missing .response field"
+            jq '.' "$OUT/response.json"
+            exit 1
+          fi
+          RESP=$(jq -r '.response' "$OUT/response.json")
+          echo "Response: $RESP"
+
+          echo "--- 2. response must mention 'Paris' (capital of France) ---"
+          if ! echo "$RESP" | grep -qi 'paris'; then
+            echo "::error::Response does not mention 'Paris' — output may be incoherent"
+            echo "Got: $RESP"
+            exit 1
+          fi
+
+          echo "--- 3. container logs must not contain panics or CUDA errors ---"
+          # POSIX-grep friendly (no lookaheads): explicit error-status alternation
+          # for CUBLAS so CUBLAS_STATUS_SUCCESS doesn't false-positive.
+          if grep -qE 'panic:|runtime error|CUDA error|CUBLAS_STATUS_(NOT_INITIALIZED|ALLOC_FAILED|INVALID_VALUE|ARCH_MISMATCH|MAPPING_ERROR|EXECUTION_FAILED|INTERNAL_ERROR|NOT_SUPPORTED)' "$OUT/container-logs.log"; then
+            echo "::error::Container logs contain panic / CUDA errors"
+            grep -E 'panic:|runtime error|CUDA error|CUBLAS_STATUS_' "$OUT/container-logs.log" | head -20
+            exit 1
+          fi
+
+          echo "--- 4. logs should NOT contain the 'incompatible head_dim' warning ---"
+          # gemma3:4b has head_dim=256, multiple of 64 → rotation should activate
+          if grep -q 'KV rotation disabled for this model' "$OUT/container-logs.log"; then
+            echo "::error::Rotation disabled warning fired — gate failed unexpectedly"
+            grep 'KV rotation' "$OUT/container-logs.log"
+            exit 1
+          fi
+
+          echo "All assertions pass — KV rotation ON-path works on $(jq -r '.model' $OUT/response.json)"
+
+      - name: Restore docker-compose container
+        if: always()
+        run: |
+          docker rm -f ollama37-kvrotate-test 2>/dev/null || true
+          cd ${OLLAMA37_ROOT:-${{ github.workspace }}}/docker && docker compose up -d || true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: kv-rotate-smoke-results
+          path: /tmp/kv-rotate-test/


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/test-kv-rotate.yml\` — a small workflow that spins up the container with \`-e OLLAMA_KV_ROTATE=1\` (matching the docker-run pattern in \`test-fa-k80.yml\`), runs a deterministic inference, and asserts the rotation code path produces coherent output without panics or CUDA errors.

## Why this is its own PR

GitHub's \`workflow_dispatch\` requires the workflow file to exist on the **default branch** before it can be triggered, even when targeting another branch. PR #133 cannot be ON-path validated until this workflow lands first. Landing it on its own keeps #133 focused on the rotation code itself.

## Files

- \`.github/workflows/test-kv-rotate.yml\` (160 lines, single new file)

## What the workflow asserts

1. \`.response\` field is non-empty.
2. Output mentions \"Paris\" (deterministic temp=0 + seed=42 prompt: \"What is the capital of France? Answer in one word.\").
3. Container logs contain no \`panic:\`, \`runtime error\`, or known-bad \`CUBLAS_STATUS_*\` codes.
4. The \`KV rotation disabled for this model\` warning did NOT fire (gate activated successfully).

Defaults to gemma3:4b which has head_dim=256 (multiple of 64, eligible for rotation).

## Test plan

- [x] Workflow YAML syntax valid (cherry-picked clean from issue-102-kv-rotation branch where the file was first authored)
- [ ] Manual dispatch on \`issue-102-kv-rotation\` after merge to actually verify ON-path works

This PR doesn't dispatch the workflow itself — that's the whole point. Merge first, dispatch second.

## Out of scope

- The rotation code itself: PR #133.
- Per-model coverage / extending to multiple head_dims: #135 covers the broader test-design work.

Resolves the validation-gap blocker noted in PR #133's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)