### PR TITLE
MLX-on-K80 Phase A+B: libmlx.a compute core + qwen_smoke link milestone + CI (#188)

### DIFF
--- a/.github/workflows/test-mlx-smoke.yml
+++ b/.github/workflows/test-mlx-smoke.yml
@@ -1,0 +1,185 @@
+name: MLX Smoke Link
+
+# Phase B link-surface probe for the MLX-on-K80 port (#188). Builds libmlx.a +
+# qwen_smoke in the builder image, then runs qwen_smoke in the production
+# runtime image with K80 GPUs exposed. The split surfaces real ld/runtime gaps
+# (missing CUDA toolkit libs, libstdc++ delta) that would otherwise stay hidden
+# behind the builder image's full toolchain.
+#
+# Follows test-workflow-pattern (#158): test logic lives in
+# cicd/scripts/test-mlx-smoke.sh; this YAML orchestrates container lifecycle
+# (stop production ollama37 → run script → restart production → upload).
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_build:
+        description: "Skip the rebuild step (reuse /tmp/test-mlx-smoke-build/qwen_smoke)"
+        required: false
+        default: false
+        type: boolean
+      build_image:
+        description: "Builder image (full toolchain)"
+        required: false
+        default: "ollama37-builder:latest"
+        type: string
+      runtime_image:
+        description: "Runtime image (production target)"
+        required: false
+        default: "ollama37:latest"
+        type: string
+
+jobs:
+  mlx-smoke:
+    name: Build + run qwen_smoke
+    runs-on: self-hosted
+    environment: cicd-1
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stop production ollama37
+        run: |
+          docker stop ollama37 || true
+          # Defensive: clear any stale smoke-test containers from prior failed runs.
+          docker rm -f ollama37-mlx-smoke 2>/dev/null || true
+
+          # Poll until VRAM drops below 1 GiB on GPU 0 (where qwen_smoke runs)
+          # or 30s timeout. Matches the test-fa-k80 stop pattern.
+          for i in $(seq 1 30); do
+            USED=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | head -1 | tr -d ' ')
+            if [ "$USED" -lt 1024 ]; then
+              echo "VRAM released after ${i}s: ${USED} MiB"
+              break
+            fi
+            sleep 1
+          done
+          nvidia-smi --query-gpu=memory.used --format=csv,noheader | head -3
+
+      - name: Run mlx smoke
+        id: smoke
+        env:
+          BUILD_IMAGE: ${{ inputs.build_image || 'ollama37-builder:latest' }}
+          RUNTIME_IMAGE: ${{ inputs.runtime_image || 'ollama37:latest' }}
+          SKIP_BUILD_FLAG: ${{ inputs.skip_build && '--skip-build' || '' }}
+        run: |
+          ARGS=(
+            --build-image "$BUILD_IMAGE"
+            --runtime-image "$RUNTIME_IMAGE"
+            --build-dir /tmp/test-mlx-smoke-build
+            --results-json /tmp/test-mlx-smoke-results.json
+          )
+          if [ -n "$SKIP_BUILD_FLAG" ]; then
+            ARGS+=("$SKIP_BUILD_FLAG")
+          fi
+
+          bash cicd/scripts/test-mlx-smoke.sh "${ARGS[@]}"
+
+      - name: Generate summary
+        if: always()
+        run: |
+          if [ ! -f /tmp/test-mlx-smoke-results.json ]; then
+            echo "No results JSON to summarize" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          SHA=$(jq -r '.git_sha' /tmp/test-mlx-smoke-results.json)
+          GPU_COUNT=$(jq -r '.gpu.device_count' /tmp/test-mlx-smoke-results.json)
+          BUILD_STATUS=$(jq -r '.build.status' /tmp/test-mlx-smoke-results.json)
+          BUILD_DUR=$(jq -r '.build.duration_sec' /tmp/test-mlx-smoke-results.json)
+          LIBMLX_SIZE=$(jq -r '.build.libmlx_size_bytes' /tmp/test-mlx-smoke-results.json)
+          LIBMLX_OBJS=$(jq -r '.build.libmlx_object_count' /tmp/test-mlx-smoke-results.json)
+          EXE_SIZE=$(jq -r '.build.exe_size_bytes' /tmp/test-mlx-smoke-results.json)
+          RUN_STATUS=$(jq -r '.run.status' /tmp/test-mlx-smoke-results.json)
+          RUN_EXIT=$(jq -r '.run.exit_code' /tmp/test-mlx-smoke-results.json)
+          RUN_DUR=$(jq -r '.run.duration_sec' /tmp/test-mlx-smoke-results.json)
+          FINAL_EXIT=$(jq -r '.final_exit' /tmp/test-mlx-smoke-results.json)
+          LDD_MISSING=$(jq -r '.run.ldd_missing' /tmp/test-mlx-smoke-results.json)
+
+          {
+            echo "## MLX Smoke Link"
+            echo ""
+            echo "**Commit:** \`${SHA}\` · **GPUs visible:** ${GPU_COUNT} · **Final exit:** \`${FINAL_EXIT}\`"
+            echo ""
+            echo "| Phase   | Status         | Duration | Detail |"
+            echo "|---------|----------------|----------|--------|"
+            echo "| build   | ${BUILD_STATUS} | ${BUILD_DUR}s | libmlx.a ${LIBMLX_SIZE}B · ${LIBMLX_OBJS} objs · qwen_smoke ${EXE_SIZE}B |"
+            echo "| run     | ${RUN_STATUS} | ${RUN_DUR}s | exit=${RUN_EXIT} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$RUN_STATUS" != "success" ] && [ -n "$LDD_MISSING" ]; then
+            {
+              echo ""
+              echo "### Missing libs (ldd)"
+              echo ""
+              echo '```'
+              echo "$LDD_MISSING"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$BUILD_STATUS" = "failed" ]; then
+            {
+              echo ""
+              echo "### Build log tail"
+              echo ""
+              echo '```'
+              jq -r '.build.log_tail' /tmp/test-mlx-smoke-results.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$RUN_STATUS" = "failed" ]; then
+            {
+              echo ""
+              echo "### Run stdout (tail)"
+              echo ""
+              echo '```'
+              jq -r '.run.stdout' /tmp/test-mlx-smoke-results.json
+              echo '```'
+              echo ""
+              echo "### Run stderr (tail)"
+              echo ""
+              echo '```'
+              jq -r '.run.stderr' /tmp/test-mlx-smoke-results.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Restart production ollama37
+        if: always()
+        run: |
+          docker rm -f ollama37-mlx-smoke 2>/dev/null || true
+
+          if docker ps -a --filter "name=^ollama37$" --format '{{.Names}}' | grep -q ollama37; then
+            docker start ollama37 || true
+          else
+            cd docker && docker compose up -d || true
+          fi
+
+      - name: Verify production ollama37 recovered
+        if: always()
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
+              echo "production ollama37 healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::production ollama37 did not recover within 60s"
+          docker logs ollama37 2>&1 | tail -50 || true
+          exit 1
+
+      - name: Upload mlx smoke results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mlx-smoke-${{ github.run_id }}
+          path: |
+            /tmp/test-mlx-smoke-results.json
+            /tmp/test-mlx-smoke-build/build.log
+            /tmp/test-mlx-smoke-build/run.stdout
+            /tmp/test-mlx-smoke-build/run.stderr

--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# test-mlx-smoke.sh — Phase B link-surface probe for the MLX-on-K80 port (#188).
+#
+# Builds libmlx.a + qwen_smoke (the on-path forward-surface probe exe) in the
+# builder image, then runs qwen_smoke in the PRODUCTION RUNTIME image with the
+# K80 GPUs exposed. The split is intentional: building in the builder image
+# masks runtime gaps (libstdc++ delta, missing CUDA toolkit libs, etc.); only
+# running in the runtime image surfaces what the eventual mlx runner exe will
+# actually hit. See docs/traces/mlx-cuda-runtime-path.md for context.
+#
+# Production ollama37 stop/start is handled by the caller (the workflow YAML)
+# so the K80 GPUs are free.
+#
+# Output:
+#   /tmp/test-mlx-smoke-results.json — structured result with build + run sections
+#   /tmp/test-mlx-smoke-build/        — build artifacts (libmlx.a, qwen_smoke, logs)
+#
+# Exit codes (load-bearing — workflow red/green follows):
+#   0 = build OK + qwen_smoke ran and printed the success line
+#   1 = build failed (compile or link error in libmlx.a / qwen_smoke)
+#   2 = build OK but qwen_smoke errored at runtime (linker resolve / throw)
+#   3 = environment issue (missing images, no GPU, etc.)
+#
+# Usage: test-mlx-smoke.sh [--build-image IMG] [--runtime-image IMG]
+#                          [--build-dir DIR]   [--results-json PATH]
+#                          [--skip-build]
+
+set -euo pipefail
+
+BUILD_IMAGE="${BUILD_IMAGE:-ollama37-builder:latest}"
+RUNTIME_IMAGE="${RUNTIME_IMAGE:-ollama37:latest}"
+BUILD_DIR="${BUILD_DIR:-/tmp/test-mlx-smoke-build}"
+RESULTS_JSON="${RESULTS_JSON:-/tmp/test-mlx-smoke-results.json}"
+SRC_DIR="${SRC_DIR:-$(git rev-parse --show-toplevel)}"
+SKIP_BUILD=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --build-image) BUILD_IMAGE="$2"; shift 2 ;;
+        --runtime-image) RUNTIME_IMAGE="$2"; shift 2 ;;
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --results-json) RESULTS_JSON="$2"; shift 2 ;;
+        --skip-build) SKIP_BUILD=true; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 3 ;;
+    esac
+done
+
+GIT_SHA="$(cd "$SRC_DIR" && git rev-parse HEAD)"
+
+# Result fields, initialized to "unknown / not reached" defaults. Each phase
+# updates the ones it owns; trap on EXIT serializes whatever's in scope.
+BUILD_STATUS="not_run"
+BUILD_DURATION=0
+BUILD_LOG_TAIL=""
+LIBMLX_SIZE=0
+LIBMLX_OBJECT_COUNT=0
+EXE_SIZE=0
+EXE_PATH=""
+
+RUN_STATUS="skipped"
+RUN_EXIT_CODE=-1
+RUN_DURATION=0
+RUN_STDOUT=""
+RUN_STDERR=""
+LDD_OUTPUT=""
+LDD_MISSING=""
+
+GPU_DEVICE_COUNT=0
+GPU_NAMES=""
+
+FINAL_EXIT=0
+
+# shellcheck disable=SC2329 # invoked via `trap` below
+write_results() {
+    # Always run on exit; emits whatever was filled in. jq object keys are
+    # quoted to avoid reserved-word collisions (per lint-ci skill).
+    jq -n \
+        --arg sha "$GIT_SHA" \
+        --arg build_image "$BUILD_IMAGE" \
+        --arg runtime_image "$RUNTIME_IMAGE" \
+        --arg build_status "$BUILD_STATUS" \
+        --argjson build_duration "$BUILD_DURATION" \
+        --arg build_log_tail "$BUILD_LOG_TAIL" \
+        --argjson libmlx_size "$LIBMLX_SIZE" \
+        --argjson libmlx_objs "$LIBMLX_OBJECT_COUNT" \
+        --argjson exe_size "$EXE_SIZE" \
+        --arg exe_path "$EXE_PATH" \
+        --arg run_status "$RUN_STATUS" \
+        --argjson run_exit "$RUN_EXIT_CODE" \
+        --argjson run_duration "$RUN_DURATION" \
+        --arg run_stdout "$RUN_STDOUT" \
+        --arg run_stderr "$RUN_STDERR" \
+        --arg ldd "$LDD_OUTPUT" \
+        --arg ldd_missing "$LDD_MISSING" \
+        --argjson gpu_count "$GPU_DEVICE_COUNT" \
+        --arg gpu_names "$GPU_NAMES" \
+        --argjson final_exit "$FINAL_EXIT" \
+        '{
+          "git_sha": $sha,
+          "test": "mlx-smoke",
+          "final_exit": $final_exit,
+          "build": {
+            "image": $build_image,
+            "status": $build_status,
+            "duration_sec": $build_duration,
+            "libmlx_size_bytes": $libmlx_size,
+            "libmlx_object_count": $libmlx_objs,
+            "exe_size_bytes": $exe_size,
+            "exe_path": $exe_path,
+            "log_tail": $build_log_tail
+          },
+          "run": {
+            "image": $runtime_image,
+            "status": $run_status,
+            "exit_code": $run_exit,
+            "duration_sec": $run_duration,
+            "stdout": $run_stdout,
+            "stderr": $run_stderr,
+            "ldd_output": $ldd,
+            "ldd_missing": $ldd_missing
+          },
+          "gpu": {
+            "device_count": $gpu_count,
+            "names": $gpu_names
+          }
+        }' > "$RESULTS_JSON"
+    echo "results: $RESULTS_JSON"
+}
+trap write_results EXIT
+
+# ------------------------------------------------------------- preflight ----
+docker image inspect "$BUILD_IMAGE" >/dev/null 2>&1 || {
+    echo "::error::build image not found: $BUILD_IMAGE" >&2
+    FINAL_EXIT=3; exit 3
+}
+docker image inspect "$RUNTIME_IMAGE" >/dev/null 2>&1 || {
+    echo "::error::runtime image not found: $RUNTIME_IMAGE" >&2
+    FINAL_EXIT=3; exit 3
+}
+GPU_DEVICE_COUNT=$(nvidia-smi -L 2>/dev/null | wc -l || echo 0)
+GPU_NAMES=$(nvidia-smi -L 2>/dev/null | head -3 | tr '\n' ';' || true)
+if [ "$GPU_DEVICE_COUNT" -eq 0 ]; then
+    echo "::error::no GPUs visible via nvidia-smi" >&2
+    FINAL_EXIT=3; exit 3
+fi
+
+# ----------------------------------------------------------------- build ----
+if [ "$SKIP_BUILD" = true ] && [ -x "$BUILD_DIR/qwen_smoke" ]; then
+    echo "skip_build: reusing $BUILD_DIR/qwen_smoke"
+    BUILD_STATUS="skipped"
+    EXE_PATH="$BUILD_DIR/qwen_smoke"
+    EXE_SIZE=$(stat -c '%s' "$EXE_PATH" 2>/dev/null || echo 0)
+    if [ -f "$BUILD_DIR/mlx_build/libmlx.a" ]; then
+        LIBMLX_SIZE=$(stat -c '%s' "$BUILD_DIR/mlx_build/libmlx.a" 2>/dev/null || echo 0)
+        LIBMLX_OBJECT_COUNT=$(ar t "$BUILD_DIR/mlx_build/libmlx.a" 2>/dev/null | wc -l || echo 0)
+    fi
+else
+    rm -rf "$BUILD_DIR" && mkdir -p "$BUILD_DIR"
+    BUILD_STATUS="running"
+    BUILD_START=$(date +%s)
+
+    set +e
+    docker run --rm \
+        -v "$SRC_DIR:/src:ro" \
+        -v "$BUILD_DIR:/build" \
+        "$BUILD_IMAGE" \
+        bash -c '
+            set -euo pipefail
+            cmake -S /src/x/mlxrunner -B /build -DCMAKE_BUILD_TYPE=Release
+            cmake --build /build -j"$(nproc)"
+        ' > "$BUILD_DIR/build.log" 2>&1
+    BUILD_RC=$?
+    set -e
+    BUILD_DURATION=$(( $(date +%s) - BUILD_START ))
+    # tail -c keeps the bytes finite for JSON embedding
+    BUILD_LOG_TAIL=$(tail -c 4000 "$BUILD_DIR/build.log" || true)
+
+    if [ $BUILD_RC -ne 0 ] || [ ! -x "$BUILD_DIR/qwen_smoke" ]; then
+        BUILD_STATUS="failed"
+        echo "::error::build failed (rc=$BUILD_RC); see $BUILD_DIR/build.log"
+        FINAL_EXIT=1; exit 1
+    fi
+
+    BUILD_STATUS="success"
+    EXE_PATH="$BUILD_DIR/qwen_smoke"
+    EXE_SIZE=$(stat -c '%s' "$EXE_PATH" 2>/dev/null || echo 0)
+    if [ -f "$BUILD_DIR/mlx_build/libmlx.a" ]; then
+        LIBMLX_SIZE=$(stat -c '%s' "$BUILD_DIR/mlx_build/libmlx.a" 2>/dev/null || echo 0)
+        LIBMLX_OBJECT_COUNT=$(ar t "$BUILD_DIR/mlx_build/libmlx.a" 2>/dev/null | wc -l || echo 0)
+    fi
+    echo "build OK: libmlx.a ${LIBMLX_SIZE}B ${LIBMLX_OBJECT_COUNT} objs / qwen_smoke ${EXE_SIZE}B"
+fi
+
+# ------------------------------------------------------------------- run ----
+# Run qwen_smoke in the PRODUCTION RUNTIME image (not the builder), with K80
+# GPUs exposed. Surfaces real ld gaps that builder-side runs would mask.
+RUN_STATUS="running"
+RUN_START=$(date +%s)
+set +e
+docker run --rm --gpus all \
+    -v "$BUILD_DIR:/build:ro" \
+    -e CUDA_VISIBLE_DEVICES=0 \
+    --entrypoint bash \
+    "$RUNTIME_IMAGE" \
+    -c '
+        set +e
+        ldd /build/qwen_smoke 2>&1
+        echo "--- ldd-end ---"
+        /build/qwen_smoke
+        echo "--- exit=$? ---"
+    ' > "$BUILD_DIR/run.stdout" 2> "$BUILD_DIR/run.stderr"
+RUN_RC=$?
+set -e
+RUN_DURATION=$(( $(date +%s) - RUN_START ))
+
+# Split ldd portion out of stdout; tail -c keeps embedded bytes bounded.
+LDD_OUTPUT=$(sed -n '1,/--- ldd-end ---/p' "$BUILD_DIR/run.stdout" \
+             | head -n -1 | tail -c 4000 || true)
+RUN_STDOUT=$(sed -n '/--- ldd-end ---/,$p' "$BUILD_DIR/run.stdout" \
+             | tail -n +2 | tail -c 4000 || true)
+RUN_STDERR=$(tail -c 4000 "$BUILD_DIR/run.stderr" || true)
+LDD_MISSING=$(echo "$LDD_OUTPUT" | grep -E "not found|undefined" | head -c 2000 || true)
+RUN_EXIT_CODE=$RUN_RC
+
+if [ $RUN_RC -eq 0 ] && echo "$RUN_STDOUT" | grep -q "qwen_smoke: forward-surface link OK"; then
+    RUN_STATUS="success"
+    echo "run OK: qwen_smoke completed in ${RUN_DURATION}s"
+    FINAL_EXIT=0
+else
+    RUN_STATUS="failed"
+    echo "::error::qwen_smoke run failed (rc=$RUN_RC, duration=${RUN_DURATION}s)"
+    if [ -n "$LDD_MISSING" ]; then
+        echo "::error::missing libs (ldd): $LDD_MISSING"
+    fi
+    FINAL_EXIT=2
+fi
+
+exit $FINAL_EXIT

--- a/x/mlx/CMakeLists.txt
+++ b/x/mlx/CMakeLists.txt
@@ -103,6 +103,9 @@ set(MLX_CUDA_HOST
     # CUDA 11.4); forward eval always uses the manual sdpa.cu vector kernel.
     # Backward (VJP) falls back to CPU.
     ${CUDA_SRC}/scaled_dot_product_attention.cpp
+    # Phase A: Convolution dispatch — cuDNN conv path stripped; forward eval
+    # always uses the GEMM-based gemm_conv (im2col + our cublas_gemm).
+    ${CUDA_SRC}/conv.cpp
 )
 
 # Device-side (.cu -> nvcc).
@@ -134,6 +137,9 @@ list(APPEND MLX_CUDA_KERNELS
     # the dequant impl is part of the Phase-B runtime reroute.
     # SDPA manual kernel (the cuDNN flash-attn path in sdpa.cpp stays deferred).
     ${CUDA_SRC}/scaled_dot_product_attention.cu
+    # GEMM-based conv (im2col + cuBLAS); handles conv1d via degenerate spatial dims.
+    ${CUDA_SRC}/conv/gemm_conv.cu
+    ${CUDA_SRC}/conv/gemm_grouped_conv.cu
 )
 
 target_sources(mlx PRIVATE ${MLX_CUDA_HOST} ${MLX_CUDA_KERNELS})

--- a/x/mlx/CMakeLists.txt
+++ b/x/mlx/CMakeLists.txt
@@ -128,6 +128,8 @@ list(APPEND MLX_CUDA_KERNELS
     ${CUDA_SRC}/gemms/gemv.cu
     # affine_quantize.cu deferred: heavy half-arithmetic + cg::dim_blocks gap;
     # the dequant impl is part of the Phase-B runtime reroute.
+    # SDPA manual kernel (the cuDNN flash-attn path in sdpa.cpp stays deferred).
+    ${CUDA_SRC}/scaled_dot_product_attention.cu
 )
 
 target_sources(mlx PRIVATE ${MLX_CUDA_HOST} ${MLX_CUDA_KERNELS})

--- a/x/mlx/CMakeLists.txt
+++ b/x/mlx/CMakeLists.txt
@@ -50,6 +50,27 @@ add_library(mlx STATIC
     ${MLX_SRC}/backend/common/reduce.cpp
     ${MLX_SRC}/backend/common/slicing.cpp
     ${MLX_SRC}/backend/common/utils.cpp
+    # backend/gpu — device-agnostic GPU helpers (contiguous_copy_gpu,
+    # copy_gpu_inplace, the shared primitive::eval_gpu glue). Used by both
+    # the CUDA and Metal backends; needs to be linked for the CUDA backend
+    # objects (rms_norm/sdpa/conv/etc.) to resolve their copy helpers.
+    ${MLX_SRC}/backend/gpu/copy.cpp
+    ${MLX_SRC}/backend/gpu/slicing.cpp
+    ${MLX_SRC}/backend/gpu/primitives.cpp
+    # backend/no_cpu — upstream's GPU-only stub backend (designed for builds
+    # that omit OpenBLAS/LAPACK/FFT). Provides eval_cpu throw-stubs for every
+    # primitive, which emits the 116 primitive vtables the linker needs, plus
+    # cpu::{is_available, device_count, device_info} returning empty/false.
+    ${MLX_SRC}/backend/no_cpu/device_info.cpp
+    ${MLX_SRC}/backend/no_cpu/primitives.cpp
+    ${MLX_SRC}/backend/no_cpu/compiled.cpp
+    # backend/cpu — only the two files the no_cpu CMakeLists pulls in (these
+    # don't drag in any of the LAPACK/BLAS/FFT-heavy cpu/*.cpp files).
+    ${MLX_SRC}/backend/cpu/eval.cpp
+    ${MLX_SRC}/backend/cpu/encoder.cpp
+    # backend/metal — single-file stub for non-Apple builds; satisfies
+    # metal::is_available() / fast::metal_kernel() refs from ops.cpp.
+    ${MLX_SRC}/backend/metal/no_metal.cpp
 )
 
 target_include_directories(mlx PRIVATE
@@ -106,6 +127,12 @@ set(MLX_CUDA_HOST
     # Phase A: Convolution dispatch — cuDNN conv path stripped; forward eval
     # always uses the GEMM-based gemm_conv (im2col + our cublas_gemm).
     ${CUDA_SRC}/conv.cpp
+    # Phase B: runtime throw-stubs for off-path symbols (CUTLASS qmm/gemm,
+    # JIT runtime, distributed collectives, BlockMaskedMM, FFT/Hadamard/
+    # Scatter/Gather/Scan/SliceUpdate/QQMatmul/FP8, affine + fp quant/dequant)
+    # — mirrors no_cpu/primitives.cpp. Lets qwen_smoke (and the runner exe)
+    # link; runtime trip = port the real impl and drop the stub.
+    ${CUDA_SRC}/k80_runtime_stubs.cpp
 )
 
 # Device-side (.cu -> nvcc).

--- a/x/mlx/CMakeLists.txt
+++ b/x/mlx/CMakeLists.txt
@@ -91,6 +91,10 @@ set(MLX_CUDA_HOST
     ${CUDA_SRC}/slicing.cpp
     ${CUDA_SRC}/utils.cpp
     ${CUDA_SRC}/worker.cpp
+    # Phase A: dense GEMM via cuBLAS (matmul + cublas_gemm). The CUTLASS gemm
+    # impls stay excluded; off-path calls are undefined refs (resolved at exe link).
+    ${CUDA_SRC}/matmul.cpp
+    ${CUDA_SRC}/gemms/cublas_gemm.cpp
 )
 
 # Device-side (.cu -> nvcc).
@@ -117,6 +121,7 @@ list(APPEND MLX_CUDA_KERNELS
     ${CUDA_SRC}/softmax.cu
     ${CUDA_SRC}/logsumexp.cu
     ${CUDA_SRC}/random.cu
+    ${CUDA_SRC}/gemms/gemv.cu
 )
 
 target_sources(mlx PRIVATE ${MLX_CUDA_HOST} ${MLX_CUDA_KERNELS})

--- a/x/mlx/CMakeLists.txt
+++ b/x/mlx/CMakeLists.txt
@@ -95,6 +95,10 @@ set(MLX_CUDA_HOST
     # impls stay excluded; off-path calls are undefined refs (resolved at exe link).
     ${CUDA_SRC}/matmul.cpp
     ${CUDA_SRC}/gemms/cublas_gemm.cpp
+    # Phase A: quantized matmul dispatch (qmm_* impls in quantized/qmm/ are CUTLASS
+    # and stay excluded; the qmm_* calls are undefined refs in libmlx.a, to be
+    # rerouted to dequant+cuBLAS at the runner exe link).
+    ${CUDA_SRC}/quantized/quantized.cpp
 )
 
 # Device-side (.cu -> nvcc).
@@ -122,6 +126,8 @@ list(APPEND MLX_CUDA_KERNELS
     ${CUDA_SRC}/logsumexp.cu
     ${CUDA_SRC}/random.cu
     ${CUDA_SRC}/gemms/gemv.cu
+    # affine_quantize.cu deferred: heavy half-arithmetic + cg::dim_blocks gap;
+    # the dequant impl is part of the Phase-B runtime reroute.
 )
 
 target_sources(mlx PRIVATE ${MLX_CUDA_HOST} ${MLX_CUDA_KERNELS})

--- a/x/mlx/CMakeLists.txt
+++ b/x/mlx/CMakeLists.txt
@@ -99,6 +99,10 @@ set(MLX_CUDA_HOST
     # and stay excluded; the qmm_* calls are undefined refs in libmlx.a, to be
     # rerouted to dequant+cuBLAS at the runner exe link).
     ${CUDA_SRC}/quantized/quantized.cpp
+    # Phase A: SDPA dispatch — cuDNN flash-attn path stripped (no fe::graph on
+    # CUDA 11.4); forward eval always uses the manual sdpa.cu vector kernel.
+    # Backward (VJP) falls back to CPU.
+    ${CUDA_SRC}/scaled_dot_product_attention.cpp
 )
 
 # Device-side (.cu -> nvcc).

--- a/x/mlx/mlx/backend/cuda/conv.cpp
+++ b/x/mlx/mlx/backend/cuda/conv.cpp
@@ -1,10 +1,17 @@
 // Copyright © 2025 Apple Inc.
+//
+// K80 port: this file originally dispatched between a cuDNN convolution
+// path (build_conv_graph + cached DnnGraph runs) and a GEMM-based fallback
+// (gemm_conv / gemm_grouped_conv in conv/). The K80 build has no cuDNN
+// frontend (cuDNN 8.2 on CUDA 11.4 lacks fe::graph), so the entire cuDNN
+// path — cudnn_utils.h include, ConvCacheKey/conv_cache, get_conv_settings,
+// build_conv_graph, group_transpose, prepare_args, register_args,
+// init_cudnn_conv_cache, plus the multi-backend cuDNN guessing — is removed.
+// Convolution::eval_gpu always calls the GEMM-based gemm_conv kernel from
+// conv/gemm_conv.cu, which uses our cublas_gemm under the hood (no CUTLASS).
 
 #include "mlx/backend/cuda/conv/conv.h"
-#include "mlx/backend/cuda/cudnn_utils.h"
 #include "mlx/backend/cuda/device.h"
-#include "mlx/backend/cuda/lru_cache.h"
-#include "mlx/backend/gpu/copy.h"
 #include "mlx/primitives.h"
 
 #include <nvtx3/nvtx3.hpp>
@@ -12,249 +19,6 @@
 #include <cassert>
 
 namespace mlx::core {
-
-namespace {
-
-enum ConvBackendType {
-  CONV_FALLBACK,
-  CONV_FORWARD,
-  CONV_BACKWARD_INPUT,
-  CONV_BACKWARD_WEIGHT,
-};
-
-struct ConvCacheKey {
-  int device_id;
-  fe::DataType_t cudnn_dtype;
-  std::array<int, MAX_NDIM> input_shape;
-  std::array<int, MAX_NDIM> weight_shape;
-  std::array<int, MAX_NDIM> stride;
-  std::array<int, MAX_NDIM> padding_lo;
-  std::array<int, MAX_NDIM> padding_hi;
-  std::array<int, MAX_NDIM> dilation;
-  int groups;
-  bool flip;
-  uint8_t input_alignment;
-  uint8_t weight_alignment;
-  uint8_t output_alignment;
-};
-
-auto& conv_cache() {
-  static thread_local LRUBytesKeyCache<
-      ConvCacheKey,
-      std::pair<ConvBackendType, std::optional<DnnGraph>>>
-      cache("MLX_CUDA_CONV_CACHE_SIZE", /* default_capacity */ 128);
-  return cache;
-}
-
-auto get_conv_settings(
-    ConvBackendType backend_type,
-    array& x,
-    array& w,
-    array& y,
-    const std::vector<int>& kernel_strides,
-    const std::vector<int>& padding_lo_,
-    const std::vector<int>& padding_hi_,
-    const std::vector<int>& kernel_dilation,
-    const std::vector<int>& input_dilation) {
-  auto padding_lo = convert_vector<int64_t>(padding_lo_);
-  auto padding_hi = convert_vector<int64_t>(padding_hi_);
-
-  if (backend_type == CONV_BACKWARD_INPUT) {
-    for (int i = 0; i < padding_lo.size(); ++i) {
-      int wt_size = 1 + kernel_dilation[i] * (w.shape(1 + i) - 1);
-      padding_lo[i] = wt_size - padding_lo[i] - 1;
-      int in_size = 1 + kernel_strides[i] * (y.shape(1 + i) - 1);
-      int out_size = 1 + input_dilation[i] * (x.shape(1 + i) - 1);
-      padding_hi[i] = out_size - in_size + padding_hi[i];
-    }
-    return std::make_tuple(
-        convert_vector<int64_t>(input_dilation),
-        std::move(padding_lo),
-        std::move(padding_hi),
-        convert_vector<int64_t>(kernel_dilation));
-
-  } else if (backend_type == CONV_BACKWARD_WEIGHT) {
-    padding_hi = padding_lo;
-    return std::make_tuple(
-        convert_vector<int64_t>(kernel_dilation),
-        std::move(padding_lo),
-        std::move(padding_hi),
-        convert_vector<int64_t>(kernel_strides));
-
-  } else {
-    return std::make_tuple(
-        convert_vector<int64_t>(kernel_strides),
-        std::move(padding_lo),
-        std::move(padding_hi),
-        convert_vector<int64_t>(kernel_dilation));
-  }
-}
-
-std::optional<DnnGraph> build_conv_graph(
-    cu::CommandEncoder& encoder,
-    ConvBackendType backend_type,
-    Dtype dtype,
-    array& x,
-    array& w,
-    array& y,
-    const std::vector<int64_t>& stride,
-    const std::vector<int64_t>& padding_lo,
-    const std::vector<int64_t>& padding_hi,
-    const std::vector<int64_t>& dilation) {
-  auto compute_dtype =
-      (dtype == float16 || dtype == bfloat16) ? float32 : dtype;
-  DnnGraph graph(get_cudnn_handle(encoder.device()), dtype, compute_dtype);
-  auto x_ = graph.tensor_nchw("X", 'x', x);
-  auto w_ = graph.tensor_nchw("W", 'w', w);
-
-  auto set_options = [&](auto& options) {
-    options.set_compute_data_type(dtype_to_cudnn_type(compute_dtype))
-        .set_convolution_mode(fe::ConvolutionMode_t::CROSS_CORRELATION)
-        .set_stride(stride)
-        .set_pre_padding(padding_lo)
-        .set_post_padding(padding_hi)
-        .set_dilation(dilation);
-  };
-
-  std::shared_ptr<fe::graph::Tensor_attributes> y_;
-  if (backend_type == CONV_FORWARD) {
-    auto options = fe::graph::Conv_fprop_attributes();
-    set_options(options);
-    y_ = graph.conv_fprop(x_, w_, options);
-  } else if (backend_type == CONV_BACKWARD_INPUT) {
-    auto options = fe::graph::Conv_dgrad_attributes();
-    set_options(options);
-    y_ = graph.conv_dgrad(x_, w_, options);
-  } else if (backend_type == CONV_BACKWARD_WEIGHT) {
-    auto options = fe::graph::Conv_wgrad_attributes();
-    set_options(options);
-    y_ = graph.conv_wgrad(w_, x_, options);
-  }
-  graph.tensor_nchw(y_, 'y', y)->set_output(true);
-
-  if (graph.prepare().is_bad()) {
-    return std::nullopt;
-  }
-  graph.deselect_numeric_notes({fe::NumericalNote_t::DOWN_CONVERT_INPUTS});
-  if (dtype == float32 && !env::enable_tf32()) {
-    graph.deselect_numeric_notes({fe::NumericalNote_t::TENSOR_CORE});
-  }
-  CHECK_CUDNN_ERROR(graph.build());
-  return graph;
-}
-
-// Transpose from (C_out, H, W, C_in / groups) to (C_in, H, W, C_out / groups).
-array group_transpose(
-    const array& x,
-    int groups,
-    int group_dim,
-    int axis1,
-    int axis2,
-    Stream s) {
-  if (groups == 1) {
-    return swapaxes_in_eval(x, axis1, axis2);
-  }
-  int ndim = x.ndim();
-  if (group_dim < 0) {
-    group_dim += ndim;
-  }
-  if (axis1 < 0) {
-    axis1 += ndim;
-  }
-  if (axis2 < 0) {
-    axis2 += ndim;
-  }
-  if (group_dim <= axis1) {
-    axis1 += 1;
-  }
-  if (group_dim <= axis2) {
-    axis2 += 1;
-  }
-  auto shape = x.shape();
-  shape.insert(shape.begin() + group_dim, groups);
-  shape[group_dim + 1] = shape[group_dim + 1] / groups;
-  array x_trans = reshape_in_eval(x, std::move(shape), s);
-  x_trans = swapaxes_in_eval(x_trans, axis1, axis2);
-  x_trans = flatten_in_eval(x_trans, group_dim, group_dim + 1, s);
-  return x_trans;
-}
-
-// Do necessary transposes and copies to prepare the inputs and outputs for
-// building the cuDNN conv op. It is safe to be called multiple times in one
-// eval_gpu, with cost of possible redundant copies.
-std::tuple<array, array, array> prepare_args(
-    cu::CommandEncoder& encoder,
-    ConvBackendType backend_type,
-    array in,
-    array wt,
-    array out,
-    int groups,
-    Stream s) {
-  // Transpose the args depending on the backend type.
-  // TODO: Handle groups.
-  if (backend_type == CONV_BACKWARD_INPUT) {
-    wt = group_transpose(wt, groups, 0, 0, -1, s);
-  } else if (backend_type == CONV_BACKWARD_WEIGHT) {
-    in = group_transpose(in, groups, -1, 0, -1, s);
-    wt = swapaxes_in_eval(wt, 0, -1);
-    // Create a contiguous array that shares the data with |out|, but with dim
-    // C_in and C_out swapped.
-    Shape shape(out.shape());
-    std::swap(shape.front(), shape.back());
-    Strides strides(shape.size(), 1);
-    for (int i = shape.size() - 2; i >= 0; --i) {
-      strides[i] = shape[i + 1] * strides[i + 1];
-    }
-    array intermediate(std::move(shape), out.dtype(), nullptr, {});
-    intermediate.copy_shared_buffer(
-        out, std::move(strides), {true, true, false}, out.data_size());
-    out = intermediate;
-  }
-
-  // cuDNN requires contiguous input.
-  if (!in.flags().row_contiguous) {
-    in = contiguous_copy_gpu(in, s);
-    encoder.add_temporary(in);
-  }
-  if (!wt.flags().row_contiguous) {
-    wt = contiguous_copy_gpu(wt, s);
-    encoder.add_temporary(wt);
-  }
-
-  return {std::move(in), std::move(wt), std::move(out)};
-}
-
-// Register inputs and outputs before actually running conv op. Can only be
-// called once per eval_gpu.
-void register_args(
-    cu::CommandEncoder& encoder,
-    ConvBackendType backend_type,
-    array& in,
-    array& wt,
-    array& intermediate_out,
-    array& final_out) {
-  encoder.set_input_array(in);
-  encoder.set_input_array(wt);
-  encoder.set_output_array(final_out);
-
-  if (backend_type == CONV_BACKWARD_WEIGHT) {
-    // Turn |out| into a strided array, which will have C_in and C_out swapped
-    // in vjp and the final |grad_weight| will then be contiguous.
-    Strides strides = intermediate_out.strides();
-    std::swap(strides.front(), strides.back());
-    final_out.copy_shared_buffer(
-        intermediate_out,
-        std::move(strides),
-        {false, false, false},
-        intermediate_out.data_size());
-  }
-}
-
-} // namespace
-
-void init_cudnn_conv_cache() {
-  conv_cache();
-}
 
 void Convolution::eval_gpu(const std::vector<array>& inputs, array& out_) {
   nvtx3::scoped_range r("Convolution::eval_gpu");
@@ -267,127 +31,11 @@ void Convolution::eval_gpu(const std::vector<array>& inputs, array& out_) {
   assert(inputs.size() == 2);
   array in = inputs[0];
   array wt = inputs[1];
-  array out = out_;
+  array& out = out_;
   out.set_data(cu::malloc_async(out.nbytes(), encoder));
-  Dtype dtype = out.dtype();
 
-  // Search cache.
-  BytesKey<ConvCacheKey> cache_key;
-  cache_key.pod.device_id = encoder.device().cuda_device();
-  cache_key.pod.cudnn_dtype = dtype_to_cudnn_type(dtype);
-  cache_key.pod.input_shape = vector_key(in.shape());
-  cache_key.pod.weight_shape = vector_key(wt.shape());
-  cache_key.pod.stride = vector_key(kernel_strides_);
-  cache_key.pod.padding_lo = vector_key(padding_lo_);
-  cache_key.pod.padding_hi = vector_key(padding_hi_);
-  cache_key.pod.dilation = vector_key(kernel_dilation_);
-  cache_key.pod.groups = groups_;
-  cache_key.pod.flip = flip_;
-  cache_key.pod.input_alignment = get_alignment(in);
-  cache_key.pod.weight_alignment = get_alignment(wt);
-  cache_key.pod.output_alignment = get_alignment(out);
-  if (auto it = conv_cache().find(cache_key); it != conv_cache().end()) {
-    auto& [backend_type, graph] = it->second;
-    if (graph) {
-      // Run cached graph.
-      std::tie(in, wt, out) =
-          prepare_args(encoder, backend_type, in, wt, out, groups_, s);
-      register_args(encoder, backend_type, in, wt, out, out_);
-      CHECK_CUDNN_ERROR(graph->encode_capturing(
-          encoder,
-          {
-              {'x', gpu_ptr<void>(in)},
-              {'w', gpu_ptr<void>(wt)},
-              {'y', gpu_ptr<void>(out)},
-          }));
-    } else {
-      // Run fallback kernel.
-      gemm_conv(
-          encoder,
-          in,
-          wt,
-          out,
-          kernel_strides_,
-          padding_lo_,
-          kernel_dilation_,
-          input_dilation_,
-          groups_,
-          flip_,
-          s);
-    }
-    return;
-  }
-
-  // There is no reliable way to deduce the proper cuDNN backend for the
-  // convolution, so we make a best guess and then try.
-  SmallVector<ConvBackendType, 2> try_backends;
-  if (flip_) {
-    // When weight is flipped, we assume it is backward input convolution.
-    try_backends.push_back(CONV_BACKWARD_INPUT);
-  } else {
-    // Otherwise it could be backward weight convolution or forward convolution,
-    // mathematically there is no difference so we have to use heuristics.
-    // Empirically backward convolutions have large kernel dimensions, and
-    // usually have |in| and |wt| transposed.
-    if (!in.flags().row_contiguous && !wt.flags().row_contiguous &&
-        wt.shape(2) > out.shape(2)) {
-      try_backends = {CONV_BACKWARD_WEIGHT, CONV_FORWARD};
-    } else {
-      try_backends = {CONV_FORWARD, CONV_BACKWARD_WEIGHT};
-    }
-  }
-
-  // Try to build op graph.
-  ConvBackendType backend_type;
-  std::optional<DnnGraph> graph;
-  for (auto try_backend : try_backends) {
-    auto [x, w, y] =
-        prepare_args(encoder, try_backend, in, wt, out, groups_, s);
-    auto [stride, padding_lo, padding_hi, dilation] = get_conv_settings(
-        try_backend,
-        x,
-        w,
-        y,
-        kernel_strides_,
-        padding_lo_,
-        padding_hi_,
-        kernel_dilation_,
-        input_dilation_);
-    graph = build_conv_graph(
-        encoder,
-        try_backend,
-        dtype,
-        x,
-        w,
-        y,
-        stride,
-        padding_lo,
-        padding_hi,
-        dilation);
-    if (graph) {
-      backend_type = try_backend;
-      in = std::move(x);
-      wt = std::move(w);
-      out = std::move(y);
-      break;
-    }
-  }
-
-  if (graph) {
-    register_args(encoder, backend_type, in, wt, out, out_);
-    CHECK_CUDNN_ERROR(graph->encode_capturing(
-        encoder,
-        {
-            {'x', gpu_ptr<void>(in)},
-            {'w', gpu_ptr<void>(wt)},
-            {'y', gpu_ptr<void>(out)},
-        }));
-    conv_cache().emplace(
-        cache_key, std::make_pair(backend_type, std::move(*graph)));
-    return;
-  }
-
-  // Use fallback kernel for settings not supported by cuDNN.
+  // K80: GEMM-based conv only (im2col-style unfold in conv/gemm_conv.cu
+  // followed by cuBLAS GEMM). Handles forward conv1d/2d/3d incl. grouped.
   gemm_conv(
       encoder,
       in,
@@ -400,7 +48,6 @@ void Convolution::eval_gpu(const std::vector<array>& inputs, array& out_) {
       groups_,
       flip_,
       s);
-  conv_cache().emplace(cache_key, std::make_pair(CONV_FALLBACK, std::nullopt));
 }
 
 } // namespace mlx::core

--- a/x/mlx/mlx/backend/cuda/conv/gemm_conv.cu
+++ b/x/mlx/mlx/backend/cuda/conv/gemm_conv.cu
@@ -71,7 +71,9 @@ __global__ void naive_unfold_nd(
     }
     *out = in[in_offset];
   } else {
-    *out = T{0};
+    // K80 (CUDA 11.4): __nv_bfloat16 has no (int) ctor; brace-init from 0
+    // is ambiguous between the (float)/(double) overloads. Use 0.0f.
+    *out = T(0.0f);
   }
 }
 

--- a/x/mlx/mlx/backend/cuda/conv/gemm_grouped_conv.cu
+++ b/x/mlx/mlx/backend/cuda/conv/gemm_grouped_conv.cu
@@ -74,7 +74,9 @@ __global__ void naive_grouped_unfold_transpose_nd(
     }
     *out = in[in_offset];
   } else {
-    *out = T{0};
+    // K80 (CUDA 11.4): __nv_bfloat16 has no (int) ctor; brace-init from 0
+    // is ambiguous between the (float)/(double) overloads. Use 0.0f.
+    *out = T(0.0f);
   }
 }
 

--- a/x/mlx/mlx/backend/cuda/k80_runtime_stubs.cpp
+++ b/x/mlx/mlx/backend/cuda/k80_runtime_stubs.cpp
@@ -1,0 +1,297 @@
+// K80 port: runtime throw-stubs for the off-path CUDA-backend symbols that
+// libmlx.a's on-path objects reference but whose impls were deferred
+// (CUTLASS qmm/gemm trio, block-mask helpers, JIT runtime, distributed
+// collectives, FFT/Hadamard/Scatter/Gather/Scan/SliceUpdate/QQMatmul/FP8,
+// affine + fp quant/dequant). The pattern mirrors backend/no_cpu/primitives.cpp.
+//
+// These exist purely to satisfy the linker so qwen_smoke (and later the real
+// runner exe) can link against libmlx.a. Every symbol throws std::runtime_error
+// if reached at runtime — that surfaces "qwen3.5 hit an off-path primitive"
+// loudly instead of silently corrupting. The qwen3.5-relevant primitives
+// (Gather/Scatter/SliceUpdate/Scan + the quantized matmul family) keep these
+// throw stubs only as long as they aren't on the inference hot path; when one
+// trips at runtime, port the real impl and remove its stub here.
+
+#include "mlx/primitives.h"
+#include "mlx/fast_primitives.h"
+#include "mlx/distributed/primitives.h"
+
+#include "mlx/backend/cuda/quantized/quantized.h"
+#include "mlx/backend/cuda/quantized/qmm/qmm.h"
+#include "mlx/backend/cuda/gemms/block_mask.h"
+#include "mlx/backend/cuda/gemms/cublas_gemm.h"
+#include "mlx/backend/cuda/gemms/gather_gemm.h"
+#include "mlx/backend/cuda/gemms/grouped_gemm.h"
+#include "mlx/backend/cuda/jit_module.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace mlx::core {
+
+namespace {
+[[noreturn]] void k80_unimpl(const char* what) {
+  throw std::runtime_error(
+      std::string("K80 build: ") + what +
+      " not implemented (off-path stub in k80_runtime_stubs.cpp)");
+}
+} // namespace
+
+// ============================================================================
+// UnaryPrimitive eval_gpu — on-path-but-unported primitives. Each one throws
+// at runtime; if qwen3.5 trips one we port the real impl and drop the stub.
+// ============================================================================
+
+#define K80_UNARY_EVAL_GPU(Cls)                                      \
+  void Cls::eval_gpu(const std::vector<array>&, array&) {            \
+    k80_unimpl(#Cls "::eval_gpu");                                   \
+  }
+
+K80_UNARY_EVAL_GPU(FFT)
+K80_UNARY_EVAL_GPU(Gather)
+K80_UNARY_EVAL_GPU(GatherAxis)
+K80_UNARY_EVAL_GPU(Hadamard)
+K80_UNARY_EVAL_GPU(MaskedScatter)
+K80_UNARY_EVAL_GPU(QQMatmul)
+K80_UNARY_EVAL_GPU(Scan)
+K80_UNARY_EVAL_GPU(Scatter)
+K80_UNARY_EVAL_GPU(ScatterAxis)
+K80_UNARY_EVAL_GPU(SliceUpdate)
+
+#undef K80_UNARY_EVAL_GPU
+
+// ============================================================================
+// fast::ConvertFP8 (multi-output Primitive). FP8 isn't on any K80 path.
+// ============================================================================
+
+namespace fast {
+void ConvertFP8::eval_gpu(
+    const std::vector<array>&,
+    std::vector<array>&) {
+  k80_unimpl("fast::ConvertFP8::eval_gpu");
+}
+} // namespace fast
+
+// ============================================================================
+// distributed::* — no multi-GPU / multi-host on this single-K80 build.
+// ============================================================================
+
+namespace distributed {
+
+#define K80_DIST_EVAL_GPU(Cls)                                            \
+  void Cls::eval_gpu(                                                     \
+      const std::vector<array>&, std::vector<array>&) {                   \
+    k80_unimpl("distributed::" #Cls "::eval_gpu");                        \
+  }
+K80_DIST_EVAL_GPU(AllReduce)
+K80_DIST_EVAL_GPU(AllGather)
+K80_DIST_EVAL_GPU(ReduceScatter)
+#undef K80_DIST_EVAL_GPU
+
+#define K80_DIST_JVP(Cls)                                            \
+  std::vector<array> Cls::jvp(                                       \
+      const std::vector<array>&,                                     \
+      const std::vector<array>&,                                     \
+      const std::vector<int>&) {                                     \
+    k80_unimpl("distributed::" #Cls "::jvp");                        \
+  }
+#define K80_DIST_VJP(Cls)                                            \
+  std::vector<array> Cls::vjp(                                       \
+      const std::vector<array>&,                                     \
+      const std::vector<array>&,                                     \
+      const std::vector<int>&,                                       \
+      const std::vector<array>&) {                                   \
+    k80_unimpl("distributed::" #Cls "::vjp");                        \
+  }
+#define K80_DIST_VMAP(Cls)                                           \
+  std::pair<std::vector<array>, std::vector<int>> Cls::vmap(         \
+      const std::vector<array>&, const std::vector<int>&) {          \
+    k80_unimpl("distributed::" #Cls "::vmap");                       \
+  }
+
+K80_DIST_JVP(AllReduce)
+K80_DIST_VJP(AllReduce)
+K80_DIST_VMAP(AllReduce)
+K80_DIST_JVP(AllGather)
+K80_DIST_VJP(AllGather)
+K80_DIST_VMAP(AllGather)
+K80_DIST_VMAP(Send)
+
+#undef K80_DIST_JVP
+#undef K80_DIST_VJP
+#undef K80_DIST_VMAP
+
+} // namespace distributed
+
+// ============================================================================
+// Quantized matmul family — qmv/qmm_*/fp_*/gather_qmv (and supports_* guards).
+// The supports_* guards return false so quantized.cpp's dispatch falls through;
+// the actual qmm / qmv / etc. throw if reached. Real reroute (dequant + cuBLAS
+// via affine_dequantize + matmul) is task #13.
+// ============================================================================
+
+#define K80_SUPPORTS_FALSE(name)                                      \
+  bool name(                                                          \
+      const array&, const array&, const array&,                       \
+      const std::optional<array>&, const array&, bool,                \
+      int, int, QuantizationMode, cu::Device&) {                      \
+    return false;                                                     \
+  }
+
+K80_SUPPORTS_FALSE(supports_qmm_sm90)
+K80_SUPPORTS_FALSE(supports_qmm_sm80)
+K80_SUPPORTS_FALSE(supports_qmm_naive)
+K80_SUPPORTS_FALSE(supports_fp_qmv)
+K80_SUPPORTS_FALSE(supports_qmv)
+
+#undef K80_SUPPORTS_FALSE
+
+void qmm_sm90(
+    const array&, const array&, const array&, const array&,
+    array&, int, int, cu::CommandEncoder&, Stream) {
+  k80_unimpl("qmm_sm90");
+}
+
+void qmm_sm80(
+    const array&, const array&, const array&,
+    const std::optional<array>&,
+    const std::optional<array>&, const std::optional<array>&,
+    array&, int, int, QuantizationMode, cu::CommandEncoder&) {
+  k80_unimpl("qmm_sm80");
+}
+
+void qmm_naive(
+    const array&, const array&, const array&,
+    const std::optional<array>&,
+    const std::optional<array>&, const std::optional<array>&,
+    array&, bool, int, int, QuantizationMode, cu::CommandEncoder&) {
+  k80_unimpl("qmm_naive");
+}
+
+void fp_qmv(
+    const array&, const array&, const array&, array&,
+    int, int, cu::CommandEncoder&, Stream) {
+  k80_unimpl("fp_qmv");
+}
+
+void qmv(
+    const array&, const array&, const array&,
+    const std::optional<array>&, array&,
+    int, int, QuantizationMode, cu::CommandEncoder&) {
+  k80_unimpl("qmv");
+}
+
+void gather_qmv(
+    const array&, const array&, const array&,
+    const std::optional<array>&,
+    const array&, const array&, array&,
+    int, int, QuantizationMode, cu::CommandEncoder&) {
+  k80_unimpl("gather_qmv");
+}
+
+// affine + fp quant/dequant (declared in quantized/quantized.h)
+void affine_quantize(
+    const array&, array&, array&, array&,
+    int, int, cu::CommandEncoder&, const Stream&) {
+  k80_unimpl("affine_quantize");
+}
+void affine_dequantize(
+    const array&, const array&, const array&, array&,
+    int, int, cu::CommandEncoder&, const Stream&) {
+  k80_unimpl("affine_dequantize");
+}
+void fp_quantize(
+    const array&, array&, array&,
+    int, int, const std::optional<array>&,
+    cu::CommandEncoder&, const Stream&) {
+  k80_unimpl("fp_quantize");
+}
+void fp_dequantize(
+    const array&, const array&, array&,
+    int, int, const std::optional<array>&,
+    cu::CommandEncoder&, const Stream&) {
+  k80_unimpl("fp_dequantize");
+}
+
+// ============================================================================
+// BlockMaskedMM helpers (block_mask.cu excluded from build)
+// ============================================================================
+void apply_block_mask(
+    cu::CommandEncoder&, array&, const array&,
+    int, int64_t, int64_t, int64_t) {
+  k80_unimpl("apply_block_mask");
+}
+array copy_with_block_mask(
+    cu::CommandEncoder&, const array&, const array&,
+    int, int64_t, int64_t, int64_t) {
+  k80_unimpl("copy_with_block_mask");
+}
+
+// ============================================================================
+// CUTLASS gemm trio (CUTLASS impls excluded from build — sm_37 doesn't have
+// tensor cores; the MoE / gather-mm paths fall back to per-expert cuBLAS,
+// rerouted at exe link if/when qwen3.6 needs them).
+// ============================================================================
+void cutlass_gather_mm(
+    bool, bool, const array&, const array&,
+    const array&, const array&, array&,
+    cu::CommandEncoder&) {
+  k80_unimpl("cutlass_gather_mm");
+}
+void cutlass_grouped_gemm_unaligned(
+    bool, int, bool, int, int,
+    const array&, const array&, const array&, array&,
+    cu::CommandEncoder&) {
+  k80_unimpl("cutlass_grouped_gemm_unaligned");
+}
+void cutlass_segmented_mm(
+    bool, int, bool, int, int, int, int,
+    const array&, const array&, const array&,
+    array&, cu::CommandEncoder&) {
+  k80_unimpl("cutlass_segmented_mm");
+}
+
+// ============================================================================
+// CublasGemm::run_batched (private member; called from matmul.cpp's batched
+// path). The non-batched cuBLAS path works; batched stays a stub until a
+// runtime trip motivates the cuBLASLt strided-batched port.
+// ============================================================================
+void CublasGemm::run_batched(
+    cu::CommandEncoder&, array&,
+    const array&, const array&,
+    const Shape&, const Strides&, const Strides&,
+    float) {
+  k80_unimpl("CublasGemm::run_batched (a,b)");
+}
+void CublasGemm::run_batched(
+    cu::CommandEncoder&, array&,
+    const array&, const array&, const array&,
+    const Shape&, const Strides&, const Strides&, const Strides&,
+    float, float) {
+  k80_unimpl("CublasGemm::run_batched (a,b,c)");
+}
+
+// ============================================================================
+// JIT runtime — get_jit_module / JitModule::get_kernel.
+// Called from slicing.cpp's compute_dynamic_offset; we defer the JIT subsystem
+// (it needs a generated cuda_jit_sources.h). Runtime trip = port the JIT path.
+// ============================================================================
+namespace cu {
+
+JitModule& get_jit_module(
+    const mlx::core::Device&,
+    const std::string&,
+    const KernelBuilder&,
+    bool) {
+  k80_unimpl("cu::get_jit_module");
+}
+
+CUfunction JitModule::get_kernel(
+    const std::string&,
+    std::function<void(CUfunction)>) {
+  k80_unimpl("cu::JitModule::get_kernel");
+}
+
+} // namespace cu
+
+} // namespace mlx::core

--- a/x/mlx/mlx/backend/cuda/matmul.cpp
+++ b/x/mlx/mlx/backend/cuda/matmul.cpp
@@ -7,6 +7,10 @@
 #include "mlx/backend/cuda/gemms/gather_gemm.h"
 #include "mlx/backend/cuda/gemms/gemv.h"
 #include "mlx/backend/cuda/gemms/grouped_gemm.h"
+// K80 port: these gemm headers only declare functions (no CUTLASS includes); the
+// CUTLASS .cu impls (block_mask/gather_gemm/grouped_gemm_unaligned) are excluded
+// from the build. The off-path/MoE-general calls become undefined symbols here —
+// fine in a static lib; resolved (cuBLAS reroute / stubs) at the runner exe link.
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/primitives.h"
 

--- a/x/mlx/mlx/backend/cuda/scaled_dot_product_attention.cpp
+++ b/x/mlx/mlx/backend/cuda/scaled_dot_product_attention.cpp
@@ -1,16 +1,40 @@
 // Copyright © 2025 Apple Inc.
+//
+// K80 port: this file originally dispatched between a cuDNN flash-attention
+// path (sdpa_cudnn / sdpa_backward_cudnn) and the manual vector kernel in
+// scaled_dot_product_attention.cu. The K80 build has no cuDNN frontend
+// (cuDNN 8.2 on CUDA 11.4 lacks fe::graph), so the entire cuDNN path —
+// cudnn_utils.h include, SDPACacheKey/build_sdpa_graph, supports_sdpa_cudnn,
+// sdpa_cudnn, sdpa_backward_cudnn, plus the cuDNN-only helpers
+// (prepare_sdpa_sinks/malloc_with_same_layout/unslice_kv/use_cudnn_for_decoding,
+// init_cudnn_sdpa_cache) — has been removed. Forward eval always goes through
+// the manual sdpa_vector kernel. Backward (VJP) is training-only and falls
+// back to CPU; eval_gpu is unreachable and throws if reached.
 
-#include "mlx/backend/cuda/cudnn_utils.h"
 #include "mlx/backend/cuda/device.h"
-#include "mlx/backend/cuda/lru_cache.h"
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/fast_primitives.h"
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <stdexcept>
+
 namespace mlx::core {
 
 namespace {
+
+// Return pointer alignment of |x|'s data. Lifted out of cudnn_utils.h (which
+// the K80 strip removed) — generic ptr-alignment helper, no cuDNN dependency.
+inline uint8_t get_alignment(const array& x) {
+  uint8_t alignment = 1;
+  uintptr_t address = reinterpret_cast<uintptr_t>(gpu_ptr<void>(x));
+  for (; alignment < 32; alignment *= 2) {
+    if (address % (alignment * 2)) {
+      return alignment;
+    }
+  }
+  return alignment;
+}
 
 array prepare_sdpa_input(const array& x, Stream s) {
   // SDPA kernel's requirements on inputs:
@@ -25,512 +49,9 @@ array prepare_sdpa_input(const array& x, Stream s) {
   return x;
 }
 
-array prepare_sdpa_sinks(const array& sinks, Stream s) {
-  // cuDNN requires sinks to be float32.
-  if (sinks.dtype() == float32) {
-    return sinks;
-  }
-  array sinks_f32(sinks.shape(), float32, nullptr, {});
-  copy_gpu(sinks, sinks_f32, CopyType::Vector, s);
-  auto& encoder = cu::get_command_encoder(s);
-  encoder.add_temporary(sinks_f32);
-  return sinks_f32;
-}
-
-void malloc_with_same_layout(
-    cu::CommandEncoder& encoder,
-    array& o,
-    const array& q) {
-  if (q.flags().row_contiguous) {
-    o.set_data(cu::malloc_async(o.nbytes(), encoder));
-    return;
-  }
-  // fill_order = argsort(q.strides())
-  Shape fill_order(q.ndim());
-  std::iota(fill_order.begin(), fill_order.end(), 0);
-  std::stable_sort(
-      fill_order.begin(), fill_order.end(), [&q](int idx1, int idx2) {
-        auto s1 = q.strides(idx1) > 0 ? q.strides(idx1) : 1;
-        auto s2 = q.strides(idx2) > 0 ? q.strides(idx2) : 1;
-        return s1 < s2;
-      });
-  // Generate o_strides with fill_order
-  Strides o_strides(q.ndim());
-  int64_t stride = 1;
-  for (int i : fill_order) {
-    o_strides[i] = stride;
-    stride *= o.shape(i);
-  }
-  // o is a transposed contiguous array
-  o.set_data(
-      cu::malloc_async(o.nbytes(), encoder),
-      o.size(),
-      o_strides,
-      {true, false, false});
-}
-
-bool use_cudnn_for_decoding(
-    const array& q,
-    const array& k,
-    const array& v,
-    bool has_arr_mask) {
-  if (q.shape(2) != 1) {
-    return false;
-  }
-  if (has_arr_mask) {
-    return false;
-  }
-  // The cuDNN SDPA is faster than vector kernel but for small sequence the
-  // overhead would kill the advantage.
-  constexpr int kv_cache_step = 256; // number is from mlx-lm
-  if (k.shape(2) < kv_cache_step) {
-    return false;
-  }
-  // When called during graph building the strides is not available, and we
-  // rely on |supports_sdpa_vector| to decide whether to use fast sdpa since
-  // we can fallback to |sdpa_vector|.
-  if ((k.status() != array::evaluated) || (v.status() != array::evaluated)) {
-    return false;
-  }
-  // Check if k/v are slices from fixed-size kv cache.
-  auto is_slice = [](const array& kv) {
-    // Get pre-sliced sequence length from strides, and check if the buffer
-    // belongs to a contiguous kv cache.
-    int64_t T_kv = kv.strides(1) / kv.strides(2);
-    if (kv.size() / kv.shape(2) * T_kv != kv.buffer_size() / kv.itemsize()) {
-      return false;
-    }
-    // It is possible to use heuristic to check slices, but for now just make
-    // mlx-lm work.
-    return T_kv % kv_cache_step == 0;
-  };
-  return is_slice(k) && is_slice(v);
-}
-
-// Get original kv from slices, i.e. undo keys[..., :offset, :]
-array unslice_kv(const array& kv) {
-  Shape shape = kv.shape();
-  shape[2] = /* T_kv */ kv.strides(1) / kv.strides(2);
-  array copy(shape, kv.dtype(), nullptr, {});
-  copy.copy_shared_buffer(
-      kv,
-      make_contiguous_strides(shape),
-      {true, true, false},
-      /* data_size */ kv.buffer_size() / kv.itemsize(),
-      /* offset */ -kv.offset());
-  return copy;
-}
-
-constexpr int QKV_NDIM = 4;
-
-struct SDPACacheKey {
-  int device_id;
-  fe::DataType_t cudnn_dtype;
-  std::array<int, QKV_NDIM> q_shape;
-  std::array<int, QKV_NDIM> k_shape;
-  std::array<int, QKV_NDIM> v_shape;
-  std::array<int64_t, QKV_NDIM> q_strides;
-  std::array<int64_t, QKV_NDIM> k_strides;
-  std::array<int64_t, QKV_NDIM> v_strides;
-  bool do_causal;
-  std::array<int, QKV_NDIM> mask_shape;
-  std::array<int64_t, QKV_NDIM> mask_strides;
-  bool has_sinks;
-  bool output_logsumexp;
-};
-
-inline BytesKey<SDPACacheKey> build_sdpa_cache_key(
-    cu::CommandEncoder& encoder,
-    const array& q,
-    const array& k,
-    const array& v,
-    bool do_causal,
-    const std::optional<array>& mask_arr,
-    const std::optional<array>& sinks,
-    bool decoding = false,
-    bool output_logsumexp = false) {
-  BytesKey<SDPACacheKey> cache_key;
-  cache_key.pod.device_id = encoder.device().cuda_device();
-  cache_key.pod.cudnn_dtype = dtype_to_cudnn_type(q.dtype());
-  cache_key.pod.q_shape = vector_key<QKV_NDIM>(q.shape());
-  cache_key.pod.k_shape = vector_key<QKV_NDIM>(k.shape());
-  cache_key.pod.v_shape = vector_key<QKV_NDIM>(v.shape());
-  cache_key.pod.q_strides = vector_key<QKV_NDIM>(q.strides());
-  cache_key.pod.k_strides = vector_key<QKV_NDIM>(k.strides());
-  cache_key.pod.v_strides = vector_key<QKV_NDIM>(v.strides());
-  cache_key.pod.do_causal = do_causal;
-  cache_key.pod.has_sinks = sinks.has_value();
-  cache_key.pod.output_logsumexp = output_logsumexp;
-  if (mask_arr) {
-    cache_key.pod.mask_shape = vector_key<QKV_NDIM>(mask_arr->shape());
-    cache_key.pod.mask_strides = vector_key<QKV_NDIM>(mask_arr->strides());
-  }
-  if (decoding) {
-    int64_t T_kv = k.strides(1) / k.strides(2);
-    cache_key.pod.k_shape[2] = T_kv;
-    cache_key.pod.v_shape[2] = T_kv;
-    cache_key.pod.k_strides.fill(0);
-    cache_key.pod.v_strides.fill(0);
-  }
-  return cache_key;
-}
-
-auto& sdpa_cache() {
-  static thread_local LRUBytesKeyCache<SDPACacheKey, DnnGraph> cache(
-      "MLX_CUDA_SDPA_CACHE_SIZE", /* default_capacity */ 256);
-  return cache;
-}
-
-auto& sdpa_backward_cache() {
-  static thread_local LRUBytesKeyCache<SDPACacheKey, DnnGraph> cache(
-      "MLX_CUDA_SDPA_BACKWARD_CACHE_SIZE", /* default_capacity */ 64);
-  return cache;
-}
-
-enum UIDS {
-  Q,
-  K,
-  V,
-  SCALE,
-  BIAS,
-  SINKS,
-  SEQ_LEN_Q,
-  SEQ_LEN_KV,
-  O,
-  STATS,
-  // Backward graph:
-  D_Q,
-  D_K,
-  D_V,
-  D_O,
-};
-
-DnnGraph build_sdpa_graph(
-    cudnnHandle_t handle,
-    const array& q,
-    const array& k,
-    const array& v,
-    bool do_causal,
-    const std::optional<array>& mask_arr,
-    const std::optional<array>& sinks,
-    const std::optional<array>& seq_len_q,
-    const std::optional<array>& seq_len_kv,
-    bool output_logsumexp,
-    const array& o,
-    const std::optional<array>& stats) {
-  DnnGraph graph(handle, q.dtype());
-
-  auto q_ = graph.tensor("Q", Q, q);
-  auto k_ = graph.tensor("K", K, k);
-  auto v_ = graph.tensor("V", V, v);
-
-  auto options = fe::graph::SDPA_attributes()
-                     .set_name("sdpa_cudnn")
-                     .set_attn_scale(graph.scalar("Scale", SCALE, float32))
-                     .set_generate_stats(output_logsumexp);
-  if (do_causal) {
-    options.set_causal_mask_bottom_right(do_causal);
-  }
-  if (mask_arr) {
-    options.set_bias(graph.tensor("BIAS", BIAS, *mask_arr));
-  }
-  if (sinks) {
-    options.set_sink_token(graph.tensor_4d("SINKS", SINKS, *sinks, 1));
-  }
-  if (seq_len_q && seq_len_kv) {
-    options.set_padding_mask(true);
-    options.set_seq_len_q(graph.tensor("SEQ_LEN_Q", SEQ_LEN_Q, *seq_len_q));
-    options.set_seq_len_kv(graph.tensor("SEQ_LEN_KV", SEQ_LEN_KV, *seq_len_kv));
-  }
-
-  auto [o_, stats_] = graph.sdpa(q_, k_, v_, options);
-  graph.tensor(o_, O, o)->set_output(true);
-  if (output_logsumexp) {
-    graph.tensor(stats_, STATS, *stats)->set_output(true);
-  }
-
-  CHECK_CUDNN_ERROR(graph.prepare());
-  graph.select_behavior_notes(
-      {fe::BehaviorNote_t::SUPPORTS_CUDA_GRAPH_NATIVE_API});
-  CHECK_CUDNN_ERROR(graph.build());
-  return graph;
-}
-
-DnnGraph build_sdpa_backward_graph(
-    cudnnHandle_t handle,
-    const array& q,
-    const array& k,
-    const array& v,
-    bool do_causal,
-    const std::optional<array>& mask_arr,
-    const std::optional<array>& sinks,
-    const array& o,
-    const array& d_o,
-    const array& stats,
-    array& d_q,
-    array& d_k,
-    array& d_v) {
-  DnnGraph graph(handle, q.dtype());
-
-  auto q_ = graph.tensor("Q", Q, q);
-  auto k_ = graph.tensor("K", K, k);
-  auto v_ = graph.tensor("V", V, v);
-  auto o_ = graph.tensor("O", O, o);
-  auto d_o_ = graph.tensor("D_O", D_O, d_o);
-  auto stats_ = graph.tensor("STATS", STATS, stats);
-
-  auto options = fe::graph::SDPA_backward_attributes()
-                     .set_name("sdpa_backward_cudnn")
-                     .set_attn_scale(graph.scalar("Scale", SCALE, float32));
-  if (do_causal) {
-    options.set_causal_mask_bottom_right(do_causal);
-  }
-  if (mask_arr) {
-    options.set_bias(graph.tensor("BIAS", BIAS, *mask_arr));
-  }
-  if (sinks) {
-    options.set_sink_token(graph.tensor_4d("SINKS", SINKS, *sinks, 1));
-  }
-
-  auto [d_q_, d_k_, d_v_] =
-      graph.sdpa_backward(q_, k_, v_, o_, d_o_, stats_, options);
-  graph.tensor(d_q_, D_Q, d_q)->set_output(true);
-  graph.tensor(d_k_, D_K, d_k)->set_output(true);
-  graph.tensor(d_v_, D_V, d_v)->set_output(true);
-
-  CHECK_CUDNN_ERROR(graph.prepare());
-  graph.select_behavior_notes(
-      {fe::BehaviorNote_t::SUPPORTS_CUDA_GRAPH_NATIVE_API});
-  CHECK_CUDNN_ERROR(graph.build());
-  return graph;
-}
-
 } // namespace
 
-void init_cudnn_sdpa_cache() {
-  sdpa_cache();
-  sdpa_backward_cache();
-}
-
-bool supports_sdpa_cudnn(
-    const array& q,
-    const array& k,
-    const array& v,
-    bool has_arr_mask,
-    bool do_causal,
-    Stream s) {
-  static bool enabled = env::get_var("MLX_CUDA_USE_CUDNN_SDPA", 1);
-  if (!enabled) {
-    return false;
-  }
-
-  // cuDNN SDPA requires Ampere and later.
-  if (cu::device(s.device).compute_capability_major() < 8) {
-    return false;
-  }
-
-  // Only use cuDNN for decoding when k/v are slices from fixed-size kv cache.
-  if ((q.shape(2) == 1) && !use_cudnn_for_decoding(q, k, v, has_arr_mask)) {
-    return false;
-  }
-
-  // cuDNN does not support bottom right mask when T_q > T_kv.
-  if (do_causal && (q.shape(2) > k.shape(2))) {
-    return false;
-  }
-
-  // D_qk and D_v must be a multiple of 8 with maximum value 128.
-  if ((q.shape(-1) % 8 != 0) || (q.shape(-1) > 128) || (v.shape(-1) % 8 != 0) ||
-      (v.shape(-1) > 128)) {
-    return false;
-  }
-
-  Dtype dtype = q.dtype();
-  return dtype == float16 || dtype == bfloat16;
-}
-
-void sdpa_cudnn(
-    const array& q,
-    array k,
-    array v,
-    float scale,
-    array& o,
-    std::optional<array>& stats,
-    bool do_causal,
-    const std::optional<array>& mask_arr,
-    const std::optional<array>& sinks,
-    bool output_logsumexp,
-    Stream s) {
-  auto& encoder = cu::get_command_encoder(s);
-  auto handle = get_cudnn_handle(encoder.device());
-
-  malloc_with_same_layout(encoder, o, q);
-
-  // For decoding, unslice k/v and apply padding mask.
-  std::optional<array> seq_len_q;
-  std::optional<array> seq_len_kv;
-  bool decoding = use_cudnn_for_decoding(q, k, v, mask_arr.has_value());
-  if (decoding) {
-    int B = q.shape(0);
-    std::vector<int> seq_len_q_vec(B, q.shape(2));
-    std::vector<int> seq_len_kv_vec(B, k.shape(2));
-    seq_len_q = array(seq_len_q_vec.begin(), {B, 1, 1, 1});
-    seq_len_kv = array(seq_len_kv_vec.begin(), {B, 1, 1, 1});
-    encoder.add_temporary(*seq_len_q);
-    encoder.add_temporary(*seq_len_kv);
-    k = unslice_kv(k);
-    v = unslice_kv(v);
-    encoder.add_temporary(k);
-    encoder.add_temporary(v);
-  }
-
-  encoder.set_input_array(q);
-  encoder.set_input_array(k);
-  encoder.set_input_array(v);
-  encoder.set_output_array(o);
-  if (mask_arr) {
-    encoder.set_input_array(*mask_arr);
-  }
-  if (sinks) {
-    encoder.set_input_array(*sinks);
-  }
-  if (seq_len_q && seq_len_kv) {
-    encoder.set_input_array(*seq_len_q);
-    encoder.set_input_array(*seq_len_kv);
-  }
-  if (output_logsumexp) {
-    stats->set_data(cu::malloc_async(stats->nbytes(), encoder));
-    encoder.set_output_array(*stats);
-  }
-
-  // Search cache.
-  auto cache_key = build_sdpa_cache_key(
-      encoder, q, k, v, do_causal, mask_arr, sinks, decoding, output_logsumexp);
-  auto it = sdpa_cache().find(cache_key);
-  if (it == sdpa_cache().end()) {
-    auto graph = build_sdpa_graph(
-        handle,
-        q,
-        k,
-        v,
-        do_causal,
-        mask_arr,
-        sinks,
-        seq_len_q,
-        seq_len_kv,
-        output_logsumexp,
-        o,
-        stats);
-    it = sdpa_cache().emplace(cache_key, std::move(graph)).first;
-  }
-  auto& graph = it->second;
-
-  std::unordered_map<int64_t, void*> variant_pack{
-      {Q, gpu_ptr<void>(q)},
-      {K, gpu_ptr<void>(k)},
-      {V, gpu_ptr<void>(v)},
-      {SCALE, &scale},
-      {O, gpu_ptr<void>(o)}};
-  if (mask_arr) {
-    variant_pack[BIAS] = gpu_ptr<void>(*mask_arr);
-  }
-  if (sinks) {
-    variant_pack[SINKS] = gpu_ptr<void>(*sinks);
-  }
-  if (seq_len_q && seq_len_kv) {
-    variant_pack[SEQ_LEN_Q] = gpu_ptr<void>(*seq_len_q);
-    variant_pack[SEQ_LEN_KV] = gpu_ptr<void>(*seq_len_kv);
-  }
-  if (output_logsumexp) {
-    variant_pack[STATS] = gpu_ptr<void>(*stats);
-  }
-
-  CHECK_CUDNN_ERROR(graph.encode_graph(encoder, std::move(variant_pack)));
-}
-
-void sdpa_backward_cudnn(
-    const array& q,
-    const array& k,
-    const array& v,
-    float scale,
-    const array& o,
-    const array& stats,
-    bool do_causal,
-    const std::optional<array>& mask_arr,
-    const std::optional<array>& sinks,
-    const array& d_o,
-    array& d_q,
-    array& d_k,
-    array& d_v,
-    Stream s) {
-  auto& encoder = cu::get_command_encoder(s);
-  auto handle = get_cudnn_handle(encoder.device());
-
-  malloc_with_same_layout(encoder, d_q, q);
-  malloc_with_same_layout(encoder, d_k, k);
-  malloc_with_same_layout(encoder, d_v, v);
-
-  encoder.set_input_array(q);
-  encoder.set_input_array(k);
-  encoder.set_input_array(v);
-  encoder.set_input_array(o);
-  encoder.set_input_array(stats);
-  encoder.set_input_array(d_o);
-  encoder.set_output_array(d_q);
-  encoder.set_output_array(d_k);
-  encoder.set_output_array(d_v);
-  if (mask_arr) {
-    encoder.set_input_array(*mask_arr);
-  }
-  if (sinks) {
-    encoder.set_input_array(*sinks);
-  }
-
-  // Search cache.
-  auto cache_key =
-      build_sdpa_cache_key(encoder, q, k, v, do_causal, mask_arr, sinks);
-  auto it = sdpa_backward_cache().find(cache_key);
-  if (it == sdpa_backward_cache().end()) {
-    auto graph = build_sdpa_backward_graph(
-        handle,
-        q,
-        k,
-        v,
-        do_causal,
-        mask_arr,
-        sinks,
-        o,
-        d_o,
-        stats,
-        d_q,
-        d_k,
-        d_v);
-    it = sdpa_backward_cache().emplace(cache_key, std::move(graph)).first;
-  }
-  auto& graph = it->second;
-
-  std::unordered_map<int64_t, void*> variant_pack{
-      {Q, gpu_ptr<void>(q)},
-      {K, gpu_ptr<void>(k)},
-      {V, gpu_ptr<void>(v)},
-      {SCALE, &scale},
-      {O, gpu_ptr<void>(o)},
-      {STATS, gpu_ptr<void>(stats)},
-      {D_O, gpu_ptr<void>(d_o)},
-      {D_Q, gpu_ptr<void>(d_q)},
-      {D_K, gpu_ptr<void>(d_k)},
-      {D_V, gpu_ptr<void>(d_v)}};
-  if (mask_arr) {
-    variant_pack[BIAS] = gpu_ptr<void>(*mask_arr);
-  }
-  if (sinks) {
-    variant_pack[SINKS] = gpu_ptr<void>(*sinks);
-  }
-
-  CHECK_CUDNN_ERROR(graph.encode_graph(encoder, std::move(variant_pack)));
-}
-
-// Defined in scaled_dot_product_attention.cu file.
+// Defined in scaled_dot_product_attention.cu.
 bool supports_sdpa_vector(
     const array& q,
     const array& k,
@@ -562,9 +83,9 @@ bool ScaledDotProductAttention::use_fallback(
   if (s.device == Device::cpu) {
     return true;
   }
-
-  return !supports_sdpa_cudnn(q, k, v, has_arr_mask, do_causal, s) &&
-      !supports_sdpa_vector(q, k, v, has_arr_mask, output_logsumexp);
+  // K80: only the manual vector kernel is available. If it can't handle this
+  // shape/dtype, fall back to the CPU primitive.
+  return !supports_sdpa_vector(q, k, v, has_arr_mask, output_logsumexp);
 }
 
 bool ScaledDotProductAttention::supports_bool_mask() {
@@ -582,99 +103,26 @@ void ScaledDotProductAttention::eval_gpu(
   array k = prepare_sdpa_input(inputs[1], s);
   array v = prepare_sdpa_input(inputs[2], s);
   array& out = outputs[0];
-  bool has_mask = inputs.size() - has_sinks_ > 3;
-  bool has_arr_mask = has_mask && !do_causal_;
 
-  std::optional<array> mask_arr;
-  if (has_arr_mask) {
-    mask_arr = prepare_sdpa_input(inputs[3], s);
-  }
   std::optional<array> sinks;
   if (has_sinks_) {
     sinks = inputs.back();
   }
-  std::optional<array> stats;
-  if (output_logsumexp_) {
-    stats = outputs[1];
-  }
 
-  if (supports_sdpa_cudnn(q, k, v, has_arr_mask, do_causal_, s)) {
-    if (sinks) {
-      sinks = prepare_sdpa_sinks(*sinks, s);
-    }
-    sdpa_cudnn(
-        q,
-        k,
-        v,
-        scale_,
-        out,
-        stats,
-        do_causal_,
-        mask_arr,
-        sinks,
-        output_logsumexp_,
-        s);
-  } else {
-    sdpa_vector(q, k, v, scale_, out, do_causal_, sinks, s);
-  }
+  sdpa_vector(q, k, v, scale_, out, do_causal_, sinks, s);
 }
 
 bool ScaledDotProductAttentionVJP::use_fallback(const array& q, Stream s) {
-  // The frontend adds a padding mask when sequence length is not a multiple of
-  // tile size.
-  if (q.shape(2) % 128 != 0) {
-    return true;
-  }
-  return s.device == Device::cpu;
+  // K80: no cuDNN backward; always fall back to the CPU primitive.
+  return true;
 }
 
 void ScaledDotProductAttentionVJP::eval_gpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {
-  nvtx3::scoped_range r("ScaledDotProductAttentionVJP::eval_gpu");
-
-  auto& s = stream();
-
-  assert(inputs.size() >= 6);
-  int primals_size = inputs.size() - 3;
-  bool has_arr_mask = primals_size > 3 + has_sinks_;
-
-  array q = prepare_sdpa_input(inputs[0], s);
-  array k = prepare_sdpa_input(inputs[1], s);
-  array v = prepare_sdpa_input(inputs[2], s);
-  array o = prepare_sdpa_input(inputs[primals_size], s);
-  array stats = prepare_sdpa_input(inputs[primals_size + 1], s);
-  array d_o = prepare_sdpa_input(inputs[primals_size + 2], s);
-
-  std::optional<array> mask_arr;
-  if (has_arr_mask) {
-    mask_arr = prepare_sdpa_input(inputs[3], s);
-  }
-  std::optional<array> sinks;
-  if (has_sinks_) {
-    sinks = prepare_sdpa_sinks(inputs.back(), s);
-  }
-
-  assert(outputs.size() == 3);
-  auto& d_q = outputs[0];
-  auto& d_k = outputs[1];
-  auto& d_v = outputs[2];
-
-  sdpa_backward_cudnn(
-      q,
-      k,
-      v,
-      scale_,
-      o,
-      stats,
-      do_causal_,
-      mask_arr,
-      sinks,
-      d_o,
-      d_q,
-      d_k,
-      d_v,
-      s);
+  throw std::runtime_error(
+      "[ScaledDotProductAttentionVJP] No GPU backward on the K80 build; "
+      "use_fallback returns true so this path should be unreachable.");
 }
 
 } // namespace fast

--- a/x/mlxrunner/CMakeLists.txt
+++ b/x/mlxrunner/CMakeLists.txt
@@ -1,0 +1,41 @@
+# K80 runner — scaffolding for Phase B. The goal is *not* to ship a full MLX
+# runner here; it's to surface what symbols an MLX exe actually needs to link
+# on top of libmlx.a (the on-path archive built from x/mlx). The first
+# deliverable is `qwen_smoke` — a probe that touches qwen3.5's forward-pass
+# op surface so the linker enumerates whatever's still missing.
+#
+# Build:
+#   cmake -S x/mlxrunner -B /tmp/runner -DCMAKE_BUILD_TYPE=Release
+#   cmake --build /tmp/runner -j$(nproc)
+# Expect: link fails (initially) with undefined refs -> punch list for reroute.
+
+cmake_minimum_required(VERSION 3.21)
+project(mlx_runner CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Pull in the libmlx.a target from the sibling x/mlx tree.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../mlx mlx_build)
+
+find_package(CUDAToolkit REQUIRED)
+
+add_executable(qwen_smoke smoke/qwen_surface.cpp)
+
+target_include_directories(qwen_smoke PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../mlx
+)
+
+# libmlx.a brings in the on-path CUDA backend; cudart + cuda_driver + cublas
+# resolve the runtime + driver-API (cuLaunchKernel/cuGraphAddKernelNode) +
+# GEMM symbols libmlx.a refers to.
+target_link_libraries(qwen_smoke PRIVATE
+    mlx
+    CUDA::cudart
+    CUDA::cuda_driver
+    CUDA::cublas
+)

--- a/x/mlxrunner/smoke/qwen_surface.cpp
+++ b/x/mlxrunner/smoke/qwen_surface.cpp
@@ -1,0 +1,62 @@
+// K80 runner — Phase B link-surface probe.
+//
+// This isn't a runner. It's the smallest C++ exe that *names* the symbols a
+// qwen3.5 forward pass needs, so the linker enumerates what libmlx.a still
+// can't satisfy. We don't care if the kernels run; we care which references
+// the static archive can't resolve. Each undefined ref is a punch-list item
+// for Phase B (reroute to stub / cuBLAS / dequant) before the real runner
+// can link.
+//
+// Build via x/mlxrunner/CMakeLists.txt; expect link failures the first time.
+
+#include "mlx/mlx.h"
+
+#include <iostream>
+
+using namespace mlx::core;
+
+int main() {
+  // Force the CUDA backend (Device::gpu = DeviceType::gpu; default index 0).
+  set_default_device(Device(Device::gpu));
+
+  // Tiny shapes — values are irrelevant, only the symbols matter.
+  const int B = 1, H = 1, T = 8, D = 64, K = 16;
+
+  // --- core ops ---
+  array a = random::uniform({B, T, D});
+  array w = random::uniform({D, D});
+  array c = matmul(a, w);
+  array x = reshape(c, {B, H, T, D});
+
+  // --- fast-fused ops ---
+  array rw = random::uniform({D});
+  array n = fast::rms_norm(c, rw, 1e-6f);
+  array rq = fast::rope(x, D, /*traditional=*/false,
+                        /*base=*/10000.0f, /*scale=*/1.0f, /*offset=*/0);
+
+  array sm = softmax(n, -1);
+
+  // --- attention (uses sdpa_vector on K80) ---
+  array q = random::uniform({B, H, T, D});
+  array kk = random::uniform({B, H, T, D});
+  array vv = random::uniform({B, H, T, D});
+  array o = fast::scaled_dot_product_attention(q, kk, vv, /*scale=*/0.125f);
+
+  // --- 1d conv (DeltaNet short-conv on q/k/v gates) ---
+  array x1d = random::uniform({B, T, K});
+  array w1d = random::uniform({K, /*kw=*/3, K});
+  array cv = conv1d(x1d, w1d, /*stride=*/1, /*padding=*/0,
+                    /*dilation=*/1, /*groups=*/1);
+
+  // --- quantized matmul dispatch (qmm impls deferred -> linker tells us) ---
+  auto qpacks = quantize(w, /*group_size=*/64, /*bits=*/4);
+  array qm = quantized_matmul(a, qpacks[0], qpacks[1], qpacks[2],
+                              /*transpose=*/true, /*group_size=*/64,
+                              /*bits=*/4);
+
+  // Force evaluation so the backend dispatch -> kernel symbols get pulled in.
+  eval({c, n, sm, rq, o, cv, qm});
+
+  std::cout << "qwen_smoke: forward-surface link OK\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary

Phase A (compute core) and Phase B (link milestone + CI standardization) for the MLX-on-K80 port (#188 / parent epic #187).

### Phase A — `libmlx.a` covers the on-path forward kernels

Each commit strips one cuDNN dispatch and routes to a path that compiles on the K80 toolchain (nvcc 11.4 / gcc-10 / sm_37, no clang, no cuDNN frontend):

| Commit | Reroute |
|---|---|
| `2790e287` | matmul.cpp → cuBLAS (CUTLASS gemm decls kept, impls excluded) |
| `b361c092` | quantized.cpp dispatch (qmm CUTLASS impls excluded) |
| `a41857ae` | sdpa.cu manual vector kernel into archive |
| `7c1fca37` | sdpa.cpp cuDNN flash-attn stripped → always manual kernel |
| `39abb387` | conv.cpp cuDNN stripped → GEMM-based gemm_conv (im2col + cuBLAS) |

`libmlx.a`: 121 → 131 objects through Phase B. Builds clean in `ollama37-builder:latest`.

### Phase B — `qwen_smoke` exe links

| Commit | What |
|---|---|
| `120adf96` | qwen_smoke link-surface probe; wires backend/gpu + backend/no_cpu (upstream's GPU-only stub backend, emits 116 primitive vtables) + backend/cpu/{eval,encoder} + backend/metal/no_metal + k80_runtime_stubs.cpp (37 off-path symbols as runtime throws — CUTLASS qmm/gemm trio, JIT runtime, distributed collectives, BlockMaskedMM, FFT/Hadamard/Scatter/Gather/Scan/SliceUpdate/QQMatmul/FP8, affine + fp quant/dequant). Undefined refs: 126 → 45 → 0. |
| `807506ea` | CI workflow `test-mlx-smoke.yml` + script `cicd/scripts/test-mlx-smoke.sh` standardizing build (in builder image) + run (in production runtime image) per `test-workflow-pattern`. |

## Test plan

1. After merge, trigger the new workflow: `gh workflow run test-mlx-smoke.yml --ref main`.
2. **Expected**: workflow goes red on the run step — `ollama37:latest` (Rocky 8.10) is missing `libcudart.so.11`, `libcublas.so.11`, `libcublasLt.so.11`, and has an older `libstdc++` (no `GLIBCXX_3.4.26`). The script captures these in the JSON's `run.ldd_missing` and `run.stderr` fields.
3. That red is the design — it's the runtime-image punch list for Phase C (decide between baking CUDA toolkit + newer libstdc++ into runtime image vs. static-link in the runner CMakeLists vs. LD_LIBRARY_PATH bundling).

Build itself is verified locally per the 7 commits above (each one ran via the builder agent and reported clean libmlx.a archives + object counts in the commit messages).

### Isolation

Nothing on the existing GGUF/GGML serving path changes. Diff touches only `x/mlx/`, `x/mlxrunner/`, `MLX_VERSION`, `cicd/scripts/test-mlx-smoke.sh`, `.github/workflows/test-mlx-smoke.yml`. The K80 production container's behavior is identical until the runner exe lands (Phase C).

Part of #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)