### PR TITLE
GPU memory attribution + labeled breakdown in /api/metrics (#98)

### DIFF
--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -753,8 +753,6 @@ func (b *Backend) BackendDevices() []ml.DeviceInfo {
 		C.ggml_backend_dev_memory(dev, &props.memory_free, &props.memory_total)
 		info.TotalMemory = (uint64)(props.memory_total)
 		info.FreeMemory = (uint64)(props.memory_free)
-		info.ContextMemory = (uint64)(props.context_memory)
-		info.CublasMemory = (uint64)(props.cublas_memory)
 
 		deviceInfos = append(deviceInfos, info)
 	}

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -106,6 +106,10 @@ type Backend struct {
 	// requiredMemory is the cumulative memory allocations needed by the backend
 	requiredMemory *ml.BackendMemory
 
+	// gpuDevices holds the GPU device handles parallel to requiredMemory.GPUs,
+	// so per-device allocation labels (#98) can be read at report time.
+	gpuDevices []C.ggml_backend_dev_t
+
 	// btDeviceMemory maps from a buffer type to the memory allocations associated with that device
 	btDeviceMemory map[C.ggml_backend_buffer_type_t]*ml.DeviceMemory
 
@@ -429,6 +433,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		sched:             sched,
 		schedBackends:     schedBackends,
 		schedBufts:        schedBufts,
+		gpuDevices:        gpus,
 		input:             deviceBufferTypes[input.d],
 		output:            output.d,
 		layers: func() map[int]layerDevice {
@@ -646,6 +651,17 @@ nextDevice:
 }
 
 func (b *Backend) BackendMemory() ml.BackendMemory {
+	// Enrich per-GPU allocation labels (#98) at report time — by now the CUDA
+	// context and cuBLAS workspace exist, and get_props reads cached values
+	// (no new CUDA context is created).
+	for i := range b.requiredMemory.GPUs {
+		if i < len(b.gpuDevices) {
+			var props C.struct_ggml_backend_dev_props
+			C.ggml_backend_dev_get_props(b.gpuDevices[i], &props)
+			b.requiredMemory.GPUs[i].Context = uint64(props.context_memory)
+			b.requiredMemory.GPUs[i].Cublas = uint64(props.cublas_memory)
+		}
+	}
 	return *b.requiredMemory
 }
 

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -737,6 +737,8 @@ func (b *Backend) BackendDevices() []ml.DeviceInfo {
 		C.ggml_backend_dev_memory(dev, &props.memory_free, &props.memory_total)
 		info.TotalMemory = (uint64)(props.memory_total)
 		info.FreeMemory = (uint64)(props.memory_free)
+		info.ContextMemory = (uint64)(props.context_memory)
+		info.CublasMemory = (uint64)(props.cublas_memory)
 
 		deviceInfos = append(deviceInfos, info)
 	}

--- a/ml/backend/ggml/ggml/include/ggml-backend.h
+++ b/ml/backend/ggml/ggml/include/ggml-backend.h
@@ -177,6 +177,13 @@ extern "C" {
         const char *library;
         // number with which the devices are accessed (Vulkan)
         const char *numeric_id;
+        // ollama (#98): labeled components of otherwise-unaccounted VRAM, in
+        // bytes. context_memory = CUDA primary context + driver/kernel baseline;
+        // cublas_memory = cuBLAS GEMM workspace. 0 until the device is activated.
+        // Read from cached per-device measurements, so fetching props does not
+        // create a CUDA context.
+        size_t context_memory;
+        size_t cublas_memory;
     };
 
     GGML_API const char *                  ggml_backend_dev_name(ggml_backend_dev_t device);

--- a/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
@@ -1024,8 +1024,15 @@ struct ggml_backend_cuda_context {
     cublasHandle_t cublas_handle(int device) {
         if (cublas_handles[device] == nullptr) {
             ggml_cuda_set_device(device);
+            // Label the "unaccounted" memory (#98): cublasCreate allocates a GEMM
+            // workspace. Snapshot free before/after to attribute that component.
+            size_t free_before = 0, free_after = 0, total_b = 0;
+            cudaMemGetInfo(&free_before, &total_b);
             CUBLAS_CHECK(cublasCreate(&cublas_handles[device]));
             CUBLAS_CHECK(cublasSetMathMode(cublas_handles[device], CUBLAS_TF32_TENSOR_OP_MATH));
+            cudaMemGetInfo(&free_after, &total_b);
+            GGML_LOG_DEBUG("memlabel: device %d cuBLAS workspace = %zu MiB\n",
+                           device, (free_before - free_after) / (1024 * 1024));
         }
         return cublas_handles[device];
     }

--- a/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
@@ -884,6 +884,12 @@ struct ggml_cuda_device_info {
 const ggml_cuda_device_info & ggml_cuda_info();
 
 void ggml_cuda_set_device(int device);
+
+// ollama (#98): cached per-device labels for otherwise-unaccounted VRAM, in
+// bytes. Filled lazily at first device activation / first cuBLAS handle creation
+// so device props can report them without creating a CUDA context.
+extern size_t g_memlabel_context_bytes[GGML_CUDA_MAX_DEVICES];
+extern size_t g_memlabel_cublas_bytes[GGML_CUDA_MAX_DEVICES];
 int ggml_cuda_get_device();
 
 struct ggml_cuda_pool {
@@ -1031,6 +1037,9 @@ struct ggml_backend_cuda_context {
             CUBLAS_CHECK(cublasCreate(&cublas_handles[device]));
             CUBLAS_CHECK(cublasSetMathMode(cublas_handles[device], CUBLAS_TF32_TENSOR_OP_MATH));
             cudaMemGetInfo(&free_after, &total_b);
+            if (device >= 0 && device < GGML_CUDA_MAX_DEVICES && free_before > free_after) {
+                g_memlabel_cublas_bytes[device] = free_before - free_after;
+            }
             GGML_LOG_DEBUG("memlabel: device %d cuBLAS workspace = %zu MiB\n",
                            device, (free_before - free_after) / (1024 * 1024));
         }

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -95,6 +95,10 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
 
 // this is faster on Windows
 // probably because the Windows CUDA libraries forget to make this check before invoking the drivers
+// ollama (#98): cached per-device labels for otherwise-unaccounted VRAM (bytes).
+size_t g_memlabel_context_bytes[GGML_CUDA_MAX_DEVICES] = {0};
+size_t g_memlabel_cublas_bytes[GGML_CUDA_MAX_DEVICES]  = {0};
+
 void ggml_cuda_set_device(int device) {
     int current_device;
     CUDA_CHECK(cudaGetDevice(&current_device));
@@ -114,6 +118,7 @@ void ggml_cuda_set_device(int device) {
         ctx_logged[device] = true;
         size_t free_b = 0, total_b = 0;
         if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) {
+            g_memlabel_context_bytes[device] = total_b - free_b;
             GGML_LOG_DEBUG("memlabel: device %d CUDA primary context+baseline = %zu MiB\n",
                            device, (total_b - free_b) / (1024 * 1024));
         }
@@ -3707,6 +3712,16 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
     // Memory reporting is disabled to avoid allocation of a CUDA primary context (~300 MB per device).
     // If you need the memory data, call ggml_backend_dev_memory() explicitly.
     props->memory_total = props->memory_free = 0;
+
+    // ollama (#98): report cached allocation labels (no CUDA call here, so this
+    // does not create a context). 0 until the device has been activated.
+    if (ctx->device >= 0 && ctx->device < GGML_CUDA_MAX_DEVICES) {
+        props->context_memory = g_memlabel_context_bytes[ctx->device];
+        props->cublas_memory  = g_memlabel_cublas_bytes[ctx->device];
+    } else {
+        props->context_memory = 0;
+        props->cublas_memory  = 0;
+    }
 
 #if defined(GGML_USE_HIP)
     int cc = ggml_cuda_info().devices[ctx->device].cc - GGML_CUDA_CC_OFFSET_AMD;

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -104,6 +104,20 @@ void ggml_cuda_set_device(int device) {
     }
 
     CUDA_CHECK(cudaSetDevice(device));
+
+    // Label the "unaccounted" memory (#98): the first activation of a device
+    // creates its CUDA primary context. total-free here (before any GGML buffer
+    // or cuBLAS handle) is the bare context + driver baseline — the dominant
+    // component of the ghost allocation on a layerless GPU.
+    static bool ctx_logged[GGML_CUDA_MAX_DEVICES] = {false};
+    if (device >= 0 && device < GGML_CUDA_MAX_DEVICES && !ctx_logged[device]) {
+        ctx_logged[device] = true;
+        size_t free_b = 0, total_b = 0;
+        if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) {
+            GGML_LOG_DEBUG("memlabel: device %d CUDA primary context+baseline = %zu MiB\n",
+                           device, (total_b - free_b) / (1024 * 1024));
+        }
+    }
 }
 
 int ggml_cuda_get_device() {

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -93,12 +93,12 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
     GGML_ABORT(GGML_CUDA_NAME " error");
 }
 
-// this is faster on Windows
-// probably because the Windows CUDA libraries forget to make this check before invoking the drivers
 // ollama (#98): cached per-device labels for otherwise-unaccounted VRAM (bytes).
 size_t g_memlabel_context_bytes[GGML_CUDA_MAX_DEVICES] = {0};
 size_t g_memlabel_cublas_bytes[GGML_CUDA_MAX_DEVICES]  = {0};
 
+// this is faster on Windows
+// probably because the Windows CUDA libraries forget to make this check before invoking the drivers
 void ggml_cuda_set_device(int device) {
     int current_device;
     CUDA_CHECK(cudaGetDevice(&current_device));
@@ -109,35 +109,29 @@ void ggml_cuda_set_device(int device) {
 
     CUDA_CHECK(cudaSetDevice(device));
 
-    // Label the "unaccounted" memory (#98), without inducing it. cudaMemGetInfo
-    // would be the first CUDA call on a freshly-set device and would *create* the
-    // primary context we want to measure (a Heisenbug that manufactures ghosts on
-    // layerless GPUs). Instead poll the driver API cuDevicePrimaryCtxGetState,
-    // which reports whether the runtime already created the context WITHOUT
-    // creating one. Measure only on the transition to active, so:
-    //   - we never induce a context, and
-    //   - active==true on a device with no layers is the runtime's *own* ghost.
-    static int ctx_active_state[GGML_CUDA_MAX_DEVICES];
-    static bool ctx_state_init = false;
-    if (!ctx_state_init) {
-        for (int i = 0; i < GGML_CUDA_MAX_DEVICES; ++i) ctx_active_state[i] = -1;
-        ctx_state_init = true;
-    }
-    if (device >= 0 && device < GGML_CUDA_MAX_DEVICES) {
+    // Label the "unaccounted" memory (#98), without inducing it, and without
+    // adding cost to this hot path once measured. cudaMemGetInfo would be the
+    // first CUDA call on a freshly-set device and would *create* the primary
+    // context we want to measure (a Heisenbug that manufactures ghosts on
+    // layerless GPUs). Until a device is measured, poll the driver API
+    // cuDevicePrimaryCtxGetState (non-creating) to detect when the runtime has
+    // created the context, then measure once and never touch the driver here
+    // again. ctx_measured is best-effort (set-once, value-stable), so an
+    // unsynchronized racing read at worst causes a redundant measurement.
+    static bool ctx_measured[GGML_CUDA_MAX_DEVICES] = {false};
+    if (device >= 0 && device < GGML_CUDA_MAX_DEVICES && !ctx_measured[device]) {
         CUdevice cudev;
         unsigned int flags = 0;
         int active = 0;
         if (cuDeviceGet(&cudev, device) == CUDA_SUCCESS &&
             cuDevicePrimaryCtxGetState(cudev, &flags, &active) == CUDA_SUCCESS &&
-            active != ctx_active_state[device]) {
-            ctx_active_state[device] = active;
-            if (active) {
-                size_t free_b = 0, total_b = 0;
-                if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) { // safe: ctx already active
-                    g_memlabel_context_bytes[device] = total_b - free_b;
-                    GGML_LOG_DEBUG("memlabel: device %d primary context active, baseline = %zu MiB\n",
-                                   device, (total_b - free_b) / (1024 * 1024));
-                }
+            active) {
+            ctx_measured[device] = true;
+            size_t free_b = 0, total_b = 0;
+            if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) { // safe: ctx already active
+                g_memlabel_context_bytes[device] = total_b - free_b;
+                GGML_LOG_DEBUG("memlabel: device %d primary context active, baseline = %zu MiB\n",
+                               device, (total_b - free_b) / (1024 * 1024));
             }
         }
     }

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -109,18 +109,36 @@ void ggml_cuda_set_device(int device) {
 
     CUDA_CHECK(cudaSetDevice(device));
 
-    // Label the "unaccounted" memory (#98): the first activation of a device
-    // creates its CUDA primary context. total-free here (before any GGML buffer
-    // or cuBLAS handle) is the bare context + driver baseline — the dominant
-    // component of the ghost allocation on a layerless GPU.
-    static bool ctx_logged[GGML_CUDA_MAX_DEVICES] = {false};
-    if (device >= 0 && device < GGML_CUDA_MAX_DEVICES && !ctx_logged[device]) {
-        ctx_logged[device] = true;
-        size_t free_b = 0, total_b = 0;
-        if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) {
-            g_memlabel_context_bytes[device] = total_b - free_b;
-            GGML_LOG_DEBUG("memlabel: device %d CUDA primary context+baseline = %zu MiB\n",
-                           device, (total_b - free_b) / (1024 * 1024));
+    // Label the "unaccounted" memory (#98), without inducing it. cudaMemGetInfo
+    // would be the first CUDA call on a freshly-set device and would *create* the
+    // primary context we want to measure (a Heisenbug that manufactures ghosts on
+    // layerless GPUs). Instead poll the driver API cuDevicePrimaryCtxGetState,
+    // which reports whether the runtime already created the context WITHOUT
+    // creating one. Measure only on the transition to active, so:
+    //   - we never induce a context, and
+    //   - active==true on a device with no layers is the runtime's *own* ghost.
+    static int ctx_active_state[GGML_CUDA_MAX_DEVICES];
+    static bool ctx_state_init = false;
+    if (!ctx_state_init) {
+        for (int i = 0; i < GGML_CUDA_MAX_DEVICES; ++i) ctx_active_state[i] = -1;
+        ctx_state_init = true;
+    }
+    if (device >= 0 && device < GGML_CUDA_MAX_DEVICES) {
+        CUdevice cudev;
+        unsigned int flags = 0;
+        int active = 0;
+        if (cuDeviceGet(&cudev, device) == CUDA_SUCCESS &&
+            cuDevicePrimaryCtxGetState(cudev, &flags, &active) == CUDA_SUCCESS &&
+            active != ctx_active_state[device]) {
+            ctx_active_state[device] = active;
+            if (active) {
+                size_t free_b = 0, total_b = 0;
+                if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) { // safe: ctx already active
+                    g_memlabel_context_bytes[device] = total_b - free_b;
+                    GGML_LOG_DEBUG("memlabel: device %d primary context active, baseline = %zu MiB\n",
+                                   device, (total_b - free_b) / (1024 * 1024));
+                }
+            }
         }
     }
 }

--- a/ml/device.go
+++ b/ml/device.go
@@ -272,6 +272,12 @@ type DeviceInfo struct {
 	// FreeMemory is the amount of memory currently available on the device for loading models
 	FreeMemory uint64 `json:"free_memory,omitempty"`
 
+	// ContextMemory and CublasMemory label otherwise-unaccounted VRAM (#98):
+	// the CUDA primary context + driver/kernel baseline, and the cuBLAS GEMM
+	// workspace. 0 until the device has been activated / used for a matmul.
+	ContextMemory uint64 `json:"context_memory,omitempty"`
+	CublasMemory  uint64 `json:"cublas_memory,omitempty"`
+
 	// ComputeMajor is the major version of capabilities of the device
 	// if unsupported by the backend, -1 will be returned
 	ComputeMajor int

--- a/ml/device.go
+++ b/ml/device.go
@@ -278,12 +278,6 @@ type DeviceInfo struct {
 	// FreeMemory is the amount of memory currently available on the device for loading models
 	FreeMemory uint64 `json:"free_memory,omitempty"`
 
-	// ContextMemory and CublasMemory label otherwise-unaccounted VRAM (#98):
-	// the CUDA primary context + driver/kernel baseline, and the cuBLAS GEMM
-	// workspace. 0 until the device has been activated / used for a matmul.
-	ContextMemory uint64 `json:"context_memory,omitempty"`
-	CublasMemory  uint64 `json:"cublas_memory,omitempty"`
-
 	// ComputeMajor is the major version of capabilities of the device
 	// if unsupported by the backend, -1 will be returned
 	ComputeMajor int

--- a/ml/device.go
+++ b/ml/device.go
@@ -130,6 +130,12 @@ type DeviceMemory struct {
 
 	// Graph is the size of the compute graph. It is not per-layer.
 	Graph uint64
+
+	// Context and Cublas label otherwise-unaccounted device VRAM (#98):
+	// the CUDA primary context + driver/kernel baseline, and the cuBLAS GEMM
+	// workspace. Populated at report time from cached per-device measurements.
+	Context uint64
+	Cublas  uint64
 }
 
 func sumMemory(mem []uint64) uint64 {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -38,6 +38,23 @@ type GPUMetrics struct {
 	VRAMFree    uint64 `json:"vram_free,omitempty"`
 	ComputeCap  string `json:"compute_cap,omitempty"` // e.g. "3.7"
 	LibraryPath string `json:"library_path,omitempty"`
+
+	// Allocation attribution (derived). VRAMUsed is the physical usage on the
+	// device (total - free, from NVML). VRAMAccounted is the sum that loaded
+	// models report placing here. VRAMUnaccounted = used - accounted is
+	// allocation the model layout does not explain — CUDA primary contexts,
+	// "ghost" allocations, or other processes sharing the device.
+	VRAMUsed        uint64 `json:"vram_used,omitempty"`
+	VRAMAccounted   uint64 `json:"vram_accounted,omitempty"`
+	VRAMUnaccounted uint64 `json:"vram_unaccounted,omitempty"`
+	// HasModelLayers is true when a loaded model placed layers on this device.
+	HasModelLayers bool `json:"has_model_layers"`
+	// Ghost flags a device carrying physical usage above idle while holding no
+	// model layers — the signature of the 93 MiB ghost allocation (#98/#138)
+	// that wakes an otherwise-idle GPU. NOTE: VRAMUsed is physical and includes
+	// any other process on the device, so treat Ghost as a flag to investigate,
+	// not proof of an ollama-created context.
+	Ghost bool `json:"ghost,omitempty"`
 }
 
 type ModelMetrics struct {
@@ -150,6 +167,35 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			m.VRAMBreakdown = perGPUBreakdown(mem)
 		}
 		models = append(models, m)
+	}
+
+	// Attribute physical per-GPU usage against what loaded models account for.
+	// The gap surfaces ghost/context allocations (#98/#138): a device with
+	// usage above idle but no model layers is flagged as a ghost to investigate.
+	const idleBaselineBytes = 20 * 1024 * 1024 // K80 idle is ~4 MiB; allow margin
+	accountedByGPU := make(map[string]uint64, len(gpus))
+	layersByGPU := make(map[string]bool, len(gpus))
+	for _, m := range models {
+		for id, v := range m.VRAMByGPU {
+			accountedByGPU[id] += v
+		}
+		for _, id := range m.GPUs {
+			layersByGPU[id] = true
+		}
+	}
+	for i := range gpus {
+		g := &gpus[i]
+		if g.VRAMTotal > g.VRAMFree {
+			g.VRAMUsed = g.VRAMTotal - g.VRAMFree
+		}
+		g.VRAMAccounted = accountedByGPU[g.ID]
+		if g.VRAMUsed > g.VRAMAccounted {
+			g.VRAMUnaccounted = g.VRAMUsed - g.VRAMAccounted
+		}
+		g.HasModelLayers = layersByGPU[g.ID]
+		if !g.HasModelLayers && g.VRAMUsed > idleBaselineBytes {
+			g.Ghost = true
+		}
 	}
 
 	c.JSON(http.StatusOK, MetricsResponse{

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -174,9 +174,38 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 		models = append(models, m)
 	}
 
-	// Attribute physical per-GPU usage against what loaded models account for.
-	// The gap surfaces ghost/context allocations (#98/#138): a device with
-	// usage above idle but no model layers is flagged as a ghost to investigate.
+	attributeGPUUsage(gpus, models)
+
+	c.JSON(http.StatusOK, MetricsResponse{
+		GPUs:   gpus,
+		Models: models,
+		Errors: s.sched.metrics.snapshot(),
+		Totals: ServerTotals{
+			LoadedModels: len(runners),
+			GPUCount:     len(devices),
+		},
+	})
+}
+
+func (m *serverMetrics) snapshot() ErrorCounters {
+	if m == nil {
+		return ErrorCounters{}
+	}
+	return ErrorCounters{
+		LoadFailures:    m.loadFailures.Load(),
+		LoadRequireFull: m.loadRequireFull.Load(),
+		LoadOther:       m.loadOther.Load(),
+		EvictionsTotal:  m.evictionsTotal.Load(),
+	}
+}
+
+// attributeGPUUsage fills the derived per-GPU attribution fields (VRAMUsed,
+// VRAMAccounted, VRAMUnaccounted, HasModelLayers, Ghost) in place, from physical
+// device usage and what loaded models report placing on each device. A device
+// carrying usage above idle while holding no model layers is flagged as a ghost
+// to investigate (#98/#138). VRAMUsed is physical, so it includes any other
+// process on the device — Ghost is a flag, not proof of an ollama context.
+func attributeGPUUsage(gpus []GPUMetrics, models []ModelMetrics) {
 	const idleBaselineBytes = 20 * 1024 * 1024 // K80 idle is ~4 MiB; allow margin
 	accountedByGPU := make(map[string]uint64, len(gpus))
 	layersByGPU := make(map[string]bool, len(gpus))
@@ -201,28 +230,6 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 		if !g.HasModelLayers && g.VRAMUsed > idleBaselineBytes {
 			g.Ghost = true
 		}
-	}
-
-	c.JSON(http.StatusOK, MetricsResponse{
-		GPUs:   gpus,
-		Models: models,
-		Errors: s.sched.metrics.snapshot(),
-		Totals: ServerTotals{
-			LoadedModels: len(runners),
-			GPUCount:     len(devices),
-		},
-	})
-}
-
-func (m *serverMetrics) snapshot() ErrorCounters {
-	if m == nil {
-		return ErrorCounters{}
-	}
-	return ErrorCounters{
-		LoadFailures:    m.loadFailures.Load(),
-		LoadRequireFull: m.loadRequireFull.Load(),
-		LoadOther:       m.loadOther.Load(),
-		EvictionsTotal:  m.evictionsTotal.Load(),
 	}
 }
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -47,14 +47,10 @@ type GPUMetrics struct {
 	VRAMUsed        uint64 `json:"vram_used,omitempty"`
 	VRAMAccounted   uint64 `json:"vram_accounted,omitempty"`
 	VRAMUnaccounted uint64 `json:"vram_unaccounted,omitempty"`
-	// Labeled components of the unaccounted memory (#98), in bytes:
-	// VRAMContext = CUDA primary context + driver/kernel baseline,
-	// VRAMCublas = cuBLAS GEMM workspace,
-	// VRAMSlack = remainder (allocator pool slack / other), = unaccounted - context - cublas.
-	VRAMContext uint64 `json:"vram_context,omitempty"`
-	VRAMCublas  uint64 `json:"vram_cublas,omitempty"`
-	VRAMSlack   uint64 `json:"vram_slack,omitempty"`
 	// HasModelLayers is true when a loaded model placed layers on this device.
+	// The labeled components of the unaccounted memory (context, cuBLAS) are
+	// reported per model in ModelMetrics.VRAMBreakdown (#98), since they are
+	// only measurable in the model-runner process.
 	HasModelLayers bool `json:"has_model_layers"`
 	// Ghost flags a device carrying physical usage above idle while holding no
 	// model layers — the signature of the 93 MiB ghost allocation (#98/#138)
@@ -146,8 +142,6 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			VRAMFree:    d.FreeMemory,
 			ComputeCap:  compute,
 			LibraryPath: libPath,
-			VRAMContext: d.ContextMemory,
-			VRAMCublas:  d.CublasMemory,
 		})
 	}
 
@@ -202,10 +196,6 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 		g.VRAMAccounted = accountedByGPU[g.ID]
 		if g.VRAMUsed > g.VRAMAccounted {
 			g.VRAMUnaccounted = g.VRAMUsed - g.VRAMAccounted
-		}
-		// Slack = unaccounted minus the labeled CUDA context + cuBLAS components.
-		if labeled := g.VRAMContext + g.VRAMCublas; g.VRAMUnaccounted > labeled {
-			g.VRAMSlack = g.VRAMUnaccounted - labeled
 		}
 		g.HasModelLayers = layersByGPU[g.ID]
 		if !g.HasModelLayers && g.VRAMUsed > idleBaselineBytes {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -77,9 +77,11 @@ type ModelMetrics struct {
 // VRAMBreakdown decomposes VRAM usage into its three components. Only the Go
 // engine (ollamaServer) tracks this; for llamacpp models it is omitted.
 type VRAMBreakdown struct {
-	Weights uint64 `json:"weights"`  // model weights on GPU
-	KVCache uint64 `json:"kv_cache"` // K/V attention cache
-	Graph   uint64 `json:"graph"`    // scratch compute buffer
+	Weights uint64 `json:"weights"`           // model weights on GPU
+	KVCache uint64 `json:"kv_cache"`          // K/V attention cache
+	Graph   uint64 `json:"graph"`             // scratch compute buffer
+	Context uint64 `json:"context,omitempty"` // CUDA primary context + driver/kernel baseline (#98)
+	Cublas  uint64 `json:"cublas,omitempty"`  // cuBLAS GEMM workspace (#98)
 }
 
 type ErrorCounters struct {
@@ -243,7 +245,7 @@ func perGPUBreakdown(mem *ml.BackendMemory) map[string]*VRAMBreakdown {
 	}
 	out := make(map[string]*VRAMBreakdown, len(mem.GPUs))
 	for _, g := range mem.GPUs {
-		b := &VRAMBreakdown{Graph: g.Graph}
+		b := &VRAMBreakdown{Graph: g.Graph, Context: g.Context, Cublas: g.Cublas}
 		for _, w := range g.Weights {
 			b.Weights += w
 		}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -47,6 +47,13 @@ type GPUMetrics struct {
 	VRAMUsed        uint64 `json:"vram_used,omitempty"`
 	VRAMAccounted   uint64 `json:"vram_accounted,omitempty"`
 	VRAMUnaccounted uint64 `json:"vram_unaccounted,omitempty"`
+	// Labeled components of the unaccounted memory (#98), in bytes:
+	// VRAMContext = CUDA primary context + driver/kernel baseline,
+	// VRAMCublas = cuBLAS GEMM workspace,
+	// VRAMSlack = remainder (allocator pool slack / other), = unaccounted - context - cublas.
+	VRAMContext uint64 `json:"vram_context,omitempty"`
+	VRAMCublas  uint64 `json:"vram_cublas,omitempty"`
+	VRAMSlack   uint64 `json:"vram_slack,omitempty"`
 	// HasModelLayers is true when a loaded model placed layers on this device.
 	HasModelLayers bool `json:"has_model_layers"`
 	// Ghost flags a device carrying physical usage above idle while holding no
@@ -137,6 +144,8 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			VRAMFree:    d.FreeMemory,
 			ComputeCap:  compute,
 			LibraryPath: libPath,
+			VRAMContext: d.ContextMemory,
+			VRAMCublas:  d.CublasMemory,
 		})
 	}
 
@@ -191,6 +200,10 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 		g.VRAMAccounted = accountedByGPU[g.ID]
 		if g.VRAMUsed > g.VRAMAccounted {
 			g.VRAMUnaccounted = g.VRAMUsed - g.VRAMAccounted
+		}
+		// Slack = unaccounted minus the labeled CUDA context + cuBLAS components.
+		if labeled := g.VRAMContext + g.VRAMCublas; g.VRAMUnaccounted > labeled {
+			g.VRAMSlack = g.VRAMUnaccounted - labeled
 		}
 		g.HasModelLayers = layersByGPU[g.ID]
 		if !g.HasModelLayers && g.VRAMUsed > idleBaselineBytes {

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,0 +1,45 @@
+package server
+
+import "testing"
+
+// TestAttributeGPUUsage covers the per-GPU attribution derived in
+// attributeGPUUsage: physical used vs model-accounted, the unaccounted gap, the
+// has-layers flag, and ghost detection (usage above idle on a layerless GPU).
+func TestAttributeGPUUsage(t *testing.T) {
+	const mib = uint64(1024 * 1024)
+
+	gpus := []GPUMetrics{
+		{ID: "model-gpu", VRAMTotal: 12000 * mib, VRAMFree: 2000 * mib},  // used 10000, has layers
+		{ID: "ghost-gpu", VRAMTotal: 12000 * mib, VRAMFree: 11900 * mib}, // used 100, no layers -> ghost
+		{ID: "idle-gpu", VRAMTotal: 12000 * mib, VRAMFree: 11996 * mib},  // used 4, below idle baseline
+	}
+	models := []ModelMetrics{
+		{GPUs: []string{"model-gpu"}, VRAMByGPU: map[string]uint64{"model-gpu": 9800 * mib}},
+	}
+
+	attributeGPUUsage(gpus, models)
+
+	model, ghost, idle := gpus[0], gpus[1], gpus[2]
+
+	// Model GPU: accounted, with a small unaccounted remainder; not a ghost.
+	if !model.HasModelLayers || model.Ghost {
+		t.Errorf("model-gpu HasModelLayers=%v Ghost=%v; want true/false", model.HasModelLayers, model.Ghost)
+	}
+	if model.VRAMUsed != 10000*mib || model.VRAMAccounted != 9800*mib || model.VRAMUnaccounted != 200*mib {
+		t.Errorf("model-gpu used=%d accounted=%d unaccounted=%d; want %d/%d/%d",
+			model.VRAMUsed, model.VRAMAccounted, model.VRAMUnaccounted, 10000*mib, 9800*mib, 200*mib)
+	}
+
+	// Ghost GPU: usage above idle, no layers -> flagged; all of it unaccounted.
+	if ghost.HasModelLayers || !ghost.Ghost {
+		t.Errorf("ghost-gpu HasModelLayers=%v Ghost=%v; want false/true", ghost.HasModelLayers, ghost.Ghost)
+	}
+	if ghost.VRAMUnaccounted != 100*mib {
+		t.Errorf("ghost-gpu unaccounted=%d; want %d", ghost.VRAMUnaccounted, 100*mib)
+	}
+
+	// Idle GPU: usage below the baseline -> not a ghost.
+	if idle.HasModelLayers || idle.Ghost {
+		t.Errorf("idle-gpu HasModelLayers=%v Ghost=%v; want false/false", idle.HasModelLayers, idle.Ghost)
+	}
+}


### PR DESCRIPTION
## Summary
Makes per-GPU VRAM usage fully attributable in `/api/metrics`, motivated by the recurring "ghost" allocation (#138) that wakes an otherwise-idle GPU (verified in Grafana: a ~93–100 MiB context pins the GPU's memory clock 324→2505 MHz, drawing power for zero work).

**GPU-level (per device):**
- `vram_used` (physical), `vram_accounted` (loaded models' layers), `vram_unaccounted` (the gap)
- `has_model_layers`, `ghost` (usage above idle on a GPU with no layers = ghost signature)

**Per-model `vram_breakdown` (per GPU) — labels the unaccounted:**
- existing `weights` / `kv_cache` / `graph`
- new `context` (CUDA primary context + driver/kernel baseline, ~100/170 MiB) and `cublas` (GEMM workspace, ~67 MiB)

The labels are measured in the **model-runner process** (where the allocations happen) and flow via the existing memory-report IPC — the device-discovery path can't see them (separate process).

## Instrumentation
- `memlabel` snapshots (level-gated `GGML_LOG_DEBUG`) attribute the context and cuBLAS components.
- Context is measured **non-inducingly** via the driver API `cuDevicePrimaryCtxGetState` — an earlier `cudaMemGetInfo`-after-`set_device` was the first CUDA call on set-but-unused devices and *manufactured* ghost contexts (a Heisenbug); fixed.

## Verified on K80
```
GPU-3032  weights=8132 kv=1705 graph=480  context=101 cublas=67
GPU-81a5  weights=7759 kv=2172 graph=506  context=170 cublas=67
```
Ghost detection catches a real layerless-GPU context truthfully (no instrument-induced false positives). Build + runtime checks pass.

## Known limitation / follow-ups
- Labels are accurate **attribution**, not an exact byte-partition (~0.4% overlap from mixing logical buffer accounting with physical snapshots) — tracked in #183.
- The runtime's real (intermittent) ghost root-cause fix is deferred (couldn't reproduce on demand; the non-inducing metric will now catch it in production).

Part of #98. Relates to #138, #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)