### PR TITLE
cicd: pin LLM judge to v2.1.0 and fix healthcheck path

### DIFF
--- a/cicd/infrastructure/docker-compose.judge.yml
+++ b/cicd/infrastructure/docker-compose.judge.yml
@@ -2,7 +2,7 @@ services:
   # LLM Judge - stable reference version for evaluating test results
   # Runs on port 11435 to avoid conflict with test subject (11434)
   ollama-judge:
-    image: dogkeeper886/ollama37:latest
+    image: dogkeeper886/ollama37:v2.1.0
     container_name: ollama37-judge
     runtime: nvidia
     deploy:
@@ -22,7 +22,7 @@ services:
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "/usr/local/bin/ollama", "list"]
+      test: ["CMD", "ollama", "list"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Pin `ollama37-judge` to `dogkeeper886/ollama37:v2.1.0` instead of `:latest` so the "stable reference" judge is reproducible from git history.
- Fix the judge healthcheck command. v2.1.0 installs the binary at `/usr/bin/ollama` (older images had `/usr/local/bin/ollama`), which made the hard-coded path probe fail and Docker mark the container unhealthy after 3 retries. Switch to bare `ollama` so it resolves via `PATH`.

## Why
The `:latest` Docker Hub tag was floating — the judge container would silently track whatever the last release built, which is the opposite of "stable reference". Pinning makes the judge version explicit in the compose file.

The healthcheck breakage is independent — it would have surfaced on the next judge container recreate regardless of how the image was tagged.

## Test plan
- [x] Pull `dogkeeper886/ollama37:v2.1.0` on the runner
- [x] `docker compose -f cicd/infrastructure/docker-compose.judge.yml up -d` — container recreated, healthcheck passes
- [x] Models in the persistent `ollama-judge-data` volume preserved (`gemma3:12b-judge`, `gemma4:26b-judge` both present)
- [x] Inference workflow in `judge_mode=dual` passes end-to-end (run [25867594164](https://github.com/dogkeeper886/ollama37/actions/runs/25867594164)): LLM judge active, 2 tests passed, both `simpleJudge` and `llmJudge` blocks present in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)