### PR TITLE
release-docker: drop failing Docker Hub README sync step

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -83,14 +83,6 @@ jobs:
           \`\`\`
           EOF
 
-      - name: Update Docker Hub README
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ env.DOCKERHUB_REPO }}
-          readme-filepath: ./docker/dockerhub-readme.md
-
       - name: Clean up local tags
         if: always()
         run: |


### PR DESCRIPTION
## Summary

The \`peter-evans/dockerhub-description@v4\` step in \`release-docker.yml\` requires \`DOCKERHUB_USERNAME\` / \`DOCKERHUB_TOKEN\` GitHub Actions secrets that have never been configured (neither at repo nor cicd-1 env level). Surfaced during v2.1.0 release: image push succeeded but the README step failed with "Required input 'username' is missing," marking the whole workflow run as failed.

Removing the step. Docker Hub README will be updated manually on hub.docker.com when needed. The image-publishing path is unchanged.

## Test plan

- [x] YAML structural parse
- [ ] Will be exercised by the v2.1.0 re-trigger (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)