### PR TITLE
v2.1.0 release: bump Docker Hub README tag

### DIFF
--- a/docker/dockerhub-readme.md
+++ b/docker/dockerhub-readme.md
@@ -33,7 +33,7 @@ Run modern LLMs on NVIDIA Tesla K80 and other CUDA Compute Capability 3.7 GPUs. 
 ### Docker (Recommended)
 ```bash
 # Pull and run
-docker pull dogkeeper886/ollama37:v2.0.3
+docker pull dogkeeper886/ollama37:v2.1.0
 docker run --runtime=nvidia --gpus all -p 11434:11434 dogkeeper886/ollama37
 ```
 


### PR DESCRIPTION
## Summary

Release branch for **v2.1.0 — K80 Performance & Observability**. Only code change in this PR is the Docker Hub README pull-tag bump (v2.0.3 → v2.1.0). All release-relevant features were merged into main earlier (#117, #136, #102, #107, #143, #98, #131, #138, #141).

## What ships in v2.1.0

- **Performance**: FA on K80 by default + q8_0 KV cache; KV rotation always-on; FA enabled for Qwen3.5 hybrid layers
- **New**: `/api/metrics` endpoint with GPU marketing names
- **Bug fixes**: ghost GPU + vision reservation overflow on K80

## Validation

Full 12-model throughput sweep against the v2.1.0 image (run [25861264249](https://github.com/dogkeeper886/ollama37/actions/runs/25861264249)) — all PASS coherence. num_predict=128, num_ctx=2048, K80 4x GPU:

| Model | Prompt tok/s | Gen tok/s | GPU% | GPU0 (MiB) | GPU1 (MiB) | GPU2 (MiB) | GPU3 (MiB) |
|-------|-------------|-----------|------|-----------|-----------|-----------|-----------|
| ministral-3:3b | 1381.13 | 18.23 | 100% | 3350 | 7 | 7 | 7 |
| gemma3:4b | 68.88 | 14.81 | 100% | 4688 | 7 | 7 | 7 |
| gpt-oss:20b | 150.53 | 13.70 | 100% | 6337 | 6502 | 7 | 7 |
| qwen3-vl:30b | 30.93 | 11.94 | 100% | 9851 | 9754 | 7 | 7 |
| qwen3-vl:8b | 34.27 | 9.48 | 100% | 6639 | 7 | 7 | 7 |
| gemma4:e4b | 56.99 | 9.32 | 100% | 9746 | 7 | 7 | 7 |
| gemma4:26b | 38.85 | 9.18 | 100% | 9164 | 9202 | 7 | 7 |
| qwen3.5:9b | 31.44 | 7.61 | 100% | 7487 | 7 | 7 | 7 |
| deepseek-r1:14b | 12.92 | 5.22 | 100% | 4630 | 7861 | 7 | 7 |
| gemma3:27b | 8.71 | 3.03 | 100% | 9780 | 9767 | 7 | 7 |
| deepseek-r1:32b | 5.44 | 2.69 | 100% | 7242 | 7128 | 9894 | 7 |
| qwen3.5:27b | 8.54 | 2.61 | 100% | 10588 | 10474 | 7 | 7 |

_Thinking models (qwen3.5, qwen3-vl, gemma4, deepseek-r1) consume the 128-token budget on reasoning; the tok/s figures measure that generation. All 12 models passed coherence checks._

Throughput rewrite (#147) + thinking-model handling (#149) landed during this release cycle and are exercised in the validation sweep.

## Post-merge steps (manual)

1. \`git tag v2.1.0\` on the merge commit
2. \`gh release create v2.1.0 --notes-file <notes>\` (notes drafted in #145 comment 4450968761)
3. \`release-docker.yml\` publishes \`dogkeeper886/ollama37:v2.1.0\` automatically; verify \`docker pull\` succeeds

Fixes #145

## Test plan

- [x] 12-model throughput sweep against v2.1.0 image — all PASS
- [x] Build (run 25850660093), runtime (run 25857575876) green
- [ ] Manual: verify Docker Hub README rendering after release-docker.yml publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)