### PR TITLE
Add qwen3.6:27b model test (TC-MODELS-014)

### DIFF
--- a/cicd/tests/testcases/models/TC-MODELS-014.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-014.yml
@@ -1,0 +1,87 @@
+id: TC-MODELS-014
+name: qwen3.6:27b Inference
+suite: models
+priority: 4
+timeout: 1200000
+dependencies: []
+issue: 176
+
+intent:
+  user_story: |
+    Validate qwen3.6:27b runs on K80 compute 3.7. Qwen3.6 reuses the Qwen3.5
+    architecture (HF model_type qwen3_5 -> GGUF arch qwen35), which the native
+    engine already supports — so this confirms the "already supported" claim on a
+    real qwen3.6 checkpoint, not a from-scratch port.
+  acceptance:
+    - API returns a coherent response (no garbage), proving the qwen35 path loads qwen3.6 weights
+    - No CUDA / CUBLAS errors
+    - Model does not spread across more GPUs than its footprint needs
+    - Model unloads cleanly
+  notes: |
+    Prerequisite: qwen3.6:27b must be pre-pulled on the runner before this test.
+    Dense variant (~17GB), splits across 2x K80 GPUs (each ~11441 MiB).
+    Acceptable warning (NOT an error): "flash attention enabled but not supported
+    by gpu" — K80 has no FA; normal fallback.
+
+steps:
+  - name: Test inference
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"qwen3.6:27b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
+        | head -c 2000
+    expectPatterns:
+      - "response"
+    rejectPatterns:
+      - "CUBLAS_STATUS"
+      - "CUDA error"
+
+  - name: Check GPU memory
+    command: docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    expectPatterns:
+      - "[0-9]+ MiB"
+
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
+  - name: Unload model
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"qwen3.6:27b","keep_alive":0}'
+      echo "Model unloaded"
+    expectPatterns:
+      - "Model unloaded"
+
+criteria: |
+  Validate qwen3.6:27b (~17GB VRAM, multi-GPU layer splitting) runs on K80 (compute 3.7).
+  Qwen3.6 reuses the qwen35 (Qwen3.5 DeltaNet hybrid) architecture, so it loads through
+  the existing native-engine path. Model exceeds a single K80 GPU (~11441 MiB), requires
+  splitting across 2x K80 GPUs.
+  Prerequisite: Model must be pre-pulled before running this test.
+
+  Expected:
+  - API returns JSON with "response" field containing coherent text
+  - GPU memory is allocated on multiple GPUs (visible in nvidia-smi)
+  - GPU count: model must not use more GPUs than needed. Each K80 GPU has 11441 MiB.
+    If total VRAM fits in (active_gpus - 1) GPUs, the model is wasting GPUs.
+  - No CUDA/CUBLAS errors in output
+  - Model unloads successfully
+
+  Acceptable warnings (NOT errors):
+  - "flash attention enabled but not supported by gpu" - K80 does not support
+    flash attention, this is a normal fallback warning, NOT an error


### PR DESCRIPTION
## Summary
Adds `cicd/tests/testcases/models/TC-MODELS-014.yml` — a model-suite test for `qwen3.6:27b`, which reuses the `qwen35` (Qwen3.5 DeltaNet hybrid) architecture (HF `model_type: qwen3_5`). Mirrors TC-MODELS-010 (qwen3.5:27b) with a full `intent:` block + `issue: 176`.

## Validation (on K80, this branch)
- Pulled `qwen3.6:27b` (17.4 GB) and ran TC-MODELS-014 directly via the framework with the LLM judge.
- Loads through the native `qwen35` path, **2-GPU layer split (35 + 30)**, FA on, q8_0 KV.
- Coherent output: prompt "What is 2+2? Answer briefly." → `"4."` with a correct thinking trace. Response/thinking correctly separated by the existing parser (also confirms #175 is a no-op).
- `GPU_COUNT_OK` on a clean run.

## Note
The shared TC-MODELS GPU-count check remains subject to the intermittent #138 93 MiB ghost allocation (a CUDA primary context on a layerless GPU; ollama-engine path, recurring). It's flaky across the whole suite, not specific to this test — tracked in #98 (allocation-attribution metric) and a deferred #138 follow-up. Passes on a clean run.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)