### PR TITLE
Scope LLM judge to response evaluation; opt-in via --llm

### DIFF
--- a/.claude/commands/build-test/test.md
+++ b/.claude/commands/build-test/test.md
@@ -17,8 +17,8 @@ npm run test -- --suite runtime
 npm run test -- --suite inference
 npm run test -- --suite models
 
-# Run without LLM judge
-npm run test -- --no-llm
+# Run with LLM judge enabled (default is simple judge only)
+npm run test -- --llm
 
 # List available tests
 npm run list

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,19 +7,6 @@ on:
         description: "Run a single test by ID (e.g. TC-BUILD-002)"
         required: false
         type: string
-      judge_mode:
-        description: "Test judge mode"
-        required: false
-        default: "dual"
-        type: choice
-        options:
-          - "simple"
-          - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -27,16 +14,6 @@ on:
         type: boolean
   workflow_call:
     inputs:
-      judge_mode:
-        description: "Test judge mode (simple, dual)"
-        required: false
-        default: "dual"
-        type: string
-      judge_model:
-        description: "LLM model for judging"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -75,20 +52,8 @@ jobs:
         run: |
           cd cicd/tests
 
-          # Build judge flags based on input
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            # dual mode (default) - both judges run
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
-          fi
-
           echo "Ollama version: $OLLAMA_VERSION"
-          echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
-          echo "Judge flags: $JUDGE_FLAGS"
 
-          # Run tests with JSON output
           # Build test ID flag if provided
           ID_FLAG=""
           if [ -n "${{ inputs.test_id }}" ]; then
@@ -96,7 +61,7 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite build $ID_FLAG $JUDGE_FLAGS --format json > /tmp/build-results.json || true
+          npx tsx src/cli.ts run --suite build $ID_FLAG --no-llm --format json > /tmp/build-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/build-results.json

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -61,7 +61,7 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite build $ID_FLAG --no-llm --format json > /tmp/build-results.json || true
+          npx tsx src/cli.ts run --suite build $ID_FLAG --format json > /tmp/build-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/build-results.json

--- a/.github/workflows/test-fa-k80.yml
+++ b/.github/workflows/test-fa-k80.yml
@@ -67,10 +67,23 @@ jobs:
     with:
       debug: false
 
+  # Recreate the production ollama37 container from the freshly built image.
+  # Without this, the existing container instance keeps its old image even
+  # though `ollama37:latest` on disk is new; subsequent `docker start ollama37`
+  # would bring the stale container back online. TC-RUNTIME-001 runs
+  # `docker compose down && up -d`, which picks up the new image.
+  runtime:
+    name: Recreate runtime container on new image
+    needs: build
+    if: ${{ !inputs.skip_build && needs.build.result == 'success' }}
+    uses: ./.github/workflows/test-runtime.yml
+    with:
+      debug: false
+
   validate:
     name: FA inference + log capture
-    needs: [build]
-    if: ${{ always() && (inputs.skip_build || needs.build.result == 'success') }}
+    needs: [build, runtime]
+    if: ${{ always() && (inputs.skip_build || (needs.build.result == 'success' && needs.runtime.result == 'success')) }}
     runs-on: self-hosted
     environment: cicd-1
     timeout-minutes: 45

--- a/.github/workflows/test-fa-k80.yml
+++ b/.github/workflows/test-fa-k80.yml
@@ -358,6 +358,14 @@ jobs:
         run: |
           set -e
 
+          # Fail loud if the inference step succeeded but produced no
+          # response.json files - otherwise the loop below walks zero
+          # entries and silently reports PASS.
+          if ! ls /tmp/fa-test/*/response.json >/dev/null 2>&1; then
+            echo "::error::No inference responses captured under /tmp/fa-test/ - nothing to judge"
+            exit 1
+          fi
+
           CRITERIA="PROMPT: ${FA_PROMPT}
 
           Response must be coherent English prose that directly addresses the prompt above. Garbled output, infinite repetition, off-topic content, single-word/single-character responses, or empty responses fail. Truncation at the num_predict limit is acceptable as long as the visible text is coherent."

--- a/.github/workflows/test-fa-k80.yml
+++ b/.github/workflows/test-fa-k80.yml
@@ -65,7 +65,6 @@ jobs:
     if: ${{ !inputs.skip_build }}
     uses: ./.github/workflows/test-build.yml
     with:
-      judge_mode: simple
       debug: false
 
   validate:
@@ -79,6 +78,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install test runner dependencies
+        run: cd cicd/tests && npm ci
 
       - name: Stop existing ollama37 container
         run: |
@@ -327,6 +334,80 @@ jobs:
                 '{baseline: $b, fa: $f, match: ($b == $f)}' \
                 > /tmp/fa-test/comparison.json
             fi
+          fi
+
+      - name: Judge captured responses with LLM judge
+        # Runs after the test container is stopped (VRAM freed) and before
+        # production ollama37 comes back up. Talks to the ollama37-judge
+        # container on port 11435.
+        env:
+          FA_PROMPT: ${{ inputs.prompt }}
+        run: |
+          set -e
+
+          CRITERIA="PROMPT: ${FA_PROMPT}
+
+          Response must be coherent English prose that directly addresses the prompt above. Garbled output, infinite repetition, off-topic content, single-word/single-character responses, or empty responses fail. Truncation at the num_predict limit is acceptable as long as the visible text is coherent."
+
+          cd "$GITHUB_WORKSPACE/cicd/tests"
+
+          FAILED=0
+          {
+            echo ""
+            echo "## K80 FA LLM judge verdicts"
+            echo ""
+            echo "| Config | Verdict | Reason |"
+            echo "|---|---|---|"
+          } > /tmp/fa-test/judge-table.md
+
+          for resp_file in /tmp/fa-test/*/response.json; do
+            [ -f "$resp_file" ] || continue
+            config_dir=$(dirname "$resp_file")
+            config_name=$(basename "$config_dir")
+
+            echo ""
+            echo "=========================================="
+            echo "=== Judging $config_name ==="
+            echo "=========================================="
+
+            judgment_json="$config_dir/judgment.json"
+            set +e
+            npx tsx src/cli.ts judge-response \
+              --response "$resp_file" \
+              --criteria "$CRITERIA" \
+              --test-id "FA-K80-${config_name}" \
+              --test-name "K80 FA validation - ${config_name}" \
+              --goal "FA-enabled inference produced coherent text matching the prompt" \
+              > "$judgment_json"
+            judge_exit=$?
+            set -e
+
+            if [ "$judge_exit" -eq 2 ]; then
+              echo "::warning::Judge unreachable at port 11435 - aborting remaining verdicts"
+              echo "| $config_name | judge unavailable | port 11435 not reachable |" >> /tmp/fa-test/judge-table.md
+              FAILED=1
+              break
+            fi
+
+            pass=$(jq -r '.pass' "$judgment_json")
+            reason=$(jq -r '.reason' "$judgment_json" | tr '\n|' '  ' | cut -c1-200)
+
+            if [ "$pass" = "true" ]; then
+              verdict="PASS"
+            else
+              verdict="FAIL"
+              FAILED=1
+            fi
+
+            echo "[$config_name] $verdict - $reason"
+            echo "| $config_name | $verdict | $reason |" >> /tmp/fa-test/judge-table.md
+          done
+
+          cat /tmp/fa-test/judge-table.md >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::LLM judge marked one or more FA responses as failing or could not be reached"
+            exit 1
           fi
 
       - name: Restart production ollama37

--- a/.github/workflows/test-inference.yml
+++ b/.github/workflows/test-inference.yml
@@ -8,9 +8,9 @@ on:
         required: false
         type: string
       judge_mode:
-        description: "Test judge mode"
+        description: "Test judge mode (simple = SimpleJudge only; dual = also run LLMJudge)"
         required: false
-        default: "dual"
+        default: "simple"
         type: choice
         options:
           - "simple"
@@ -30,7 +30,7 @@ on:
       judge_mode:
         description: "Test judge mode (simple, dual)"
         required: false
-        default: "dual"
+        default: "simple"
         type: string
       judge_model:
         description: "LLM model for judging"
@@ -78,16 +78,14 @@ jobs:
         run: |
           cd cicd/tests
 
-          # Build judge flags based on input
+          # Build judge flags based on input. Default is simple (SimpleJudge
+          # only); dual adds the LLMJudge via --llm.
           JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            # dual mode (default) - both judges run
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
+          if [ "${{ inputs.judge_mode }}" = "dual" ]; then
+            JUDGE_FLAGS="--llm --judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
           fi
 
-          echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
+          echo "Judge mode: ${{ inputs.judge_mode || 'simple' }}"
           echo "Judge flags: $JUDGE_FLAGS"
 
           # Run tests with JSON output

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -8,9 +8,9 @@ on:
         required: false
         type: string
       judge_mode:
-        description: "Test judge mode"
+        description: "Test judge mode (simple = SimpleJudge only; dual = also run LLMJudge)"
         required: false
-        default: "dual"
+        default: "simple"
         type: choice
         options:
           - "simple"
@@ -30,7 +30,7 @@ on:
       judge_mode:
         description: "Test judge mode (simple, dual)"
         required: false
-        default: "dual"
+        default: "simple"
         type: string
       judge_model:
         description: "LLM model for judging"
@@ -75,16 +75,14 @@ jobs:
         run: |
           cd cicd/tests
 
-          # Build judge flags based on input
+          # Build judge flags based on input. Default is simple (SimpleJudge
+          # only); dual adds the LLMJudge via --llm.
           JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            # dual mode (default) - both judges run
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
+          if [ "${{ inputs.judge_mode }}" = "dual" ]; then
+            JUDGE_FLAGS="--llm --judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
           fi
 
-          echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
+          echo "Judge mode: ${{ inputs.judge_mode || 'simple' }}"
           echo "Judge flags: $JUDGE_FLAGS"
 
           # Build test ID flag if provided

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       judge_mode:
-        description: "Test judge mode"
+        description: "Test judge mode for inference + models (simple = SimpleJudge only; dual = also run LLMJudge)"
         required: false
-        default: "dual"
+        default: "simple"
         type: choice
         options:
           - "simple"

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -27,8 +27,6 @@ jobs:
     name: Build Tests
     uses: ./.github/workflows/test-build.yml
     with:
-      judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       debug: ${{ inputs.debug }}
 
   runtime:
@@ -36,8 +34,6 @@ jobs:
     needs: build
     uses: ./.github/workflows/test-runtime.yml
     with:
-      judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       debug: ${{ inputs.debug }}
 
   inference:

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -7,19 +7,6 @@ on:
         description: "Run a single test by ID (e.g. TC-RUNTIME-001)"
         required: false
         type: string
-      judge_mode:
-        description: "Test judge mode"
-        required: false
-        default: "dual"
-        type: choice
-        options:
-          - "simple"
-          - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -27,16 +14,6 @@ on:
         type: boolean
   workflow_call:
     inputs:
-      judge_mode:
-        description: "Test judge mode (simple, dual)"
-        required: false
-        default: "dual"
-        type: string
-      judge_model:
-        description: "LLM model for judging"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -75,19 +52,6 @@ jobs:
         run: |
           cd cicd/tests
 
-          # Build judge flags based on input
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            # dual mode (default) - both judges run
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
-          fi
-
-          echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
-          echo "Judge flags: $JUDGE_FLAGS"
-
-          # Run tests with JSON output
           # Build test ID flag if provided
           ID_FLAG=""
           if [ -n "${{ inputs.test_id }}" ]; then
@@ -95,7 +59,7 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite runtime $ID_FLAG $JUDGE_FLAGS --format json > /tmp/runtime-results.json || true
+          npx tsx src/cli.ts run --suite runtime $ID_FLAG --no-llm --format json > /tmp/runtime-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/runtime-results.json

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -59,7 +59,7 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite runtime $ID_FLAG --no-llm --format json > /tmp/runtime-results.json || true
+          npx tsx src/cli.ts run --suite runtime $ID_FLAG --format json > /tmp/runtime-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/runtime-results.json

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -19,8 +19,8 @@ npm run test -- --suite build
 npm run test -- --suite runtime
 npm run test -- --suite inference
 
-# Run without LLM judge
-npm run test -- --no-llm
+# Run with LLM judge enabled (default is simple judge only)
+npm run test -- --llm
 
 # List available tests
 npm run list

--- a/cicd/docs/CICD.md
+++ b/cicd/docs/CICD.md
@@ -262,8 +262,8 @@ npm run test -- --suite build
 npm run test -- --suite runtime
 npm run test -- --suite inference
 
-# Run without LLM judge
-npm run test -- --no-llm
+# Run with LLM judge enabled (default is simple judge only)
+npm run test -- --llm
 
 # List available tests
 npm run list

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -5,16 +5,17 @@
  * Usage:
  *   npx tsx src/cli.ts run [options]
  *   npx tsx src/cli.ts list [options]
+ *   npx tsx src/cli.ts judge-response [options]
  */
 
 import { Command } from 'commander';
 import path from 'path';
-import { mkdirSync, existsSync } from 'fs';
+import { mkdirSync, existsSync, readFileSync } from 'fs';
 import { TestLoader } from './loader.js';
 import { TestExecutor } from './executor.js';
 import { SimpleJudge, LLMJudge } from './judge/index.js';
 import { JsonReporter, ConsoleReporter } from './reporter/index.js';
-import { RunConfig, DEFAULT_CONFIG } from './types.js';
+import { RunConfig, DEFAULT_CONFIG, TestCase, TestResult, StepResult } from './types.js';
 
 const program = new Command();
 
@@ -218,6 +219,81 @@ program
 
     console.log('\n' + '='.repeat(60));
     console.log(`Total: ${testCases.length} test(s)`);
+  });
+
+/**
+ * judge-response — grade a single captured inference response with the LLM judge.
+ *
+ * Built for workflows like test-fa-k80.yml that produce a /api/generate response
+ * outside the run framework but still want the LLM judge's verdict on whether
+ * the captured text makes sense for the prompt.
+ *
+ * Reads a response file (an Ollama /api/generate JSON body with a `.response`
+ * field, or a raw text file), wraps it in a synthetic TestResult, runs LLMJudge
+ * on it, prints the Judgment as JSON to stdout, and exits non-zero on fail.
+ */
+program
+  .command('judge-response')
+  .description('Run the LLM judge against a single saved inference response')
+  .requiredOption('--response <path>', 'Path to a JSON file with a .response field, or a raw text file')
+  .requiredOption('--criteria <text>', 'Evaluation criteria for the LLM judge')
+  .option('--test-id <id>', 'Test identifier surfaced to the judge', 'AD-HOC')
+  .option('--test-name <name>', 'Test name surfaced to the judge', 'Ad-hoc inference judgment')
+  .option('--goal <text>', 'One-line test objective for judge context')
+  .option('--judge-url <url>', 'Ollama URL for the LLM judge', 'http://localhost:11435')
+  .option('--judge-model <model>', 'Model to use for LLM judging', 'gemma3:12b-judge')
+  .action(async (options) => {
+    let responseText: string;
+    const raw = readFileSync(options.response, 'utf-8');
+    try {
+      const parsed = JSON.parse(raw);
+      // /api/generate returns {response: "...", ...}; fall back to the raw body
+      // if there's no .response field (e.g., user passed a plain text file).
+      responseText = typeof parsed.response === 'string' ? parsed.response : raw;
+    } catch {
+      responseText = raw;
+    }
+
+    const testCase: TestCase = {
+      id: options.testId,
+      name: options.testName,
+      suite: 'inference',
+      priority: 1,
+      timeout: 0,
+      dependencies: [],
+      goal: options.goal,
+      steps: [{ name: 'inference', command: '(captured response)' }],
+      criteria: options.criteria,
+    };
+
+    const stepResult: StepResult = {
+      name: 'inference',
+      command: '(captured response)',
+      stdout: responseText,
+      stderr: '',
+      exitCode: 0,
+      duration: 0,
+    };
+
+    const result: TestResult = {
+      testCase,
+      steps: [stepResult],
+      totalDuration: 0,
+      logs: '',
+      logFile: '',
+    };
+
+    const llmJudge = new LLMJudge(options.judgeUrl, options.judgeModel);
+    if (!(await llmJudge.isAvailable())) {
+      process.stderr.write(`[ERROR] LLM judge not reachable at ${options.judgeUrl}\n`);
+      process.exit(2);
+    }
+
+    const [judgment] = await llmJudge.judgeResults([result]);
+    await llmJudge.unloadModel();
+
+    process.stdout.write(JSON.stringify(judgment, null, 2) + '\n');
+    process.exit(judgment.pass ? 0 : 1);
   });
 
 program.parse();

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -33,7 +33,7 @@ program
   .option('-s, --suite <suite>', 'Run only tests from this suite (build, runtime, inference, models)')
   .option('-i, --id <id>', 'Run only the test with this ID')
   .option('--dry-run', 'Show what would run without executing', false)
-  .option('--no-llm', 'Skip LLM judging (simple judge only)')
+  .option('--llm', 'Also run the LLM judge (default: simple judge only)', false)
   .option('--judge-url <url>', 'Ollama URL for LLM judge', 'http://localhost:11435')
   .option('--judge-model <model>', 'Model to use for LLM judging', 'gemma3:12b-judge')
   .option('-o, --output-dir <dir>', 'Output directory for results')

--- a/cicd/tests/src/judge/llm-judge.ts
+++ b/cicd/tests/src/judge/llm-judge.ts
@@ -1,14 +1,13 @@
 /**
- * LLM Judge - Semantic analysis of test results using Ollama.
+ * LLM Judge - Semantic evaluation of an LLM's response against test criteria.
  *
- * Uses a language model to evaluate test execution logs against criteria.
- * Catches silent failures that exit code checking misses:
- * - CUDA errors that don't cause exit failures
- * - GPU fallback to CPU mode
- * - Memory allocation warnings
- * - Incorrect but non-crashing output
+ * Scope: the judge decides whether the model's response (step stdout) meets the
+ * criteria. It does NOT analyze ollama container logs, GPU detection state, or
+ * CUDA error patterns - those are SimpleJudge's domain (expect/reject patterns
+ * on logs). Keeping the two judges orthogonal stops them from second-guessing
+ * each other.
  *
- * Sends structured JSON prompt and uses Ollama JSON mode for reliable parsing.
+ * Sends a structured JSON prompt and uses Ollama JSON mode for reliable parsing.
  */
 
 import axios from 'axios';
@@ -47,12 +46,16 @@ export class LLMJudge {
 
   /**
    * Build structured JSON prompt for LLM evaluation of a single test.
+   *
+   * The prompt carries the test's criteria plus each step's stdout/stderr
+   * (where the model's response lives for inference-style tests). Container
+   * logs and infra-error rules are intentionally absent - SimpleJudge handles
+   * those via pattern matches.
    */
   private buildPrompt(result: TestResult): string {
     const r = result;
     const stdoutLimit = 1000;
     const stderrLimit = 500;
-    const logsLimit = 3000;
 
     const steps = r.steps.map((step, j) => {
       const stepDef = r.testCase.steps[j];
@@ -68,19 +71,14 @@ export class LLMJudge {
     });
 
     const promptData = {
-      role: 'You are a test result evaluator for ollama37 (Ollama fork for Tesla K80 GPU, CUDA compute 3.7). Analyze the test execution data and determine if the test passed or failed.',
+      role: 'You evaluate an LLM-generated response against a set of test criteria. Look only at the response (in step stdout) and decide whether it meets the criteria. Do not infer pass/fail from environment, GPU state, or container logs - those are checked separately.',
       rules: [
-        'Check step stdout for error responses (e.g. {"error":"model not found"} means FAIL)',
-        'CUBLAS_STATUS_* in step stdout → FAIL',
-        'cudaMalloc failed followed by "applying backoff" in container logs is NORMAL (iterative memory fitting) → NOT an error',
-        'cudaMalloc failed in step stdout without backoff context → FAIL',
-        'library=cpu in logs means GPU detection failed → FAIL',
-        'CUDA errors with exit code 0 → still FAIL',
-        'flash attention warnings on K80 are acceptable, NOT errors',
-        'For AI-generated text, accept reasonable variations (e.g. "4", "four", "The answer is 4")',
-        'Long durations within timeout are acceptable',
-        'Build times are expected to be long for CUDA compilation',
-        'GPU_COUNT_EXCEEDED in step output means the model is using more GPUs than its total VRAM requires (each K80 has 11441 MiB) → FAIL',
+        'Judge only the response text against the criteria.',
+        'An API-level error response such as {"error":"model not found"} in stdout is FAIL - the model did not produce an answer.',
+        'Empty, garbled, or repetitive nonsense output is FAIL.',
+        'Off-topic content that does not address the prompt is FAIL.',
+        'Truncation at the token limit is acceptable as long as the visible text is coherent and on-topic.',
+        'For AI-generated text, accept reasonable variations (e.g. "4", "four", "The answer is 4").',
       ],
       test: {
         id: r.testCase.id,
@@ -88,18 +86,15 @@ export class LLMJudge {
         suite: r.testCase.suite,
         goal: r.testCase.goal || r.testCase.name,
         criteria: r.testCase.criteria,
-        timeout_ms: r.testCase.timeout,
-        duration_ms: r.totalDuration,
       },
       steps,
-      container_logs: this.truncate(r.logs, logsLimit),
       respond: {
         format: 'Respond with a single JSON object',
         fields: {
           testId: r.testCase.id,
-          pass: 'true if test meets all criteria, false otherwise',
+          pass: 'true if the response meets the criteria, false otherwise',
           reason: 'Brief explanation of your verdict',
-          evidence: 'Required if pass is false — the exact stdout content or log line that caused failure',
+          evidence: 'Required if pass is false - the exact stdout content that caused failure',
         },
       },
     };
@@ -109,7 +104,7 @@ export class LLMJudge {
     // Log prompt stats
     const totalStdout = r.steps.reduce((sum, s) => sum + s.stdout.length, 0);
     const totalStderr = r.steps.reduce((sum, s) => sum + s.stderr.length, 0);
-    process.stderr.write(`  [LLM] Prompt for ${r.testCase.id}: logs ${r.logs.length} chars, stdout ${totalStdout} chars, stderr ${totalStderr} chars\n`);
+    process.stderr.write(`  [LLM] Prompt for ${r.testCase.id}: stdout ${totalStdout} chars, stderr ${totalStderr} chars\n`);
 
     return prompt;
   }

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -227,7 +227,7 @@ export interface RunConfig {
   testId?: string;
   /** Show what would run without executing */
   dryRun: boolean;
-  /** Skip LLM judging (simple judge only) */
+  /** Skip LLM judging (simple judge only). Defaults to true; opt in with --llm. */
   noLlm: boolean;
   /** URL of the LLM judge Ollama instance */
   judgeUrl: string;

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -248,7 +248,7 @@ export interface RunConfig {
  */
 export const DEFAULT_CONFIG: Partial<RunConfig> = {
   dryRun: false,
-  noLlm: false,
+  noLlm: true,
   judgeUrl: 'http://localhost:11435',
   judgeModel: 'gemma3:12b-judge',
   outputFormat: 'console',


### PR DESCRIPTION
Fixes #142

## Summary
- **LLMJudge narrowed**: prompt no longer includes container logs; CUDA/GPU/FA/build-time rules removed. The judge now decides only "does the response meet the criteria?" SimpleJudge keeps its existing job of pattern-matching logs.
- **LLM judge removed from build/runtime CI**: `test-build.yml` and `test-runtime.yml` no longer carry `judge_mode` / `judge_model` inputs. `test-pipeline.yml` keeps those inputs but only forwards them to inference + models.
- **Default flipped from `dual` → `simple` across all workflows.** *Behavior change worth flagging*: `test-inference.yml` and `test-models.yml` no longer run the LLM judge by default. The LLM-judge safety net for response-grading suites is now opt-in via `judge_mode: dual` per dispatch (or `--llm` at the CLI). Anyone relying on automatic LLM verdicts on inference/models needs to start passing `judge_mode: dual`.
- **CLI surface flipped**: `--no-llm` (opt-out) → `--llm` (opt-in). Default is SimpleJudge only; pass `--llm --judge-model X` to also run LLMJudge.
- **`judge-response` subcommand**: bridges bespoke workflows (like fa-k80) into the LLM judge — wraps a saved `response.json` in a synthetic `TestResult`, runs `LLMJudge`, prints the verdict.
- **fa-k80 wiring**: new step grades every captured FA inference response via the LLM judge; verdicts surface in the run log + step summary; workflow fails on any FAIL, unreachable judge, or zero captured responses.
- **fa-k80 image freshness fix**: inserted a `runtime` job (reusing `test-runtime.yml`) between build and validate, so the production `ollama37` container is recreated from the freshly built image instead of being restarted on the old one.

## Test plan
- [ ] Dispatch `test-build.yml` directly — no `judge_mode` input shown; run completes with SimpleJudge only.
- [ ] Dispatch `test-runtime.yml` directly — same.
- [ ] Dispatch `test-pipeline.yml` with defaults — inference and models run SimpleJudge only; total run is faster.
- [ ] Dispatch `test-pipeline.yml` with `judge_mode: dual` — inference and models also run LLMJudge; verdicts appear in JSON output.
- [ ] Dispatch `test-inference.yml` with `judge_mode: dual` — confirm the `[LLM] Prompt for ...` stderr line no longer mentions `logs N chars` (only stdout/stderr).
- [ ] Dispatch `test-fa-k80.yml` end-to-end:
  - `build` job builds a fresh image.
  - `runtime` job recreates the production container on the new image.
  - `validate` job runs FA inference, then per-config LLM judge verdicts appear in the step summary table.
  - After the run, `docker inspect ollama37` shows the new image ID (not the previous one).
- [ ] Dispatch `test-fa-k80.yml` with `skip_build: true` — build + runtime both skipped; validate runs against the existing image; LLM judge step still runs.
- [ ] Local smoke: `npm run test -- --llm --suite inference --id <one>` runs both judges; the existing READMEs/docs now show the `--llm` opt-in form rather than the removed `--no-llm` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)