### PR TITLE
Fix #138: ghost-GPU layout + vision reservation overflow on K80

### DIFF
--- a/docs/traces/qwen3vl-batched-cublas-launch.md
+++ b/docs/traces/qwen3vl-batched-cublas-launch.md
@@ -1,0 +1,243 @@
+# Trace: qwen3-vl CUDA "invalid configuration argument" at batched cublas
+
+**Issue**: #138 — TC-MODELS-011 (qwen3-vl:8b) and TC-MODELS-012 (qwen3-vl:30b) crash on load
+**Date**: 2026-05-12
+**Run**: [25308846241](https://github.com/dogkeeper886/ollama37/actions/runs/25308846241)
+
+## Symptom
+
+Both qwen3-vl tests die during worst-case graph reservation:
+
+```
+CUDA error: invalid configuration argument
+  current device: 0, in function ggml_cuda_mul_mat_batched_cublas_impl
+    at ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu:2182
+  cudaGetLastError()
+llama runner terminated, error="exit status 2"
+```
+
+`do load request: Post "http://127.0.0.1:XXXX/load": EOF` surfaces in the API client.
+
+## Crash site (verified from stack)
+
+`ggml-cuda.cu:2182` is the `CUDA_CHECK(cudaGetLastError())` immediately after a
+`k_compute_batched_ptrs` kernel launch on the broadcasting / non-contiguous
+branch of `ggml_cuda_mul_mat_batched_cublas_impl`:
+
+```c
+// ggml-cuda.cu:2161-2182
+} else {
+    // use cublasGemmBatchedEx
+    const int64_t ne23 = ne12*ne13;
+
+    ggml_cuda_pool_alloc<const void *> ptrs_src(ctx.pool(), 2*ne23);
+    ggml_cuda_pool_alloc<      void *> ptrs_dst(ctx.pool(), 1*ne23);
+
+    size_t src1_stride_size = sizeof(cuda_t);
+
+    dim3 block_dims(ne13, ne12);
+    k_compute_batched_ptrs<<<1, block_dims, 0, main_stream>>>(...);
+    CUDA_CHECK(cudaGetLastError());   // ← line 2182
+```
+
+The launch packs **all batch indices into a single block**: `gridDim = (1,1,1)`,
+`blockDim = (ne13, ne12, 1)`. K80 (CC 3.7) caps **threads per block at 1024**.
+When `ne12 * ne13 > 1024`, `cudaLaunchKernel` returns `cudaErrorInvalidConfiguration`
+and the next `cudaGetLastError()` surfaces it.
+
+The kernel itself supports a 2D grid+block (it indexes with
+`blockIdx.x * blockDim.x + threadIdx.x` and bounds-checks `i12 < ne12`,
+`i13 < ne13` — see `k_compute_batched_ptrs` at ggml-cuda.cu:1933-1938). Only
+the launch config under-uses that capability — fixable, but out of scope for
+this trace.
+
+## Dispatch flow
+
+```
+runner.allocModel()                                     # runner.go:1208
+  └── reserveWorstCaseGraph(multimodal=true)            # runner.go:1208
+        ├── maxPixels = 2048 (s.flashAttention=true)    # runner.go:1055-1062  ← the regression
+        ├── synth image: 2048×2048 grayscale            # runner.go:1063-1065
+        ├── multimodalProcessor.EncodeMultimodal(img)   # qwen3vl/imageprocessor.go:85
+        │     └── SmartResize → grid {H=W=102, T=1}     # ~10,404 raw patches at 2048×2048
+        ├── batch.Multimodal = ...                      # runner.go:1108-1110
+        ├── model.Forward(ctx, batch)                   # runner.go:1126
+        │     └── VisionModel.Forward(pixelValues,grid) # qwen3vl/model_vision.go:221
+        │           ├── PatchEmbedding (Conv3D)
+        │           ├── PositionEmbedding
+        │           ├── 27 × VisionEncoderLayer
+        │           │     └── VisionAttention.Forward
+        │           │           └── nn.Attention(Q,K,V, cache=nil)   # ml/nn/attention.go:24
+        │           │                 └── (cache==nil → manual path) # attention.go:84
+        │           │                       ├── K.MulmatFullPrec(Q)
+        │           │                       └── V.Mulmat(KQ)
+        │           ├── PatchMerger
+        │           └── DeepstackMerger (×N indexes)
+        └── ctx.Reserve()                               # ggml.go:855
+              └── ggml_backend_sched_reserve()
+                    └── while executing the graph, ggml_cuda_mul_mat dispatches
+                        to ggml_cuda_mul_mat_batched_cublas for any matmul
+                        where src1->ne[2]*src1->ne[3] > 1                 # ggml-cuda.cu:2303-2306
+                          → ggml_cuda_mul_mat_batched_cublas_impl
+                            → broadcast/non-contig branch                  # ggml-cuda.cu:2161
+                              → k_compute_batched_ptrs launch              # ggml-cuda.cu:2171  ← crashes
+```
+
+## What changed (the real regression chain)
+
+| Change | Effect |
+|---|---|
+| `c379fd96` (Apr 27) — Productize K80 FA (#117) | FA is now actually enabled on K80 instead of being warned-off |
+| `5d09f609` (May 3)  — K80 perf defaults (#137)  | docker-compose sets `OLLAMA_FLASH_ATTENTION=1` by default |
+| Net effect on `s.flashAttention` | was `false` pre-Apr-27 → now `true` |
+
+Effect at `runner.go:1055-1062`:
+
+```go
+maxPixels := int(envconfig.VisionMaxPixels())
+if maxPixels == 0 {
+    if s.flashAttention {
+        maxPixels = 2048      // ← active path after #117 + #137
+    } else {
+        maxPixels = 512       // ← previous path; #50cba688 lowered this for K80
+    }
+}
+img := image.NewGray(image.Rect(0, 0, maxPixels, maxPixels))
+```
+
+The 2048-vs-512 branch chooses image resolution for the **worst-case graph
+reservation only** — it has nothing to do with actual inference image sizes.
+The vision-tower forward at 2048×2048 produces enough patches that some
+batched-cublas matmul in the graph hits `ne12 * ne13 > 1024` and the kernel
+launch fails.
+
+### Why not caught on main
+
+No Models-suite full run has been recorded on `main` since #117 and #137
+landed (last full main run was `24251137369` on 2026-04-10, before either
+change). The breakage was first surfaced on the `issue-138-...` branch
+because that's the first branch to run a full Models suite on top of the
+new defaults.
+
+The branch's three commits only touch `llm/server.go` (layout planner) —
+none of them are upstream of the vision-tower or CUDA dispatch path.
+Initial bisection-by-CI-run misattributed the crash to `e20ce9c9`; that was
+a false positive caused by the prior runs being scoped to TC-MODELS-010
+only. Not a regression from this branch.
+
+## Pre-regression evidence
+
+Run `24251137369` on `main` (2026-04-10, before #117) was the last full
+Models suite — qwen3-vl:8b passed:
+
+```
+"flash attention enabled but not supported by gpu"
+FlashAttention:false                  ← FA warned-off ⇒ maxPixels=512
+Per-GPU memory: 7608 MiB              ← model on 1 GPU, no crash
+```
+
+In the failing 2026-05-04 run, same model, same K80 hardware:
+
+```
+"enabling flash attention"
+FlashAttention:true                   ← FA actually on ⇒ maxPixels=2048
+CUDA error: invalid configuration argument
+```
+
+## Which specific tensor overflows
+
+Not yet pinpointed from logs alone — the crash is `cudaGetLastError()` after
+the launch, with no GGML node name in the back-trace. Hypothesis space:
+
+1. **Vision attention K.MulmatFullPrec(Q) or V.Mulmat(KQ).** Direct dim
+   analysis suggests `ne12 = numHeads = 16` and `ne13 = 1` for these — that's
+   only 16 threads, under the cap. So pure attention shouldn't overflow at
+   numHeads ≤ 1024.
+2. **A reshape/permute in PositionEmbedding or PatchMerger** that produces a
+   tensor with one of `ne[2]` or `ne[3]` equal to the per-side patch count
+   (~102 for the 2048×2048 case) and the other multiplied up by mergeSize /
+   spatial-merge structure. `102 × ≥10` is enough to exceed 1024.
+3. **The mRoPE positional path** in qwen3-vl (`mropeSections: [24, 20, 20]`)
+   may introduce a section-dimension that contributes to `ne[2]` or `ne[3]`.
+4. **DeepstackMerger** runs after specific vision blocks (per
+   `deepstackVisualIndexes`); its mul_mat dispatch could differ from the
+   normal layer matmul.
+
+To pin down (1)–(4) we need the actual ne dims at the crashing dispatch.
+The existing `GGML_CUDA_DEBUG` log block at `ggml-cuda.cu:2117-2123` only
+captures the GEMM compute-type config, not the kernel launch dims. The
+trace adds a level-gated launch-dim log at the kernel call site (see
+"Debug log additions" below) so the next CI run with `GGML_CUDA_DEBUG=1`
+can finish the trace.
+
+## Debug log additions
+
+`ggml-cuda.cu` — at the kernel launch site of
+`ggml_cuda_mul_mat_batched_cublas_impl` (gated by `GGML_CUDA_DEBUG=1`,
+matching the existing static-bool style at line 2118):
+
+```c
+if (debug_enabled) {
+    fprintf(stderr,
+            "DEBUG batched_cublas k_compute_batched_ptrs: "
+            "ne02=%lld ne03=%lld ne12=%lld ne13=%lld threads_per_block=%lld "
+            "src0_name=\"%s\" src1_name=\"%s\" dst_name=\"%s\"\n",
+            (long long)ne02, (long long)ne03, (long long)ne12, (long long)ne13,
+            (long long)(ne12 * ne13),
+            src0->name, src1->name, dst->name);
+}
+```
+
+This is permanent (level-gated, not removed), surfaces the launch
+configuration before the failing `<<<1, block_dims>>>` call, and lets
+future debugging of similar K80-block-overflow crashes find the offending
+tensor immediately by name. The kernel launch is per-graph-node so the log
+volume with `GGML_CUDA_DEBUG=1` is bounded (≈ once per dispatched matmul,
+not per element).
+
+## Fix options
+
+In priority order:
+
+1. **Drop the `s.flashAttention` gate on the vision reservation.** The
+   gate is unsound: every `model/models/*/model_vision.go` passes
+   `cache=nil` to `nn.Attention`, and the SDPA fast-path in
+   `ml/nn/attention.go:84` requires `cache!=nil`. So vision always runs
+   the manual matmul path regardless of the server-level FA flag — the
+   `if s.flashAttention { maxPixels = 2048 }` branch was reserving at the
+   FA-friendly size while the actual graph still materializes the full
+   non-FA attention matrix. Smallest surface; restores the working
+   behavior from before #117 flipped `s.flashAttention` to `true` on K80.
+
+2. **Fix the kernel launch to use grid+block split.** The kernel already
+   supports `<<<grid, block>>>` (see indexing at ggml-cuda.cu:1933-1934).
+   Change `<<<1, dim3(ne13, ne12)>>>` to
+   `<<<dim3(ceil_div(ne13, bx), ceil_div(ne12, by)), dim3(bx, by)>>>` with
+   e.g. `bx = by = 32`. Upstream-shaped fix; affects all GPUs (no
+   regression risk on CC ≥ 7.0 because they hit the strided branch first).
+
+3. **Route around the broadcast/non-contig branch for K80.** Force the
+   strided path when possible — but the dispatch into the broadcast branch
+   is driven by tensor stride / broadcast factors, not GPU CC, so this
+   would require model-side reshape changes.
+
+## Resolution
+
+Applied **option 1** (`runner/ollamarunner/runner.go:1055-1067`): drop the
+`s.flashAttention` branch, cap `maxPixels` at 512 unconditionally when the
+user has not set `OLLAMA_VISION_MAX_PIXELS`. The comment in-source links
+back to this trace for the reasoning. Option 2 remains a worthwhile
+upstream-shaped fix; not done here to keep the change minimal and aimed at
+the immediate CI red.
+
+CI verification is pending — the K80 runner is the only build/run
+environment for this code path, so the proper validation is the next full
+Models suite run on this branch.
+
+## Related
+
+- #138 (this issue) — first encountered the failure
+- #117 — productized K80 FA (changed `s.flashAttention` from false to true)
+- #137 — productized FA-on default (made #117's effect happen by default)
+- #63 / #50cba688 — added the `maxPixels = 512` fallback for non-FA path;
+  the FA-on path retains the original 2048 upstream value

--- a/kvcache/recurrent.go
+++ b/kvcache/recurrent.go
@@ -595,6 +595,13 @@ func (c *Recurrent) convBuffer(layer int) ml.Tensor {
 
 	buf := c.convCtxs[layer].Zeros(ml.DTypeF32, c.convDim*c.convChannels, c.maxSequences)
 	c.convStates[layer] = buf
+	bytes := uint64(c.convDim) * uint64(c.convChannels) * uint64(c.maxSequences) * 4 // DTypeF32
+	slog.Debug("recurrent: conv state allocated",
+		"layer", layer,
+		"conv_dim", c.convDim,
+		"conv_channels", c.convChannels,
+		"max_sequences", c.maxSequences,
+		"bytes", bytes)
 	return buf
 }
 
@@ -609,6 +616,15 @@ func (c *Recurrent) recurrentBuffer(layer int) ml.Tensor {
 
 	buf := c.recurrentCtxs[layer].Zeros(ml.DTypeF32, c.recurrentStateSize, c.maxSequences)
 	c.recurrentStates[layer] = buf
+	// Log first allocation per layer. The byte total here multiplied by the
+	// number of recurrent layers should match what shows up in the per-GPU
+	// Cache rollup (server.go buildLayout). Mismatch ⇒ accounting bug. See #138.
+	bytes := uint64(c.recurrentStateSize) * uint64(c.maxSequences) * 4 // DTypeF32
+	slog.Debug("recurrent: state allocated",
+		"layer", layer,
+		"state_size", c.recurrentStateSize,
+		"max_sequences", c.maxSequences,
+		"bytes", bytes)
 	return buf
 }
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -923,6 +923,23 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 		logutil.Trace("layer to assign", "layer", i, "size", format.HumanBytes2(layers[i]))
 	}
 
+	// Per-GPU memory rollup. When a hybrid model (e.g. qwen35) under-reports
+	// per-layer cache, this log reveals which GPU is missing the recurrent
+	// state contribution that buildLayout would otherwise size correctly.
+	// See issue #138.
+	for j := range memory.GPUs {
+		var weights, cache uint64
+		for i := range memory.GPUs[j].Weights {
+			weights += memory.GPUs[j].Weights[i]
+			cache += memory.GPUs[j].Cache[i]
+		}
+		slog.Debug("buildLayout: gpu rollup",
+			"id", memory.GPUs[j].ID,
+			"weights", format.HumanBytes2(weights),
+			"cache", format.HumanBytes2(cache),
+			"graph", format.HumanBytes2(memory.GPUs[j].Graph))
+	}
+
 	gpuLayers := ml.GPULayersList{}
 	for _, gl := range ml.ByLibrary(gpus) {
 		// If a GPU already has a graph allocated on it, then we should continue to use it.
@@ -961,10 +978,25 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 			}
 		}
 
+		// lastUsedGPU pins the layout floor: assignLayers won't try fewer GPUs
+		// than this. The intent is cycle prevention (see comment above), but
+		// the side-effect is that once a transient over-allocation places graph
+		// on GPU N, subsequent iterations stay at >= N+1 GPUs even if fewer
+		// would now fit. Log it so layout-instability bugs (e.g. issue #138)
+		// are diagnosable from OLLAMA_DEBUG=1 alone.
+		slog.Debug("buildLayout: stickiness pinned",
+			"library", gl[0].Library,
+			"last_used_gpu", lastUsedGPU,
+			"n_gpus_in_library", len(gl))
+
 		libraryGpuLayers := assignLayers(layers, gl, requireFull, s.options.NumGPU, lastUsedGPU)
 		if libraryGpuLayers.Sum() > gpuLayers.Sum() {
 			gpuLayers = libraryGpuLayers
 		}
+		slog.Debug("buildLayout: library result",
+			"library", gl[0].Library,
+			"layers_placed", libraryGpuLayers.Sum(),
+			"gpus_used", len(libraryGpuLayers))
 	}
 	return gpuLayers, layers, nil
 }
@@ -1042,6 +1074,12 @@ func assignLayers(layers []uint64, gpus []ml.DeviceInfo, requireFull bool, reque
 				// Try to pack things into as few GPUs as possible
 				forceRequest := i == len(gpus)-1 && !requireFull
 				gpuLayers = findBestFit(layers, gpus[:i+1], requestedLayers, forceRequest)
+				slog.Debug("assignLayers: fit attempt",
+					"n_gpus_tried", i+1,
+					"layers_placed", gpuLayers.Sum(),
+					"layers_total", len(layers),
+					"requested_layers", requestedLayers,
+					"force_request", forceRequest)
 				if gpuLayers.Sum() == len(layers) || gpuLayers.Sum() == requestedLayers {
 					break
 				}

--- a/llm/server.go
+++ b/llm/server.go
@@ -942,19 +942,20 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 
 	gpuLayers := ml.GPULayersList{}
 	for _, gl := range ml.ByLibrary(gpus) {
-		// If a GPU already has a graph allocated on it, then we should continue to use it.
-		// Otherwise, we lose information that we got from previous allocations, which can
-		// cause cycling. Plus, we get more information about required allocation from each
-		// iteration, so it doesn't make sense that a later iteration would use fewer GPUs.
-		lastUsedGPU := 0
+		// Compute per-GPU available memory after reserving graph + minimum +
+		// overhead. We deliberately do NOT pin a "lastUsedGPU" floor here:
+		// previous iterations' transient over-spills (e.g. a 3-GPU layout
+		// briefly tried during convergence) would otherwise lock the planner
+		// into >= 3 GPUs forever, even when later iterations have data
+		// showing 2 GPUs fit. See issue #138 — qwen3.5:27b ghost-allocated
+		// 93 MiB on a 3rd die because of exactly this ratchet behavior.
+		// Cycle prevention is handled by the pastAllocations hash check at
+		// the call site (server.go ~line 759), which detects revisited
+		// layouts without needing to monotonically grow GPU count.
 		for i := range gl {
 			found := false
 			for j := range memory.GPUs {
 				if gl[i].DeviceID == memory.GPUs[j].DeviceID {
-					if memory.GPUs[j].Graph != 0 {
-						lastUsedGPU = i
-					}
-
 					reserved := uint64(float32(gl[i].FreeMemory)*backoff) + gl[i].MinimumMemory() + envconfig.GpuOverhead() + memory.GPUs[j].Graph
 					if gl[i].FreeMemory > reserved {
 						gl[i].FreeMemory -= reserved
@@ -978,18 +979,7 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 			}
 		}
 
-		// lastUsedGPU pins the layout floor: assignLayers won't try fewer GPUs
-		// than this. The intent is cycle prevention (see comment above), but
-		// the side-effect is that once a transient over-allocation places graph
-		// on GPU N, subsequent iterations stay at >= N+1 GPUs even if fewer
-		// would now fit. Log it so layout-instability bugs (e.g. issue #138)
-		// are diagnosable from OLLAMA_DEBUG=1 alone.
-		slog.Debug("buildLayout: stickiness pinned",
-			"library", gl[0].Library,
-			"last_used_gpu", lastUsedGPU,
-			"n_gpus_in_library", len(gl))
-
-		libraryGpuLayers := assignLayers(layers, gl, requireFull, s.options.NumGPU, lastUsedGPU)
+		libraryGpuLayers := assignLayers(layers, gl, requireFull, s.options.NumGPU, 0)
 		if libraryGpuLayers.Sum() > gpuLayers.Sum() {
 			gpuLayers = libraryGpuLayers
 		}

--- a/llm/server.go
+++ b/llm/server.go
@@ -942,20 +942,37 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 
 	gpuLayers := ml.GPULayersList{}
 	for _, gl := range ml.ByLibrary(gpus) {
-		// Compute per-GPU available memory after reserving graph + minimum +
-		// overhead. We deliberately do NOT pin a "lastUsedGPU" floor here:
-		// previous iterations' transient over-spills (e.g. a 3-GPU layout
-		// briefly tried during convergence) would otherwise lock the planner
-		// into >= 3 GPUs forever, even when later iterations have data
-		// showing 2 GPUs fit. See issue #138 — qwen3.5:27b ghost-allocated
-		// 93 MiB on a 3rd die because of exactly this ratchet behavior.
-		// Cycle prevention is handled by the pastAllocations hash check at
-		// the call site (server.go ~line 759), which detects revisited
-		// layouts without needing to monotonically grow GPU count.
+		// lastUsedGPU pins the layout floor: assignLayers won't try fewer
+		// GPUs than this. The original predicate was `memory.GPUs[j].Graph != 0`,
+		// which over-pinned: any transient graph spillover (e.g. compute
+		// graph briefly placed on a 3rd GPU during convergence) would
+		// permanently lock that GPU into the layout, even when later
+		// iterations had data showing fewer would fit. See #138.
+		//
+		// Refined predicate: pin only when a GPU has been assigned actual
+		// layer data (weights or cache). A pure-graph allocation is a
+		// trial-balloon that should not influence the floor; a layer
+		// assignment reflects the runner having decided the GPU is
+		// genuinely needed. This still protects models that don't fit on
+		// fewer GPUs (e.g. qwen3-vl:30b ~19 GiB needs 2+ K80 dies — the
+		// ratchet correctly maintains lastUsedGPU>=1 once layers land
+		// there) while letting the planner shrink past transient ghosts.
+		lastUsedGPU := 0
 		for i := range gl {
 			found := false
 			for j := range memory.GPUs {
 				if gl[i].DeviceID == memory.GPUs[j].DeviceID {
+					gpuHasLayerData := false
+					for k := range memory.GPUs[j].Weights {
+						if memory.GPUs[j].Weights[k] != 0 || memory.GPUs[j].Cache[k] != 0 {
+							gpuHasLayerData = true
+							break
+						}
+					}
+					if gpuHasLayerData {
+						lastUsedGPU = i
+					}
+
 					reserved := uint64(float32(gl[i].FreeMemory)*backoff) + gl[i].MinimumMemory() + envconfig.GpuOverhead() + memory.GPUs[j].Graph
 					if gl[i].FreeMemory > reserved {
 						gl[i].FreeMemory -= reserved
@@ -967,7 +984,8 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 						"available layer vram", format.HumanBytes2(gl[i].FreeMemory),
 						"backoff", fmt.Sprintf("%.2f", backoff), "minimum", format.HumanBytes2(gl[i].MinimumMemory()),
 						"overhead", format.HumanBytes2(envconfig.GpuOverhead()),
-						"graph", format.HumanBytes2(memory.GPUs[j].Graph))
+						"graph", format.HumanBytes2(memory.GPUs[j].Graph),
+						"has_layer_data", gpuHasLayerData)
 
 					found = true
 					break
@@ -979,7 +997,12 @@ func (s *ollamaServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.Backen
 			}
 		}
 
-		libraryGpuLayers := assignLayers(layers, gl, requireFull, s.options.NumGPU, 0)
+		slog.Debug("buildLayout: stickiness pinned",
+			"library", gl[0].Library,
+			"last_used_gpu", lastUsedGPU,
+			"n_gpus_in_library", len(gl))
+
+		libraryGpuLayers := assignLayers(layers, gl, requireFull, s.options.NumGPU, lastUsedGPU)
 		if libraryGpuLayers.Sum() > gpuLayers.Sum() {
 			gpuLayers = libraryGpuLayers
 		}

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2167,6 +2167,22 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
 
         size_t src1_stride_size = sizeof(cuda_t);
 
+        // Surface the launch config for the broadcast/non-contig batched-cublas
+        // path: this kernel packs `ne12 * ne13` threads into a single block, so
+        // any matmul where that product exceeds the device's
+        // maxThreadsPerBlock (1024 on Tesla K80 / CC 3.7) fails the launch with
+        // cudaErrorInvalidConfiguration. Reuses the `debug_enabled` flag set
+        // earlier in this function (GGML_CUDA_DEBUG=1).
+        if (debug_enabled) {
+            fprintf(stderr,
+                    "DEBUG batched_cublas k_compute_batched_ptrs: "
+                    "ne02=%lld ne03=%lld ne12=%lld ne13=%lld threads_per_block=%lld "
+                    "src0_name=\"%s\" src1_name=\"%s\" dst_name=\"%s\"\n",
+                    (long long)ne02, (long long)ne03, (long long)ne12, (long long)ne13,
+                    (long long)(ne12 * ne13),
+                    src0->name, src1->name, dst->name);
+        }
+
         dim3 block_dims(ne13, ne12);
         k_compute_batched_ptrs<<<1, block_dims, 0, main_stream>>>(
                 src0_ptr, src1_ptr, dst_t,

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1049,16 +1049,29 @@ func (s *Server) reserveWorstCaseGraph(prompt bool) error {
 		defer mmCtx.Close()
 
 		// Determine max image size for vision reservation.
-		// Without flash attention (e.g. K80 compute 3.7), large images produce
-		// impractical attention matrices in the vision encoder (e.g. 1540px mistral3
-		// = 12,100 patches = 8.7 GiB). Default to 512px without flash attention.
+		//
+		// Vision-tower attention always runs the manual matmul path in this
+		// codebase: every model/models/*/model_vision.go calls nn.Attention
+		// with cache=nil, and the SDPA fast-path in ml/nn/attention.go:84
+		// requires cache!=nil. So the server-level s.flashAttention flag —
+		// which gates the *text-side* SDPA — does not change anything in the
+		// vision encoder. The reservation cap below must be the non-FA value
+		// regardless of s.flashAttention; otherwise the FA-on default
+		// reserves at 2048px while the actual graph still materializes the
+		// full [patches × patches × heads] attention matrix.
+		//
+		// Without FA, 2048×2048 on K80 trips two limits:
+		//   1. VRAM — ~12k patches × heads ≈ 8.7 GiB per layer (#63,
+		//      50cba688 originally introduced the 512px fallback for this).
+		//   2. The batched-cublas kernel launch limit — k_compute_batched_ptrs
+		//      packs ne12*ne13 into a single block and K80 (CC 3.7) caps at
+		//      1024 threads/block (see docs/traces/qwen3vl-batched-cublas-launch.md
+		//      for the trace surfaced via #138).
+		// 512px keeps both budgets safe across current vision models.
+		// Users with larger inference inputs can raise via OLLAMA_VISION_MAX_PIXELS.
 		maxPixels := int(envconfig.VisionMaxPixels())
 		if maxPixels == 0 {
-			if s.flashAttention {
-				maxPixels = 2048
-			} else {
-				maxPixels = 512
-			}
+			maxPixels = 512
 		}
 		img := image.NewGray(image.Rect(0, 0, maxPixels, maxPixels))
 		var buf bytes.Buffer


### PR DESCRIPTION
## Summary

- Fix the scheduler's `last_used_gpu` ratchet so qwen3.5:27b stops ghost-allocating 93 MiB on a 3rd K80 die — fits cleanly on 2 GPUs (TC-MODELS-010 `GPU_COUNT_OK`).
- Fix an unrelated qwen3-vl crash surfaced while verifying the above: the worst-case multimodal graph reservation gates on `s.flashAttention` to pick 2048-vs-512-px reservation image, but vision tower never uses FA (cache=nil at every `model_vision.go` call site, SDPA fast-path requires cache!=nil) — the 2048-px path on K80 then trips the batched-cublas kernel launch limit (`k_compute_batched_ptrs<<<1, dim3(ne13, ne12)>>>`, K80 caps at 1024 threads/block). Drop the FA gate; always cap at 512 unless `OLLAMA_VISION_MAX_PIXELS` is set.
- Add a permanent level-gated debug log at the kernel launch site (`GGML_CUDA_DEBUG=1`) printing `ne02/ne03/ne12/ne13/threads_per_block` and tensor names — reuses the existing static-bool flag in the same function. Permanent, makes any future K80 launch-overflow in this code path immediately diagnosable.
- Full call-chain + RCA in `docs/traces/qwen3vl-batched-cublas-launch.md`.

Fixes #138.

## Test plan

CI on issue-138-scheduler-recurrent-accounting after `108d7055`:

- [x] Build Verification — build artifact clean (run [25738616495](https://github.com/dogkeeper886/ollama37/actions/runs/25738616495); LLM judge timeout flake unrelated to commit)
- [x] Runtime Tests (simple) — 4/4 pass (run [25780647299](https://github.com/dogkeeper886/ollama37/actions/runs/25780647299))
- [x] Models Tests (simple) — **13/13 pass** (run [25780951985](https://github.com/dogkeeper886/ollama37/actions/runs/25780951985))

Targeted layout results from the Models run:

| Test | Model | GPUs | VRAM | Result |
|---|---|---|---|---|
| TC-MODELS-010 | qwen3.5:27b | **2** (10789 + 10687) | 21476 MiB | ✅ `GPU_COUNT_OK` — scheduler fix |
| TC-MODELS-011 | qwen3-vl:8b | 1 (6631) | 6631 MiB | ✅ `GPU_COUNT_OK` — vision reservation fix |
| TC-MODELS-012 | qwen3-vl:30b | 2 (9841 + 9745) | 19586 MiB | ✅ `GPU_COUNT_OK` |

Regression sweep: TC-MODELS-001..009, -013 all green — no collateral damage from either the planner change or the vision cap.

### Acceptance criteria (from #138)

1. ✅ qwen3.5:27b fits on 2 K80 GPUs with FA on + q8_0 KV
2. ✅ TC-MODELS-010 passes
3. ✅ Other multi-GPU layouts unaffected (TC-MODELS-002 / -007 / -009 all green)

## Commits

- `a70a35c9` — Add permanent debug logs for layout decisions and recurrent allocation
- `e20ce9c9` — Fix #138: don't ratchet `last_used_gpu` upward
- `d2670ecf` — Fix #138: refine `lastUsedGPU` predicate, don't disable it
- `108d7055` — Cap vision reservation at 512px regardless of FA setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)