### PR TITLE
Codify LLM-judge-scope principle in CLAUDE.md and add-test skill

### DIFF
--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -73,6 +73,20 @@ Required fields:
 - `rejectPatterns` — List of regex patterns that must NOT match output
 - `timeout` — Optional per-step timeout in milliseconds
 
+## When to use the LLM judge vs deterministic checks
+
+Per CLAUDE.md → "LLM Judge Scope", the LLM judge is ONLY for validating that an LLM-generated response is meaningful for its prompt. Everything else is deterministic.
+
+| Validation | Mechanism |
+|-----------|-----------|
+| Response contains specific text | `expectPatterns: ["regex"]` |
+| Response avoids error string | `rejectPatterns: ["CUBLAS_STATUS"]` |
+| Step crashes the runner | Exit code (default; no extra config) |
+| Container log signals | `expectPatterns` / `rejectPatterns` matched against captured logs |
+| Generated prose is coherent and on-topic | LLM judge (run suite with `--llm`); set `criteria:` field describing what "meaningful" means |
+
+Do not write tests that rely on the LLM judge to confirm static facts (e.g. "response contains '4'"). That's what `expectPatterns` is for.
+
 ## Related files
 - Test cases: `cicd/tests/testcases/<suite>/`
 - Framework docs: `cicd/README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,32 @@ GitHub Issue (User Story)  →  TestLink Test Case  →  YAML Test Script
 - **YAML** = execution authority (what actually runs in CI)
 - If they conflict, update YAML to match TestLink
 
+### LLM Judge Scope
+
+The LLM judge has exactly one purpose: validating that an LLM-generated response is **meaningful for its prompt**. Every other check is deterministic.
+
+| Check type | How to validate | Tool |
+|------------|-----------------|------|
+| LLM response is meaningful for the prompt | Send `(prompt, output)` to the judge endpoint, parse `{pass, reason}` verdict | LLM judge (`--llm` flag) |
+| Stdout / API response shape | Regex match, exact match, non-empty assertion in the test step itself | Bash + `grep` / `jq` / shell tests |
+| Container log signal (CUDA errors, fallback warnings, OOM) | Pattern match against captured container logs | SimpleJudge `expectPatterns` / `rejectPatterns` |
+| Crash / non-crash | Exit code of the test step | Bash `set -e` and step exit status |
+
+**Why this matters**
+
+- The judge is slow (one LLM call per assertion) and costs GPU time.
+- Using it where deterministic checks suffice hides regressions when the judge itself drifts (cf. #149 / #151 — judge prompt bias).
+- Confining the judge to response-meaningfulness makes failures debuggable: a judge "FAIL" always points at the same class of problem.
+
+**Test step design rule**
+
+When adding or modifying a test:
+- If you're validating a string contains some text → regex in `expectPatterns`, not the judge.
+- If you're validating no CUDA error occurred → pattern in `rejectPatterns`, not the judge.
+- If you're validating a model produced coherent prose → judge with `--llm`.
+
+This is the principle that #142 (scope LLM judge to response checks) and #147 / #149 / #151 (throughput judge for response-meaningfulness) already moved us toward. Don't re-introduce LLM-judging for static checks.
+
 ## Skill Quick Reference
 
 Extracted triggers and key rules from each skill. Use these to recognize when to load a skill, and as a fallback if the Skill tool is unavailable.


### PR DESCRIPTION
## Summary

Documents in writing what #142, #147, #149, and #151 already converged on: the LLM judge is ONLY for "is this LLM response meaningful for its prompt?" — everything else is deterministic. Without this written down, the principle drifts every time someone authors a new test and reaches for the judge for convenience.

Fixes #157

## Changes

- `CLAUDE.md`: new **LLM Judge Scope** subsection under "Test Management Flow" with a check-type table, the rationale, and a test-step design rule
- `.claude/skills/add-test/SKILL.md`: new "When to use the LLM judge vs deterministic checks" subsection that points back to the CLAUDE.md section

## What's NOT in this PR

- No code, runner, workflow, or test YAML changes
- Existing call sites already conform (the audit during #146 verified this)
- TestLink removal is #161; YAML schema work is #156

## Test plan

- [x] Diff is documentation-only — no executable code paths affected
- [ ] None needed beyond proofread

🤖 Generated with [Claude Code](https://claude.com/claude-code)