### PR TITLE
Define unified test workflow pattern (skill + command + CLAUDE.md route)

### DIFF
--- a/.claude/commands/build-test/test-workflow.md
+++ b/.claude/commands/build-test/test-workflow.md
@@ -1,0 +1,111 @@
+Author or refactor a CI workflow that follows the unified test-workflow pattern. Reference `.claude/skills/test-workflow-pattern/SKILL.md` for the full contract.
+
+The user will provide: **$ARGUMENTS** (workflow name and what it tests, e.g. `fa-k80 — flash attention validation`)
+
+## Steps
+
+1. **Confirm pattern fit** — This pattern is for perf benchmarks, experiments, profiling — anything that runs on the K80 runner but isn't a TC-framework correctness suite. If it's a build/runtime/inference/models correctness test, use the TC framework instead (`/add-test`).
+
+2. **Pick the names** — `.github/workflows/test-<name>.yml` and `cicd/scripts/test-<name>.sh`. Same stem.
+
+3. **Create the script** at `cicd/scripts/test-<name>.sh`:
+
+```bash
+#!/usr/bin/env bash
+# test-<name>.sh — <one-line purpose>
+#
+# Exits non-zero on any validation failure. Writes structured results to
+# /tmp/test-<name>-results.json. Sources shared helpers from
+# cicd/scripts/lib/.
+
+set -euo pipefail
+
+LIB_DIR="$(dirname "$0")/lib"
+# shellcheck source=lib/response_capture.sh
+source "$LIB_DIR/response_capture.sh"
+# shellcheck source=lib/simple_check.sh
+source "$LIB_DIR/simple_check.sh"
+# shellcheck source=lib/judge_response.sh   # only if you need it
+source "$LIB_DIR/judge_response.sh"
+
+OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
+OUTPUT="${OUTPUT:-/tmp/test-<name>-results.json}"
+
+# ... test logic ...
+# capture responses, run checks, emit JSON, exit non-zero on fail
+
+echo "$REPORT" > "$OUTPUT"
+[ "$FAILED" -gt 0 ] && exit 1
+```
+
+4. **Create the workflow** at `.github/workflows/test-<name>.yml`:
+
+```yaml
+name: <Name> Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      # ... workflow-specific inputs ...
+
+env:
+  OLLAMA_HOST: http://localhost:11434
+  JUDGE_HOST: http://localhost:11435   # only if using LLM judge
+
+jobs:
+  test:
+    runs-on: self-hosted
+    environment: cicd-1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Optional standardized pre-step
+      - name: Stop production ollama37
+        run: |
+          cd ${OLLAMA37_ROOT}/docker && docker compose down 2>/dev/null || true
+
+      - name: Run test
+        run: |
+          bash cicd/scripts/test-<name>.sh
+
+      # Always-on standardized post-step
+      - name: Restart production ollama37
+        if: always()
+        run: |
+          cd ${OLLAMA37_ROOT}/docker && docker compose up -d
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-<name>-results
+          path: /tmp/test-<name>-results.json
+```
+
+5. **Verify locally before pushing**:
+
+```bash
+bash -n cicd/scripts/test-<name>.sh                    # syntax
+python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/test-<name>.yml"))'   # YAML
+# /lint-ci skill for the full pre-merge checklist
+```
+
+6. **Trigger on the runner**:
+
+```bash
+gh workflow run test-<name>.yml --ref <branch>
+gh run watch <run-id>
+gh run download <run-id>   # inspect the artifact
+```
+
+## Reference implementations
+
+- `.github/workflows/test-throughput.yml` + `cicd/scripts/benchmark-throughput.sh` — most-evolved current example. After #159 lands, the script will source from `cicd/scripts/lib/` as the canonical helpers reference.
+
+## Do not
+
+- Put test logic in inline workflow `run:` blocks. They orchestrate; the script does the work.
+- Re-implement helpers that exist in `cicd/scripts/lib/`. Source them.
+- Use the LLM judge for static / log / exit-code checks. Per CLAUDE.md → "LLM Judge Scope", the judge is for response-meaningfulness only.
+- Skip the `if: always()` on the restore step. Production container left stopped = next workflow run starts broken.

--- a/.claude/skills/test-workflow-pattern/SKILL.md
+++ b/.claude/skills/test-workflow-pattern/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: test-workflow-pattern
+description: Defines the unified design pattern every test workflow + test script follows. Use when authoring or refactoring a workflow under .github/workflows/ that runs something on the K80 runner — perf benchmarks, experiments, profiling. The TC framework (build/runtime/inference/models suites) keeps its own pattern documented in cicd/docs/CICD.md.
+---
+
+# Test Workflow Pattern
+
+A single design pattern every test workflow + test script in this project follows. Replaces the historical situation where every perf workflow (throughput, fa-k80, kv-rotate, profile) invented its own shape.
+
+## When to use this pattern
+
+- Authoring a new `.github/workflows/test-<name>.yml` that runs against the K80 runner
+- Refactoring an existing standalone-script workflow that doesn't yet conform
+- Anything that isn't a correctness suite covered by the TC framework (build / runtime / inference / models)
+
+The TC framework remains the right tool for correctness validation — it has YAML test cases, the TypeScript runner, and the dual-judge architecture. See `cicd/docs/CICD.md`. This pattern is for everything else.
+
+## The shape
+
+```
+.github/workflows/test-<name>.yml
+├─ checkout + deps
+├─ pre:    optional, standardized — stop production ollama37 container
+├─ exec:   bash cicd/scripts/test-<name>.sh    ← ONE entry point. No inline run: blocks for test logic.
+├─ post:   always-on, standardized — restore production container
+└─ upload: artifact at known path (/tmp/test-<name>-results.json)
+```
+
+```
+cicd/scripts/test-<name>.sh
+├─ sources shared helpers from cicd/scripts/lib/
+├─ exits non-zero on validation failure
+├─ emits structured JSON to /tmp/test-<name>-results.json
+├─ defaults to bash + curl + jq for HTTP
+└─ Python permitted only when bash is genuinely insufficient (heavy parsing, stats); document the choice in the script header
+```
+
+## Rules
+
+1. **No inline test logic in workflow YAML.** Workflow `run:` blocks orchestrate (checkout, env setup, calling the script, uploading the artifact). All actual test logic lives in `cicd/scripts/test-<name>.sh`.
+2. **One script per workflow.** Same name stem (`test-throughput.yml` → `test-throughput.sh`).
+3. **Structured JSON output.** Every script writes its results to `/tmp/test-<name>-results.json`. This is the artifact that gets uploaded.
+4. **Shared helpers, not duplicated logic.** When a behavior is needed by two or more scripts, it goes into `cicd/scripts/lib/` (see [Helpers contract](#helpers-contract) below).
+5. **Standardized pre/post container handling.** Workflows that need to stop / restart the production `ollama37` container use the standardized snippet — not bespoke bash per workflow.
+6. **Exit codes are load-bearing.** Validation failure → exit non-zero. The workflow's red / green status must reflect actual test pass / fail, not "the script crashed."
+7. **LLM judge usage follows the scope rule.** Per `CLAUDE.md → "LLM Judge Scope"`, the judge is ONLY for "is this LLM response meaningful?". Static / log / exit-code checks stay deterministic.
+
+## Helpers contract
+
+`cicd/scripts/lib/` provides these shared bash functions, sourceable by any test script:
+
+| Helper | Purpose | Signature (rough) |
+|--------|---------|-------------------|
+| `response_capture` | Call `/api/generate` with a prompt and capture `.response` + `.thinking` + perf metrics into JSON | `capture_response MODEL PROMPT [num_predict] [num_ctx]` → JSON to stdout |
+| `simple_check` | Pass if response or thinking is non-empty (whitespace-stripped) | `simple_check RESPONSE THINKING` → `{pass, reason, source}` JSON; exit 0/1 |
+| `judge_response` | Send `(prompt, output)` to the LLM judge endpoint, parse verdict | `judge_response MODEL PROMPT OUTPUT` → `{pass, reason}` JSON |
+| `container_log_snip` | Capture a slice of a container's logs between markers, for log-based assertions | `container_log_snip CONTAINER START_MARKER END_MARKER` → log text |
+
+These are the canonical implementations. Scripts must source them rather than re-implementing equivalents inline. Concrete implementations land in #159; this skill defines the contract.
+
+## Reference implementation (today)
+
+`cicd/scripts/benchmark-throughput.sh` is the most-evolved current example — it captures responses, runs simple + optional LLM-judge checks, exits non-zero on validation failure, and writes structured JSON. Today it has the validation logic inlined; after #159 it'll source from `cicd/scripts/lib/` as the canonical reference.
+
+For the workflow side, `.github/workflows/test-throughput.yml` already follows the pattern: validate inputs → invoke the script → summary → unload → upload artifact. The three other perf workflows (#160) will be refactored to match.
+
+## Why this matters
+
+- Surfaced during the v2.1.0 release (#147 / #149 / #151): throughput shipped with no response capture and no coherence check for ~a year because the workflow was a one-off with bespoke logic. Same gap exists in `test-fa-k80`, `test-kv-rotate`, `test-profile` today.
+- A unified pattern means a new workflow can be written by copying the template, not by inventing yet another shape.
+- A reader (human or AI agent) needs only one mental model to understand any `test-*.yml`.
+
+## Related
+
+- `CLAUDE.md → "Test Management Flow"` — covers test cases inside the TC framework
+- `cicd/docs/CICD.md` — TC-framework design philosophy
+- `.claude/skills/add-test/SKILL.md` — authoring a new test case in the TC framework
+- `/test-workflow` command — operational guide for applying this pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,10 @@ GitHub Issue (User Story)  →  YAML Test Case (intent + steps)
 - **YAML `steps:` + `expectPatterns:` / `rejectPatterns:`** = execution authority (what actually runs in CI)
 - Both live in the same file by design (one source of truth, no drift surface)
 
+### Workflow-level pattern (non-TC workflows)
+
+The flow above governs the TC framework (build / runtime / inference / models). Perf benchmarks, experiments, and profiling workflows (`test-throughput.yml`, `test-fa-k80.yml`, `test-kv-rotate.yml`, `test-profile.yml`) follow a separate unified pattern documented in the [`test-workflow-pattern`](./.claude/skills/test-workflow-pattern/SKILL.md) skill: one extracted bash script per workflow, shared helpers from `cicd/scripts/lib/`, structured JSON output, standardized container handling.
+
 ### LLM Judge Scope
 
 The LLM judge has exactly one purpose: validating that an LLM-generated response is **meaningful for its prompt**. Every other check is deterministic.
@@ -247,6 +251,10 @@ Extracted triggers and key rules from each skill. Use these to recognize when to
 - **Trigger**: Before pushing changes to `.github/workflows/*.yml`
 - **Rules**: Validate `jq -n '{...}'` object templates with `jq -n` against placeholder values (catches reserved-word collisions like `label`, `break`); shellcheck `run:` blocks (catches redirect-order bugs like `2>&1 > file`); actionlint for workflow structure. Most CI bugs in this project's history (jq reserved word, shell redirect, header staleness) were locally testable in isolation.
 
+### test-workflow-pattern
+- **Trigger**: Authoring or refactoring a `.github/workflows/test-*.yml` workflow that runs on the K80 runner (perf benchmarks, experiments, profiling) — not a TC-framework correctness suite
+- **Rules**: One entry point per workflow (`bash cicd/scripts/test-<name>.sh`); no inline test logic in YAML; source helpers from `cicd/scripts/lib/`; emit structured JSON to `/tmp/test-<name>-results.json`; exit non-zero on validation failure; standardized pre/post container handling.
+
 ## Logging Guidelines
 
 All debug logging must be **level-gated and permanent** — never add temporary log lines that need manual removal.
@@ -316,11 +324,11 @@ When creating or updating skills and commands, follow the format guides in `.cla
 **Design principle**: Skills define *when* and *what*. Commands define *how* (invoked via `/slash`). Keep executable content in commands, not skills.
 
 ### Skill files (`.claude/skills/<name>/SKILL.md`)
-`build`, `debug`, `ci`, `test`, `git-flow`, `plan`, `implement`, `add-test`, `trace`, `instrument`, `profile`, `annotate`, `script-review`, `lint-ci`
+`build`, `debug`, `ci`, `test`, `git-flow`, `plan`, `implement`, `add-test`, `test-workflow-pattern`, `trace`, `instrument`, `profile`, `annotate`, `script-review`, `lint-ci`
 
 ### Slash commands (`.claude/commands/<category>/`)
 - **dev-workflow/**: `/plan`, `/implement`
-- **build-test/**: `/build`, `/debug`, `/test`, `/ci`, `/add-test`
+- **build-test/**: `/build`, `/debug`, `/test`, `/ci`, `/add-test`, `/test-workflow`
 - **code-analysis/**: `/trace`, `/instrument`, `/profile`, `/annotate`
 - **project/**: `/script-review`
 - **utility/**: `/session-summary`


### PR DESCRIPTION
## Summary

Documents in writing the single design pattern every test workflow + test script must follow. Replaces the historical situation where each perf workflow (throughput, fa-k80, kv-rotate, profile) invented its own shape.

The pattern:
- One extracted bash script per workflow (`cicd/scripts/test-<name>.sh`)
- No inline test logic in workflow YAML
- Structured JSON output to `/tmp/test-<name>-results.json`
- Shared helpers from `cicd/scripts/lib/` (the contract: `response_capture`, `simple_check`, `judge_response`, `container_log_snip` — implemented in #159)
- Standardized pre/post container handling
- Exit non-zero on validation failure

Fixes #158

## Changes

- `.claude/skills/test-workflow-pattern/SKILL.md` (new) — full contract + helpers specification + reference implementation pointer + "why this matters"
- `.claude/commands/build-test/test-workflow.md` (new) — operational guide with workflow YAML and bash script templates, plus a "do not" list
- `CLAUDE.md`:
  - Skill Quick Reference adds `test-workflow-pattern` entry
  - "Skills and Commands" skill list and command list updated
  - Test Management Flow gets a "Workflow-level pattern (non-TC workflows)" cross-reference

## Builds on / unblocks

- Builds on: #156 (`intent:` block as design authority), #157 (LLM judge scope rule)
- Unblocks: #159 (implements helpers this pattern specifies), #160 (refactors fa-k80/kv-rotate/profile), #162 (sync docs to reference this pattern)

## Test plan

- [x] YAML in templates parses (Python yaml.safe_load)
- [x] All new skill / command files are discoverable (system reminder confirms `test-workflow-pattern` and `build-test:test-workflow` are indexed)
- [x] CLAUDE.md edits land in the right sections, no broken references
- [ ] Operational verification: this pattern gets exercised in #159 (helpers) and #160 (workflow refactors). If the contract turns out to be wrong there, we revise it before #159 merges

## What's NOT in this PR

- The actual `cicd/scripts/lib/` helpers — that's #159
- Refactoring `test-fa-k80`, `test-kv-rotate`, `test-profile` to the pattern — that's #160
- Updating `cicd/README.md` and `cicd/docs/CICD.md` to reference this skill — that's #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)