### PR TITLE
Remove TestLink integration from project

### DIFF
--- a/.claude/commands/build-test/add-test.md
+++ b/.claude/commands/build-test/add-test.md
@@ -14,22 +14,7 @@ The user will provide: **$ARGUMENTS** (suite name and description of what to tes
 ls cicd/tests/testcases/<suite>/
 ```
 
-4. **Create TestLink test case** — Use MCP tool to create the test case in TestLink:
-
-```
-mcp__testlink__create_test_case:
-  project_id: "1"
-  suite_id: "<suite ID>"  # Build=2, Inference=3, Runtime=39, Models=122
-  name: "TC-<SUITE>-<NNN>: <Descriptive Name>"
-  summary: "Related to #<issue>. <What this test validates.>"
-  steps: [{ actions: "<command>", expected_results: "<expected>" }]
-  importance: 2
-  execution_type: 2
-```
-
-Record the returned `tc_external_id` as the `testlink_id`.
-
-5. **Create the YAML test case** at `cicd/tests/testcases/<suite>/TC-<SUITE>-<NNN>.yml`:
+4. **Create the YAML test case** at `cicd/tests/testcases/<suite>/TC-<SUITE>-<NNN>.yml`:
 
 ```yaml
 id: TC-<SUITE>-<NNN>
@@ -38,8 +23,15 @@ suite: <suite>
 priority: <1-3>
 timeout: <milliseconds>
 dependencies: []
-testlink_id: ollama37-<N>
 issue: <github-issue-number>
+
+intent:
+  user_story: |
+    <What value this test delivers, in plain prose.>
+  acceptance:
+    - <What must be true for the test to be considered correct>
+  notes: |
+    <Optional: prerequisites, gotchas, acceptable warnings>
 
 steps:
   - name: <step description>
@@ -50,14 +42,14 @@ steps:
       - "<regex pattern>"
 
 criteria: |
-  <Description for LLM judge>
+  <Description for LLM judge — only used when running with --llm>
 
   Expected:
   - <condition 1>
   - <condition 2>
 ```
 
-6. **Verify** — Run the new test:
+5. **Verify** — Run the new test:
 
 ```bash
 cd cicd/tests && npm run test -- --suite <suite>

--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: <suite> <test-name>
 
 # Add Test
 
-Create a new test case following the **Test Management Flow**: User Story → TestLink → YAML.
+Create a new test case following the **Test Management Flow**: User Story (GitHub Issue) → YAML test case (with `intent:` block).
 
 ## When to use
 - After implementing a feature that needs test coverage
@@ -18,31 +18,11 @@ Create a new test case following the **Test Management Flow**: User Story → Te
 ### 1. Identify the User Story
 - Every test must trace to a GitHub Issue
 - If no issue exists, create one first (or ask the user)
+- Record the issue number — it goes into the YAML's `issue:` field
 
-### 2. Create TestLink Test Case
-- Use MCP tools to create the test case in TestLink
-- TestLink is the **design authority** — define steps and expected results here first
-- Include the GitHub issue reference in the summary field
+### 2. Create the YAML test case
 
-**TestLink reference:**
-| Suite | TestLink Suite ID |
-|-------|------------------|
-| Build | 2 |
-| Inference | 3 |
-| Runtime | 39 |
-| Models | 122 |
-
-**MCP tool:** `mcp__testlink__create_test_case`
-- `project_id`: "1"
-- `suite_id`: suite ID from table above
-- `name`: "TC-<SUITE>-<NNN>: <Descriptive Name>"
-- `summary`: include "Related to #N" for GitHub issue link
-- `steps`: array of `{ actions, expected_results }`
-- `importance`: 1 (low), 2 (medium), 3 (high)
-- `execution_type`: 2 (automated)
-
-### 3. Create YAML Test Script
-YAML is the **execution authority** — what actually runs in CI.
+YAML is the single source of truth for the test — both **design intent** (the `intent:` block) and **execution** (the `steps:` block) live in the same file.
 
 **Test suites:**
 | Suite | Directory | ID prefix |
@@ -52,19 +32,24 @@ YAML is the **execution authority** — what actually runs in CI.
 | inference | `cicd/tests/testcases/inference/` | TC-INFERENCE |
 | models | `cicd/tests/testcases/models/` | TC-MODELS |
 
-**Test case format (YAML):**
+Auto-increment the test ID by checking existing files: `ls cicd/tests/testcases/<suite>/`.
 
-Required fields:
+**Required YAML fields:**
 - `id` — Unique ID (e.g. `TC-BUILD-004`)
 - `name` — Descriptive name
 - `suite` — Suite name
 - `priority` — Integer (1 = highest)
 - `timeout` — Milliseconds
 - `dependencies` — List of prerequisite test IDs
-- `testlink_id` — TestLink external ID (e.g. `ollama37-21`)
 - `issue` — GitHub issue number (e.g. `28`)
+- `intent` — Design intent block (see below)
 - `steps` — List of step objects
-- `criteria` — LLM judge criteria string
+- `criteria` — LLM judge criteria string (only used when running with `--llm`)
+
+**`intent:` block (canonical record of why this test exists):**
+- `user_story` — What value this test delivers, in plain prose
+- `acceptance` — Optional list of "what must be true" criteria (human-readable)
+- `notes` — Optional free-form notes: prerequisites, gotchas, acceptable warnings
 
 **Step fields:**
 - `name` — Step description
@@ -90,4 +75,3 @@ Do not write tests that rely on the LLM judge to confirm static facts (e.g. "res
 ## Related files
 - Test cases: `cicd/tests/testcases/<suite>/`
 - Framework docs: `cicd/README.md`
-- TestLink MCP tools: `mcp__testlink__*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,8 @@ When only part of the work is complete:
 Test cases follow a **requirements-driven** flow: every test traces back to a user story.
 
 ```
-GitHub Issue (User Story)  →  TestLink Test Case  →  YAML Test Script
-(what to validate)            (how to validate)      (automated execution)
+GitHub Issue (User Story)  →  YAML Test Case (intent + steps)
+(what to validate)            (how to validate + automated execution)
 ```
 
 ### 1. User Story (GitHub Issue)
@@ -155,26 +155,16 @@ GitHub Issue (User Story)  →  TestLink Test Case  →  YAML Test Script
 - Describes WHAT needs testing and WHY
 - Has type + priority + component labels
 
-### 2. Test Case Design (TestLink)
-- Create test case in the appropriate suite via MCP tools (`mcp__testlink__create_test_case`)
-- Define steps, expected results, preconditions
-- Include GitHub issue reference in the summary field (e.g., "Related to #N")
-- Record the TestLink external ID (e.g., `ollama37-21`)
-
-### 3. Test Script (YAML)
-- Create executable YAML via `/add-test` skill
-- Must include `testlink_id` and `issue` fields linking back to TestLink and GitHub
+### 2. Test Case (YAML)
+- Create executable YAML via `/add-test` skill at `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`
+- Must include an `intent:` block (`user_story`, optional `acceptance`, optional `notes`) — the canonical record of why the test exists
+- Must include the `issue:` field linking back to the GitHub issue
 - PR includes the new YAML file
 
-### TestLink Reference
-- Project: ollama37 (ID: 1)
-- Test plan: "CI/CD Pipeline v1.0" (ID: 87)
-- Suites: Build (ID: 2), Inference (ID: 3), Runtime (ID: 39), Models (ID: 122)
-
-### Authorities
-- **TestLink** = design authority (what should be tested, how)
-- **YAML** = execution authority (what actually runs in CI)
-- If they conflict, update YAML to match TestLink
+### Authority
+- **YAML `intent:` block** = design authority (the test's purpose, in writing)
+- **YAML `steps:` + `expectPatterns:` / `rejectPatterns:`** = execution authority (what actually runs in CI)
+- Both live in the same file by design (one source of truth, no drift surface)
 
 ### LLM Judge Scope
 

--- a/cicd/specs/inference.md
+++ b/cicd/specs/inference.md
@@ -1,12 +1,10 @@
 # Inference Tests
 
-Exported from TestLink project: **ollama37**
 
 ---
 
 ## TC-INFERENCE-001: Model Pull
 
-**External ID:** ollama37-14
 **Importance:** High
 **Execution Type:** Automated
 
@@ -24,7 +22,6 @@ Pull the gemma3:4b model for testing inside the container.
 
 ## TC-INFERENCE-002: API Inference Test
 
-**External ID:** ollama37-15
 **Importance:** High
 **Execution Type:** Automated
 

--- a/cicd/specs/runtime.md
+++ b/cicd/specs/runtime.md
@@ -1,12 +1,10 @@
 # Runtime Tests
 
-Exported from TestLink project: **ollama37**
 
 ---
 
 ## TC-RUNTIME-001: Container Startup
 
-**External ID:** ollama37-11
 **Importance:** High
 **Execution Type:** Automated
 
@@ -25,7 +23,6 @@ Start the ollama37 container with GPU passthrough using docker compose.
 
 ## TC-RUNTIME-002: GPU Detection
 
-**External ID:** ollama37-12
 **Importance:** High
 **Execution Type:** Automated
 
@@ -45,7 +42,6 @@ Verify Tesla K80 GPU is detected by both nvidia-smi AND Ollama CUDA runtime. Inc
 
 ## TC-RUNTIME-003: Health Check
 
-**External ID:** ollama37-13
 **Importance:** High
 **Execution Type:** Automated
 

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -256,7 +256,6 @@ export class TestLoader {
       priority: typeof raw.priority === 'number' ? raw.priority : 1,
       timeout: typeof raw.timeout === 'number' ? raw.timeout : 60000,
       dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
-      testlinkId: typeof raw.testlink_id === 'string' ? raw.testlink_id : undefined,
       issue: typeof raw.issue === 'number' ? raw.issue : undefined,
       intent,
       goal: typeof raw.goal === 'string' ? raw.goal : undefined,

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -29,7 +29,7 @@ export interface TestStep {
 /**
  * Test design intent — the canonical record of WHY this test exists.
  * Read by humans / AI agents to understand purpose; not consumed by the
- * runner for execution decisions. Replaces TestLink as the design authority.
+ * runner for execution decisions. The single design authority for the test.
  */
 export interface Intent {
   /** User story or imperative goal: what value this test delivers. */
@@ -56,8 +56,6 @@ export interface TestCase {
   timeout: number;
   /** Test IDs that must pass before this test runs */
   dependencies: string[];
-  /** TestLink external ID (e.g., ollama37-21) — deprecated, see #161 */
-  testlinkId?: string;
   /** GitHub issue number this test traces to */
   issue?: number;
   /** Design intent for this test (user story + acceptance + notes). */

--- a/cicd/tests/testcases/models/TC-MODELS-004.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-004.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 900000
 dependencies: []
-testlink_id: ollama37-21
 issue: 30
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-005.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-005.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 600000
 dependencies: []
-testlink_id: ollama37-26
 issue: 39
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-006.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-006.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 900000
 dependencies: []
-testlink_id: ollama37-27
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-007.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-007.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 1200000
 dependencies: []
-testlink_id: ollama37-28
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-008.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-008.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 600000
 dependencies: []
-testlink_id: ollama37-29
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-009.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-009.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 1200000
 dependencies: []
-testlink_id: ollama37-30
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-010.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-010.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 1200000
 dependencies: []
-testlink_id: ollama37-31
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-011.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-011.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 900000
 dependencies: []
-testlink_id: ollama37-32
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-012.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-012.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 4
 timeout: 1200000
 dependencies: []
-testlink_id: ollama37-33
 issue: 55
 intent:
   user_story: |

--- a/cicd/tests/testcases/models/TC-MODELS-013.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-013.yml
@@ -4,7 +4,6 @@ suite: models
 priority: 2
 timeout: 600000
 dependencies: []
-testlink_id: ""
 issue: ""
 intent:
   user_story: |

--- a/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
+++ b/cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
@@ -5,7 +5,6 @@ priority: 2
 timeout: 60000
 dependencies:
   - TC-RUNTIME-001
-testlink_id: ""
 issue: "130"
 intent:
   user_story: |


### PR DESCRIPTION
## Summary

TestLink was the nominal "design authority" for test cases, but in practice tests drifted in the YAML scripts without ever syncing back. With #156's `intent:` block now in place on every YAML, TestLink is dead weight — strip it.

Fixes #161

## What's stripped

| Location | Change |
|----------|--------|
| `CLAUDE.md` | Test Management Flow rewritten without TestLink subsection / External ID Reference / Authorities sections. YAML is now stated as the single source of truth |
| `.claude/skills/add-test/SKILL.md` | "Create TestLink Test Case" step removed + MCP tool example dropped; added `intent:` block guidance |
| `.claude/commands/build-test/add-test.md` | TestLink MCP step removed; YAML template no longer has `testlink_id` field, gains `intent:` block |
| `cicd/tests/src/types.ts` | `testlinkId` field removed from TestCase |
| `cicd/tests/src/loader.ts` | Stopped parsing `raw.testlink_id` |
| 11 YAML files | Stripped `testlink_id:` line |
| `cicd/specs/inference.md`, `cicd/specs/runtime.md` | Removed "Exported from TestLink" attribution + "External ID: ollama37-NN" lines |

## Verification

```
$ grep -ri testlink CLAUDE.md .claude/ cicd/
(no matches)

$ cd cicd/tests && npx tsc --noEmit
(clean)

$ npx tsx src/cli.ts list
(all 22 tests enumerated, no warnings)
```

## What's NOT in this PR

- `.claude/settings.local.json` MCP permission cleanup — that file is user-local and gitignored. The `mcp__testlink__*` entries are stripped on my local copy but won't appear in this commit (correct behavior; each developer manages their own MCP permissions)
- The TestLink MCP server itself (in your Claude Code config) — out of scope for the repo

## Test plan

- [x] `grep -ri testlink ...` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx tsx src/cli.ts list` enumerates all 22 tests, no warnings
- [ ] Will be exercised by CI on next merge — no behavior change expected (TestLink ID was never consumed by the runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)