### PR TITLE
/api/metrics: return marketing GPU name instead of CUDA enumeration label (closes #131)

### DIFF
--- a/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
+++ b/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
@@ -96,11 +96,14 @@ steps:
   - name: gpus[].name returns marketing name, not runtime enumeration label
     command: |
       # Per #131: name should be "Tesla K80" or similar, NOT "CUDA0/HIP0/etc."
+      # The `// ""` coerces missing/null names into empty strings so an
+      # empty `^$` alternation can fail the assertion alongside the
+      # enum-style names.
       BAD=$(curl -s http://localhost:11434/api/metrics \
-        | jq -r '.gpus[].name' \
-        | grep -E '^(CUDA|HIP|Vulkan)[0-9]+$' \
+        | jq -r '.gpus[] | (.name // "")' \
+        | grep -E '^$|^(CUDA|HIP|Vulkan)[0-9]+$' \
         | wc -l)
-      echo "GPUs with runtime-enum-style name: $BAD"
+      echo "GPUs with empty or runtime-enum-style name: $BAD"
       [ "$BAD" = "0" ] && echo "gpu name OK" || echo "gpu name FAIL"
     expectPatterns:
       - "gpu name OK"

--- a/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
+++ b/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
@@ -93,6 +93,20 @@ steps:
     rejectPatterns:
       - "gpu_count match FAIL"
 
+  - name: gpus[].name returns marketing name, not runtime enumeration label
+    command: |
+      # Per #131: name should be "Tesla K80" or similar, NOT "CUDA0/HIP0/etc."
+      BAD=$(curl -s http://localhost:11434/api/metrics \
+        | jq -r '.gpus[].name' \
+        | grep -E '^(CUDA|HIP|Vulkan)[0-9]+$' \
+        | wc -l)
+      echo "GPUs with runtime-enum-style name: $BAD"
+      [ "$BAD" = "0" ] && echo "gpu name OK" || echo "gpu name FAIL"
+    expectPatterns:
+      - "gpu name OK"
+    rejectPatterns:
+      - "gpu name FAIL"
+
   - name: Dump full response for inspection
     command: curl -s http://localhost:11434/api/metrics | jq '.'
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -104,9 +104,18 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 		if len(d.LibraryPath) > 0 {
 			libPath = d.LibraryPath[0]
 		}
+		// Prefer the user-friendly Description (e.g. "Tesla K80") over the
+		// backend's Name field, which is the runtime enumeration label
+		// (e.g. "CUDA0"). Name is what humans look at when answering "what
+		// hardware is this?" — Description matches that intent. Fall back
+		// to Name if Description is empty (some backends may not set it).
+		name := d.Description
+		if name == "" {
+			name = d.Name
+		}
 		gpus = append(gpus, GPUMetrics{
 			ID:          d.DeviceID.ID,
-			Name:        d.Name,
+			Name:        name,
 			VRAMTotal:   d.TotalMemory,
 			VRAMFree:    d.FreeMemory,
 			ComputeCap:  compute,


### PR DESCRIPTION
## Summary

\`/api/metrics\` was returning the CUDA enumeration label (\`CUDA0\`, \`CUDA1\`...) in \`gpus[].name\` instead of the marketing name (\`Tesla K80\`). \`ml.DeviceInfo\` already exposes both — \`Name\` is the backend label, \`Description\` is the user-friendly string. This PR swaps to \`Description\`, with a fallback to \`Name\` for backends that don't populate it.

## Files

- **\`server/metrics.go\`** — 7 lines: prefer \`d.Description\`, fallback to \`d.Name\` if empty. Comment explains why.
- **\`cicd/tests/testcases/runtime/TC-RUNTIME-004.yml\`** — new step asserts \`gpus[].name\` does not match \`^(CUDA|HIP|Vulkan)[0-9]+$\`. Catches re-regressions.

## Why this matters

Operators answering \"what hardware do I have?\" via \`/api/metrics\` were getting back the CUDA runtime's enumeration index, not the GPU model. Cross-referencing was needed (e.g. \`CUDA2\` → which physical GPU?). The startup logs and \`nvidia-smi\` both expose \"Tesla K80\" — so should the metrics endpoint.

## Test plan

- [x] Build — green ([25281952233](https://github.com/dogkeeper886/ollama37/actions/runs/25281952233))
- [x] Runtime — green ([25282492021](https://github.com/dogkeeper886/ollama37/actions/runs/25282492021)). New TC-RUNTIME-004 step output: \`GPUs with runtime-enum-style name: 0\` → \`gpu name OK\`. Confirms all 4 dies now return marketing names.

## Risk

**Low.** The endpoint just shipped (PR #129); no external consumers depend on the field semantics yet. Now is the cheapest moment to fix.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)