### PR TITLE
Restore qwen35moe + qwen3next dispatch wiring (Qwen3.6 35B-A3B MoE)

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -250,7 +250,8 @@ func (kv KV) OllamaEngineRequired() bool {
 		"qwen25vl",
 		"qwen3", "qwen3moe",
 		"qwen3vl", "qwen3vlmoe",
-		"qwen35",
+		"qwen35", "qwen35moe",
+		"qwen3next",
 	}, kv.Architecture())
 }
 
@@ -890,7 +891,7 @@ func (f GGML) SupportsFlashAttention() bool {
 
 	// qwen35 is hybrid (DeltaNet + attention) and needs the OllamaEngine;
 	// flash attention is handled via SupportsFlashAttentionInNewEngine instead.
-	if slices.Contains([]string{"gemma2", "qwen35"}, arch) {
+	if slices.Contains([]string{"gemma2", "qwen35", "qwen35moe", "qwen3next"}, arch) {
 		return false
 	}
 
@@ -940,7 +941,8 @@ func (f GGML) FlashAttention() bool {
 		"gemma3",
 		"gptoss", "gpt-oss",
 		"qwen3", "qwen3moe",
-		"qwen35",
+		"qwen35", "qwen35moe",
+		"qwen3next",
 		"qwen3vl", "qwen3vlmoe",
 	}, f.KV().String("general.architecture"))
 }

--- a/model/models/qwen35/model.go
+++ b/model/models/qwen35/model.go
@@ -558,4 +558,6 @@ func New(c fs.Config) (model.Model, error) {
 
 func init() {
 	model.Register("qwen35", New)
+	model.Register("qwen35moe", New)
+	model.Register("qwen3next", New)
 }


### PR DESCRIPTION
## Summary
Re-adds the three arch registrations + dispatch entries that upstream Ollama's `qwen3next` package has but our fork dropped during the `qwen3next`→`qwen35` rename. The MoE `sparse` path already exists in `model/models/qwen35` but was unreachable because `qwen35moe` never dispatched to the native engine.

- `model.Register`: add `qwen35moe`, `qwen3next` (alongside `qwen35`)
- `OllamaEngineRequired`: add both
- `SupportsFlashAttention` hybrid deny-gate: add both
- `FlashAttention` enable list: add both

Deliberately **not** added to `SupportsFlashAttentionInNewEngine` (the new-engine FA allowlist) — that carries a K80 empirical-validation gate (#107/#123). `qwen35moe` FA-on must be validated on K80 before joining it.

Enables Qwen3.6-35B-A3B (HF `model_type: qwen3_5_moe` → GGUF arch `qwen35moe`).

## Regression testing (CI, K80 runner, branch)
| Suite | Result |
|---|---|
| Build (no-cache, real compile) | ✅ |
| Runtime | ✅ |
| Inference | ✅ |
| Models | ✅ 13/13 |

(One earlier models run failed on `gemma4:26b` GPU-count — an intermittent 93 MiB ghost allocation, #73/#138 class, unrelated to this change; did not reproduce on rerun.)

## Pending before merge
- After-hours `qwen3.6:35b-a3b` runtime validation: confirm it loads through `qwen35moe` → `sparse` (needs model download).
- FA-allowlist (`SupportsFlashAttentionInNewEngine`) decision after K80 FA validation.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)