### PR TITLE
Fix #107: enable FA on qwen35 (hybrid DeltaNet + attention)

### DIFF
--- a/docs/research/k80-fa-model-coverage.md
+++ b/docs/research/k80-fa-model-coverage.md
@@ -2,7 +2,7 @@
 
 **Issues**: [#122](https://github.com/dogkeeper886/ollama37/issues/122) (Phase 1) and [#123](https://github.com/dogkeeper886/ollama37/issues/123) (Phase 2) of [#121](https://github.com/dogkeeper886/ollama37/issues/121)
 **Date**: 2026-04-27 (Phase 1 + Phase 2 results)
-**Status**: Empirical verification of 3 representatives complete. Phase 3 (#124) ready with a seeded allowlist.
+**Status**: Empirical verification complete for 5 architectures (Phase 2 representatives + qwen35 via #107). Phase 3 allowlist seeded and extended.
 
 ## TL;DR (after Phase 2)
 
@@ -22,6 +22,23 @@ Phase 2 corrected one Phase 1 assumption and confirmed three predictions:
 | [24978699810](https://github.com/dogkeeper886/ollama37/actions/runs/24978699810) | deepseek-r1:14b | qwen2 | **llama.cpp** (llamarunner) | ✅ | ✅ thinking-model; coherent | KV size not in logs (different log format on llama.cpp path) |
 
 **Key finding**: 4 different architectures empirically validated. The new-engine models (gemma3, gptoss, qwen3vl) all produce correct output with FA. deepseek-r1's qwen2 path goes through llama.cpp and works via the existing head-count gate — not affected by Phase 3 changes.
+
+## qwen35 follow-up validation (via #107, 2026-05-13)
+
+Phase 2 deferred qwen35 with the note *"requires empirical validation of hybrid SSM+attention output correctness with FA enabled."* That validation was triggered while investigating #107 (asymmetric K-only KV quant), which was rendered obsolete if FA + symmetric Q8 KV could be made to work on qwen35.
+
+Methodology was the existing `test-fa-k80.yml` benchmark mode (3 configs: off-f16 / on-f16 / on-q8_0), prefixed by a 1-line allowlist patch adding `"qwen35"` to `SupportsFlashAttentionInNewEngine`.
+
+| Run | Model | GPUs used | FA enables? | Output coherent? | VRAM Δ (off→on-q8_0) | tok/s Δ |
+|---|---|---|---|---|---|---|
+| [25799484945](https://github.com/dogkeeper886/ollama37/actions/runs/25799484945) | qwen3.5:9b | 1 | ✅ | ✅ thinking-coherent across all 3 configs; on-f16 ≡ on-q8_0 same structure | -138 MiB (-1.8%) | -1.4% |
+| [25799818450](https://github.com/dogkeeper886/ollama37/actions/runs/25799818450) | qwen3.5:27b | 2 (34+31 layer split) | ✅ | ✅ **bit-identical** thinking output across all 3 configs | -174 MiB (-1.6%) | -0.8% |
+
+**VRAM savings smaller than Phase 2 baselines** (~1-2% here vs ~47% for gemma3). Expected: qwen35 is hybrid — only attention layers use KV cache (DeltaNet layers use a recurrent state, unaffected by FA or KV quant), and at 4k ctx the attention-layer KV is small. The fraction-of-a-small-thing pattern matches the architecture. FA benefit would compound at longer context.
+
+**Tokens/sec essentially flat** (within ±1.5%). No speedup, no regression. The fewer-attention-layers structure means FA's compute savings have less surface area to apply.
+
+**Resolution**: qwen35 added to `SupportsFlashAttentionInNewEngine` allowlist. This obsoletes the original framing of #107 (K-only Q8 was a workaround for the unavailable FA path — now the FA path is available).
 
 ## Workflow caveats discovered during Phase 2
 

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -923,10 +923,14 @@ func (f GGML) SupportsFlashAttentionInNewEngine() bool {
 		"qwen3vl", // validated #123 Phase 2 (qwen3-vl:8b run 24978521066)
 		// "qwen3vlmoe" — same Go package as qwen3vl; presumed safe but
 		// untested. Add when a qwen3-vl:30b benchmark validates it.
-		// "qwen35" — currently in SupportsFlashAttention deny list. Adding
-		// here would bypass the deny but requires empirical validation of
-		// hybrid SSM+attention output correctness with FA enabled. See
-		// docs/traces/qwen35-flash-attention-gate.md.
+		"qwen35", // validated #107: qwen3.5:9b run 25799484945 (coherent A/B/C),
+		//            qwen3.5:27b run 25799818450 (bit-identical A/B/C output).
+		//            Hybrid DeltaNet + attention: only attention layers use the
+		//            FA path; recurrent layers are unaffected. The deny in
+		//            SupportsFlashAttention (legacy llama.cpp head-count check)
+		//            still applies — this allowlist bypasses it for the new
+		//            engine only. With FA on, symmetric Q8 KV works on
+		//            attention layers, obsoleting the K-only-quant path in #107.
 	}, f.KV().Architecture())
 }
 


### PR DESCRIPTION
## Summary

- Add `qwen35` to `SupportsFlashAttentionInNewEngine` so qwen3.5 (hybrid DeltaNet + attention) gets FA on the new-engine attention path.
- The legacy `SupportsFlashAttention` deny is preserved — its head-count check still fails for hybrid geometry and that's correct (qwen35 only runs on the new engine, forced by `OllamaEngineRequired`).
- Obsoletes the asymmetric K-only KV-quant plan from the original framing of #107. With FA on, qwen3.5 gets symmetric Q8 KV through the same mechanism every other supported model uses — no asymmetric-quant plumbing, no new env var.

## Why the original #107 plan is no longer needed

#107 was opened as a workaround when FA was unavailable for K80: llama.cpp's V-quant-needs-FA constraint blocked any KV quant on qwen35, so K-only-quant was the only quantization shape available. After #117 (productize K80 FA) and #137 (FA-on default), the FA path is live for every model the new engine handles — except qwen35, which was deferred from Phase 2 (#123) pending hybrid-attention validation. This PR runs that deferred validation and closes the gap.

## Test plan

Validation harness: `test-fa-k80.yml` benchmark mode (3 configs: FA-off f16 / FA-on f16 / FA-on q8_0), executed on the validation branch.

- [x] Build Verification (simple) — [run 25797681307](https://github.com/dogkeeper886/ollama37/actions/runs/25797681307) ✅ 3/3
- [x] Runtime Tests (simple) — [run 25798524194](https://github.com/dogkeeper886/ollama37/actions/runs/25798524194) ✅ 4/4
- [x] K80 FA Validation — qwen3.5:9b — [run 25799484945](https://github.com/dogkeeper886/ollama37/actions/runs/25799484945) ✅ FA engaged; off/on/on-q8_0 all produce coherent thinking-trace output with the same structure
- [x] K80 FA Validation — qwen3.5:27b — [run 25799818450](https://github.com/dogkeeper886/ollama37/actions/runs/25799818450) ✅ FA engaged; **bit-identical thinking output** across all 3 configs
- [x] Models Tests (simple, full regression) — [run 25800632502](https://github.com/dogkeeper886/ollama37/actions/runs/25800632502) ✅ **13/13 pass**

### qwen3.5 results in the regression run

| Test | GPUs | VRAM | Pre-PR (#138 main) | After this PR | Δ |
|---|---|---|---|---|---|
| TC-MODELS-004 qwen3.5:9b | 1 | 7516 MiB | ~7660 MiB f16 (from FA-validation baseline) | 7516 MiB q8_0 + FA | ~-140 MiB |
| TC-MODELS-010 qwen3.5:27b | 2 | 21117 MiB | 21476 MiB f16 (no FA) | 21117 MiB q8_0 + FA | -359 MiB |

VRAM deltas modest at the test context size (8k); benefit compounds at longer ctx since qwen35 is hybrid — only the attention layers see KV/FA savings.

Other 11 models pass identically — no collateral.

## Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)