### PR TITLE
Sync drifted CI/CD docs (cicd/README.md and cicd/docs/CICD.md)

### DIFF
--- a/cicd/README.md
+++ b/cicd/README.md
@@ -42,10 +42,12 @@ TypeScript-based test framework with dual-judge architecture.
 **Test Suites:**
 | Suite | Tests | Purpose |
 |-------|-------|---------|
-| Build | 2 | Verify Docker images and toolchain |
-| Runtime | 3 | Container startup, GPU detection |
-| Inference | 2 | Model loading, API endpoints |
-| Models | 3 | Large model testing (gpt-oss, gemma3:27b, deepseek-r1) |
+| Build | 3 | Verify Docker images, toolchain, image sizes |
+| Runtime | 4 | Container startup, GPU detection, health check, /api/metrics schema |
+| Inference | 2 | Model pull + API inference smoke |
+| Models | 13 | Per-model regression — gpt-oss, ministral-3, gemma3 (4b/27b), gemma4 (e4b/26b), qwen3.5 (9b/27b), qwen3-vl (8b/30b), deepseek-r1 (14b/32b) |
+
+Each test case lives in `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`. The `intent:` block in every YAML — `user_story`, optional `acceptance`, optional `notes` — is the single design authority for that test.
 
 ### LLM Judge (`infrastructure/docker-compose.judge.yml`)
 
@@ -72,20 +74,40 @@ docker compose -f docker-compose.judge.yml down
 
 ## GitHub Actions Workflows
 
-Located in `.github/workflows/`:
+Located in `.github/workflows/`. Two families:
+
+### TC-framework workflows (correctness validation)
+
+These workflows execute the YAML test suites via the TypeScript runner with the dual-judge architecture described above.
 
 | Workflow | Description |
 |----------|-------------|
 | `test-pipeline.yml` | Full pipeline: build → runtime → inference → models |
-| `test-build.yml` | Build verification only |
-| `test-runtime.yml` | Runtime tests only |
-| `test-inference.yml` | Inference tests only |
-| `test-models.yml` | Models test (TC-MODELS-001 only) |
+| `test-build.yml` | Build suite (image verification) |
+| `test-runtime.yml` | Runtime suite (container, GPU, health, metrics) |
+| `test-inference.yml` | Inference suite (pull + smoke); supports `--llm` opt-in judge |
+| `test-models.yml` | Models suite (all 13 per-model regressions); supports `--llm` opt-in judge |
+
+### Perf / experiment workflows (the unified test-workflow pattern)
+
+These follow the contract documented in [`.claude/skills/test-workflow-pattern/SKILL.md`](../.claude/skills/test-workflow-pattern/SKILL.md): one extracted bash script per workflow at `cicd/scripts/test-<name>.sh`, sourcing shared helpers from `cicd/scripts/lib/`, emitting structured JSON to `/tmp/test-<name>-results.json`.
+
+| Workflow | Script | Description |
+|----------|--------|-------------|
+| `test-throughput.yml` | `cicd/scripts/benchmark-throughput.sh` | Per-model tok/s benchmark with simple + optional LLM-judge output check |
+| `test-fa-k80.yml` | `cicd/scripts/test-fa-k80.sh` | K80 flash-attention regression + benchmark (FA off/on × KV cache type) |
+
+### Release workflow
+
+| Workflow | Description |
+|----------|-------------|
+| `release-docker.yml` | Builds and publishes Docker image on release publication |
 
 **Usage:**
-- Trigger manually via GitHub Actions "Run workflow"
-- Pipeline runs all suites in sequence
-- Individual workflows assume container is already running
+- Trigger manually via GitHub Actions "Run workflow" or `gh workflow run`
+- The TC pipeline runs all suites in sequence
+- Individual TC workflows assume the production container is already running
+- Perf workflows manage their own container lifecycle (stop production → boot test container → restart production)
 
 ## Folder Structure
 
@@ -97,6 +119,15 @@ cicd/
 ├── infrastructure/
 │   ├── docker-compose.judge.yml
 │   └── README.md
+├── scripts/                 # Perf / experiment workflow scripts (unified pattern)
+│   ├── benchmark-throughput.sh
+│   ├── test-fa-k80.sh
+│   ├── format-results.sh
+│   └── lib/                 # Shared helpers (sourceable from any script)
+│       ├── response_capture.sh
+│       ├── simple_check.sh
+│       ├── judge_response.sh
+│       └── container_log_snip.sh
 ├── specs/
 │   ├── build.md             # Build test specifications
 │   ├── runtime.md           # Runtime test specifications
@@ -104,7 +135,7 @@ cicd/
 │   └── models.md            # Models test specifications
 ├── tests/
 │   ├── src/                 # Framework source code
-│   ├── testcases/           # YAML test definitions
+│   ├── testcases/           # YAML test definitions (intent + steps)
 │   ├── package.json
 │   └── tsconfig.json
 ├── results/                 # Test output (gitignored)

--- a/cicd/docs/CICD.md
+++ b/cicd/docs/CICD.md
@@ -141,13 +141,13 @@ sed -n '/===TEST:TC-RUNTIME-001:START:/,${/===TEST:/d;p}' /tmp/ollama37-session-
 
 Tests are organized into four suites that must run in order:
 
-**Build Suite** (2 tests): Verifies Docker images exist and are correctly configured. No GPU required.
+**Build Suite** (3 tests): Verifies the builder Docker image contents, runtime image build, and image-size invariants. No GPU required.
 
-**Runtime Suite** (3 tests): Starts the container and verifies GPU detection. Checks that Ollama recognizes K80 hardware and loads CUDA libraries. Critical validation that the driver/toolkit/container integration works.
+**Runtime Suite** (4 tests): Starts the container and verifies GPU detection, container health, and `/api/metrics` endpoint schema. Critical validation that the driver/toolkit/container integration works.
 
-**Inference Suite** (2 tests): Tests model loading and API inference with gemma3:4b. Validates that models load correctly and generate responses using GPU.
+**Inference Suite** (2 tests): Tests model pull + API inference with gemma3:4b. Validates that models load correctly and generate responses using GPU.
 
-**Models Suite** (3 tests): Tests large models on K80 hardware - gpt-oss:20b, gemma3:27b, and deepseek-r1:14b. Each model size unloads after testing to free VRAM for the next.
+**Models Suite** (13 tests): Per-model regression coverage on K80 hardware — gpt-oss:20b, ministral-3:3b, gemma3 (4b / 27b), gemma4 (e4b / 26b), qwen3.5 (9b / 27b), qwen3-vl (8b / 30b), deepseek-r1 (14b / 32b). Each model size unloads after testing to free VRAM for the next.
 
 ### Model Unload Strategy
 
@@ -216,10 +216,10 @@ cicd/
 │   │       ├── json.ts
 │   │       └── console.ts
 │   ├── testcases/
-│   │   ├── build/           # TC-BUILD-001, 002
-│   │   ├── runtime/         # TC-RUNTIME-001, 002, 003
-│   │   ├── inference/       # TC-INFERENCE-001, 002
-│   │   └── models/          # TC-MODELS-001, 002, 003
+│   │   ├── build/           # TC-BUILD-001..003
+│   │   ├── runtime/         # TC-RUNTIME-001..004
+│   │   ├── inference/       # TC-INFERENCE-001..002
+│   │   └── models/          # TC-MODELS-001..013
 │   ├── package.json
 │   └── tsconfig.json
 ├── results/                 # Test output (gitignored)
@@ -233,17 +233,28 @@ The test framework integrates with GitHub Actions via reusable workflows in `.gi
 **Pipeline Workflow** (`test-pipeline.yml`):
 Runs all test suites in sequence: build → runtime → inference → models. This is the primary workflow for full validation.
 
-**Individual Workflows**:
-- `test-build.yml` - Build verification only
-- `test-runtime.yml` - Runtime tests only
-- `test-inference.yml` - Inference tests only
-- `test-models.yml` - Models test (TC-MODELS-001 only)
+**Individual TC-framework Workflows**:
+- `test-build.yml` — Build suite (3 tests)
+- `test-runtime.yml` — Runtime suite (4 tests)
+- `test-inference.yml` — Inference suite (2 tests); supports `--llm` opt-in judge
+- `test-models.yml` — Models suite (13 tests); supports `--llm` opt-in judge
 
 **Design Notes**:
-- Individual workflows do not manage container lifecycle
-- Container must be running before runtime/inference/models tests
+- Individual TC workflows do not manage container lifecycle
+- Container must be running before runtime / inference / models tests
 - Pipeline workflow orchestrates the sequence via `needs:` dependencies
 - All workflows run on self-hosted runners with K80 hardware
+
+### Perf / experiment workflows (separate pattern)
+
+The TC framework above handles **correctness validation** — "did this model load and produce coherent output?". Performance benchmarks and experiments live alongside under a separate, simpler contract documented in [`.claude/skills/test-workflow-pattern/SKILL.md`](../../.claude/skills/test-workflow-pattern/SKILL.md):
+
+- One extracted bash script per workflow at `cicd/scripts/test-<name>.sh`
+- Shared helpers in `cicd/scripts/lib/` (response capture, simple check, LLM judge wrapper, container log snip)
+- Structured JSON output at `/tmp/test-<name>-results.json`
+- Workflow manages container lifecycle (stop production → run script → restart production → upload artifacts)
+
+Current perf workflows: `test-throughput.yml` (tok/s benchmark) and `test-fa-k80.yml` (FA regression + benchmark). The LLM judge is invoked here too but only ever to answer "is this response meaningful for its prompt?" — never for static / log / exit-code checks (per CLAUDE.md → "LLM Judge Scope").
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Closes the final issue in the #146 chain. Both `cicd/README.md` and `cicd/docs/CICD.md` had drifted from the actual state of the test framework — suite counts wrong, workflow descriptions stale, no mention of the helpers / patterns / intent block introduced in #156–#160.

Fixes #162

## Drift corrected

| Doc | Was | Now |
|-----|-----|-----|
| Build suite test count | 2 | 3 (correct) |
| Runtime suite test count | 3 | 4 |
| Models suite test count | 3 | 13 |
| Models suite model list | gpt-oss, gemma3:27b, deepseek-r1 only | 10+ models across all families |
| test-models.yml description | "TC-MODELS-001 only" | "Models suite (13 tests)" |
| Workflow inventory | missing perf workflows | TC-framework / perf / release split |
| Folder structure | no cicd/scripts/ | includes scripts/ + scripts/lib/ |
| Authority statement | implicit | explicit: YAML `intent:` block |

## Changes

- `cicd/README.md`: suite counts fixed; workflow table reorganized into three families (TC-framework, perf, release) with the perf section linking to the `test-workflow-pattern` skill; folder structure updated to show `cicd/scripts/lib/`; mentions the `intent:` block as design authority
- `cicd/docs/CICD.md`: Test Architecture suite counts fixed; `test-models.yml` description corrected; new "Perf / experiment workflows" section explaining the unified pattern + helpers + judge-scope rule; testcases tree shows actual TC-MODELS-001..013 range

## Verification

```
$ grep -rln -i testlink CLAUDE.md .claude/ cicd/
(no matches)

$ for s in build runtime inference models; do
    n=$(ls cicd/tests/testcases/$s/*.yml | wc -l)
    echo "$s: $n tests"
  done
build: 3
runtime: 4
inference: 2
models: 13
```

Doc counts match the filesystem.

## Closes the #146 chain

| # | Status |
|---|--------|
| #157 LLM-judge-scope principle | ✅ |
| #156 YAML intent: block | ✅ |
| #161 Remove TestLink | ✅ |
| #158 Unified test workflow pattern | ✅ |
| #159 Shared script helpers | ✅ |
| #160 Refactor + delete perf workflows | ✅ |
| #162 Sync drifted docs | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)