### PR TITLE
Phase C: QuantizedMatmul dequant+cuBLAS fallback on K80 (#188)

### DIFF
--- a/x/mlx/mlx/backend/cuda/quantized/quantized.cpp
+++ b/x/mlx/mlx/backend/cuda/quantized/quantized.cpp
@@ -12,6 +12,87 @@
 
 namespace mlx::core {
 
+namespace {
+
+// K80 fallback for QuantizedMatmul / GatherQMM: when no native qmm variant is
+// supported (always true on sm_37 — supports_qmm_sm90/sm80/naive all return
+// false in k80_runtime_stubs.cpp), dequantize the weights into a temporary
+// full-precision buffer and route through the existing dense cuBLAS Matmul.
+// Slower than fused qmm (extra buffer + memory bandwidth) but functional on
+// pre-sm_80 GPUs that lack the tensor cores qmm_sm80/sm90 require.
+void dequant_then_matmul_k80(
+    const array& x,
+    const array& wq,
+    const array& scales,
+    const std::optional<array>& biases,
+    bool transpose,
+    int bits,
+    int group_size,
+    QuantizationMode mode,
+    array& out,
+    cu::CommandEncoder& encoder,
+    Stream s) {
+  if (mode != QuantizationMode::Affine) {
+    throw std::runtime_error(
+        "[QuantizedMatmul] K80 fallback supports affine mode only; "
+        "fp/qx modes have no dequant impl yet.");
+  }
+  if (!biases) {
+    throw std::runtime_error(
+        "[QuantizedMatmul] K80 affine fallback requires biases.");
+  }
+
+  // Reconstruct full weight shape: wq's last dim is packed; expand by
+  // pack_factor (matches affine_dequantize.cu's grid math).
+  const int pack_factor = (bits == 3 || bits == 5) ? 8
+      : (bits == 6)                                ? 4
+                                                   : (8 / bits);
+  auto w_shape = wq.shape();
+  w_shape.back() *= pack_factor;
+
+  array w_full(w_shape, x.dtype(), nullptr, {});
+  w_full.set_data(cu::malloc_async(w_full.nbytes(), encoder));
+  encoder.add_temporary(w_full);
+
+  affine_dequantize(
+      wq, scales, *biases, w_full, group_size, bits, encoder, s);
+
+  // QuantizedMatmul's transpose=true convention: wq encodes a (N, K_packed)
+  // matrix, so w_full is (N, K) and we want `out = x @ w_full.T`. Build a
+  // strided transposed view (no copy) so Matmul's check_transpose detects
+  // col-major strides and sets the cuBLAS b_transposed flag.
+  array w_for_gemm = w_full;
+  if (transpose) {
+    const int rank = w_full.ndim();
+    Shape t_shape = w_full.shape();
+    Strides t_strides = w_full.strides();
+    std::swap(t_shape[rank - 1], t_shape[rank - 2]);
+    std::swap(t_strides[rank - 1], t_strides[rank - 2]);
+    array::Flags t_flags = w_full.flags();
+    if (rank == 2) {
+      // 2D row-contig becomes col-contig after axis swap.
+      std::swap(t_flags.row_contiguous, t_flags.col_contiguous);
+    } else {
+      // Higher-D: neither row nor col contiguous in general after a
+      // last-two-dims swap; conservative clear.
+      t_flags.row_contiguous = false;
+      t_flags.col_contiguous = false;
+    }
+    w_for_gemm = array(t_shape, w_full.dtype(), nullptr, {});
+    w_for_gemm.copy_shared_buffer(
+        w_full, t_strides, t_flags, w_full.data_size());
+  }
+
+  // Delegate to the existing dense Matmul GPU primitive. It allocates `out`
+  // itself (set_data inside its eval_gpu) and handles batched + transposed
+  // inputs via check_transpose on strides — same path Phase A wired.
+  Matmul mm(s);
+  std::vector<array> mm_inputs = {x, w_for_gemm};
+  mm.eval_gpu(mm_inputs, out);
+}
+
+} // namespace
+
 void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   nvtx3::scoped_range r("QuantizedMatmul::eval_gpu");
   auto& s = stream();
@@ -125,20 +206,10 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     return;
   }
 
-  throw std::runtime_error(
-      fmt::format(
-          "[quantized_matmul] No implementation for "
-          "problem shape: {}x{}x{}x{}, transpose: {}, "
-          "activation: {}, bits: {}, group size: {}, mode: \"{}\".",
-          M,
-          N,
-          K,
-          B,
-          transpose_,
-          dtype_to_string(x.dtype()),
-          bits_,
-          group_size_,
-          quantization_mode_to_string(mode_)));
+  // K80 fallback: no native qmm variant on sm_37. Dequant + cuBLAS GEMM.
+  dequant_then_matmul_k80(
+      x, w, scales, biases, transpose_, bits_, group_size_, mode_,
+      out, encoder, s);
 }
 
 void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {

--- a/x/mlx/mlx/backend/cuda/quantized/quantized.cpp
+++ b/x/mlx/mlx/backend/cuda/quantized/quantized.cpp
@@ -70,8 +70,11 @@ void dequant_then_matmul_k80(
     std::swap(t_strides[rank - 1], t_strides[rank - 2]);
     array::Flags t_flags = w_full.flags();
     if (rank == 2) {
-      // 2D row-contig becomes col-contig after axis swap.
-      std::swap(t_flags.row_contiguous, t_flags.col_contiguous);
+      // 2D row-contig becomes col-contig after axis swap. std::swap can't
+      // bind to bitfield members (no lvalue ref to bool), so swap manually.
+      const bool was_row = t_flags.row_contiguous;
+      t_flags.row_contiguous = t_flags.col_contiguous;
+      t_flags.col_contiguous = was_row;
     } else {
       // Higher-D: neither row nor col contiguous in general after a
       // last-two-dims swap; conservative clear.

--- a/x/mlx/mlx/backend/cuda/quantized/quantized.cpp
+++ b/x/mlx/mlx/backend/cuda/quantized/quantized.cpp
@@ -42,13 +42,26 @@ void dequant_then_matmul_k80(
         "[QuantizedMatmul] K80 affine fallback requires biases.");
   }
 
-  // Reconstruct full weight shape: wq's last dim is packed; expand by
-  // pack_factor (matches affine_dequantize.cu's grid math).
-  const int pack_factor = (bits == 3 || bits == 5) ? 8
-      : (bits == 6)                                ? 4
-                                                   : (8 / bits);
+  // Reconstruct the full-precision weight shape from wq. The public API
+  // stores wq as uint32, where each uint32 packs `32 / bits` weights for
+  // bits in {2,4,8} (see dequantize() in ops.cpp:4978 — `out_size =
+  // w.shape(-1) * 32 / bits`). The irregular bits (3/5/6) use a different
+  // packing that affine_dequantize.cu's bits==3/5/6 branches handle, but
+  // their wq → w-full shape formula doesn't reduce to a single multiplier;
+  // defer those until we have a model that needs them.
+  int weights_per_uint32;
+  switch (bits) {
+    case 2: weights_per_uint32 = 16; break;
+    case 4: weights_per_uint32 = 8; break;
+    case 8: weights_per_uint32 = 4; break;
+    default:
+      throw std::runtime_error(
+          std::string("[QuantizedMatmul] K80 dequant fallback only "
+                      "supports bits in {2,4,8} for now; got bits=") +
+          std::to_string(bits));
+  }
   auto w_shape = wq.shape();
-  w_shape.back() *= pack_factor;
+  w_shape.back() *= weights_per_uint32;
 
   array w_full(w_shape, x.dtype(), nullptr, {});
   w_full.set_data(cu::malloc_async(w_full.nbytes(), encoder));

--- a/x/mlxrunner/smoke/qwen_surface.cpp
+++ b/x/mlxrunner/smoke/qwen_surface.cpp
@@ -9,11 +9,15 @@
 // inference compute path is wired end-to-end on the K80.
 //
 // What's NOT here on purpose:
-//   - quantize() / quantized_matmul() — those are weight-conversion ops that
-//     dispatch to affine_quantize (currently a throw-stub). qwen3.5 loads
-//     pre-quantized weights and only needs affine_dequantize at inference
-//     time, which we'll exercise once task #13's dequant+cuBLAS reroute
-//     lands.
+//   - quantize() — the weight-conversion op. Dispatches to affine_quantize
+//     which is still a throw-stub; inference never calls it.
+//
+// What IS here as of the dequant+matmul wiring landing: quantized_matmul()
+// against hand-shaped pre-quantized inputs (uint8 packed + scales + biases),
+// exercising the K80 fallback chain
+//     QuantizedMatmul::eval_gpu -> dequant_then_matmul_k80
+//       -> affine_dequantize  (Phase C kernel)
+//       -> Matmul::eval_gpu   (Phase A cuBLAS path).
 //
 // Build via x/mlxrunner/CMakeLists.txt.
 
@@ -56,9 +60,29 @@ int main() {
   array cv = conv1d(x1d, w1d, /*stride=*/1, /*padding=*/0,
                     /*dilation=*/1, /*groups=*/1);
 
+  // --- quantized matmul (K80 fallback: dequant + cuBLAS) ---
+  // Hand-shaped pre-quantized inputs for a 4-bit / group_size=64 weight
+  // matrix matching qwen-style quants. We bypass quantize() (which calls
+  // the still-stubbed affine_quantize); instead construct uint8 packed
+  // weights + fp32 scales/biases directly, exactly the way an MLX safetensors
+  // load would land them. Tiny shapes — only the dispatch surface matters.
+  const int N = 32;       // out features
+  const int Kq = 64;      // in features (one quant group)
+  const int qbits = 4;
+  const int qgroup = 64;
+  array x_q = random::uniform({1, /*M=*/4, Kq});
+  // wq packs 2 4-bit weights per uint8 -> (N, Kq/2) uint8.
+  array wq = zeros({N, Kq / 2}, uint8);
+  array scales = random::uniform({N, Kq / qgroup});
+  array biases = random::uniform({N, Kq / qgroup});
+  array qm = quantized_matmul(x_q, wq, scales, biases,
+                              /*transpose=*/true,
+                              /*group_size=*/qgroup,
+                              /*bits=*/qbits);
+
   // Force evaluation so the backend dispatch -> kernel symbols get pulled in
   // and the actual GPU kernels execute.
-  eval({c, n, sm, rq, o, cv});
+  eval({c, n, sm, rq, o, cv, qm});
 
   std::cout << "qwen_smoke: forward-surface link OK\n";
   return 0;

--- a/x/mlxrunner/smoke/qwen_surface.cpp
+++ b/x/mlxrunner/smoke/qwen_surface.cpp
@@ -63,18 +63,20 @@ int main() {
   // --- quantized matmul (K80 fallback: dequant + cuBLAS) ---
   // Hand-shaped pre-quantized inputs for a 4-bit / group_size=64 weight
   // matrix matching qwen-style quants. We bypass quantize() (which calls
-  // the still-stubbed affine_quantize); instead construct uint8 packed
-  // weights + fp32 scales/biases directly, exactly the way an MLX safetensors
-  // load would land them. Tiny shapes — only the dispatch surface matters.
-  const int N = 32;       // out features
+  // the still-stubbed affine_quantize); instead construct uint32 packed
+  // weights + fp32 scales/biases directly, exactly the way an MLX
+  // safetensors load would land them. The public API requires wq to be
+  // uint32 (32/bits weights packed per uint32 — 8 weights/uint32 for
+  // bits=4). Tiny shapes — only the dispatch surface matters.
+  const int Nq = 32;      // out features
   const int Kq = 64;      // in features (one quant group)
   const int qbits = 4;
   const int qgroup = 64;
   array x_q = random::uniform({1, /*M=*/4, Kq});
-  // wq packs 2 4-bit weights per uint8 -> (N, Kq/2) uint8.
-  array wq = zeros({N, Kq / 2}, uint8);
-  array scales = random::uniform({N, Kq / qgroup});
-  array biases = random::uniform({N, Kq / qgroup});
+  // wq packs 8 4-bit weights per uint32 -> (Nq, Kq/8) uint32.
+  array wq = zeros({Nq, Kq / 8}, uint32);
+  array scales = random::uniform({Nq, Kq / qgroup});
+  array biases = random::uniform({Nq, Kq / qgroup});
   array qm = quantized_matmul(x_q, wq, scales, biases,
                               /*transpose=*/true,
                               /*group_size=*/qgroup,


### PR DESCRIPTION
## Summary

Wires the `affine_dequantize` kernel from #196 into `QuantizedMatmul::eval_gpu`. The "no implementation for problem shape" throw that always fired on sm_37 (because `supports_qmm_sm90/sm80/naive` all return false in `k80_runtime_stubs.cpp`) is replaced with a real fallback:

```
QuantizedMatmul::eval_gpu
  -> dequant_then_matmul_k80
    -> affine_dequantize          (Phase C kernel, #196)
    -> Matmul::eval_gpu           (Phase A cuBLAS path, #194)
```

## Mechanics

- Allocates a temp full-precision buffer `w_full` of shape `(..., N, K)` with `K = wq.shape[-1] * 32/bits` weights per uint32 (the public-API packing convention from `dequantize()` in ops.cpp:4978). Bits in `{2,4,8}` are handled; bits in `{3,5,6,…}` throw with a clear message (qwen3.6:35b-mlx uses bits=4 so the A3B path is covered).
- Calls `affine_dequantize(wq, scales, biases, w_full, …)`.
- For `transpose=true` (canonical layout — wq encodes a stored-transposed weight), builds a strided view of `w_full` with last two dims swapped — no copy. `Matmul::eval_gpu`'s `check_transpose` then detects column-major strides and sets the cuBLAS `b_transposed` flag.
- Constructs a `Matmul` primitive on the same stream and calls its `eval_gpu` directly. Matmul allocates `out` itself.

Scope guards:
- `mode != Affine` → throw (fp/qx modes have no dequant impl yet).
- `biases == std::nullopt` → throw (affine requires them).

## qwen_smoke probe

Hand-shaped pre-quantized inputs (uint32 packed `wq` + fp32 `scales` + `biases`) for a 4-bit/group=64 weight matching qwen-style quants. Bypasses `quantize()` (still stubbed via `affine_quantize`).

## Test plan

Workflow `26452190141` against this branch — **green**:

| Phase | Status | Detail |
|---|---|---|
| build | success | libmlx.a 132 objects (was 131) — `quantized.cpp.o` updated |
| run   | success | qwen_smoke prints `forward-surface link OK` after exercising matmul + RMS norm + RoPE + softmax + SDPA + conv1d + **quantized_matmul** end-to-end on K80 |

Two iterations to land:
1. C++ bitfield restriction: `std::swap` can't bind to bool bitfield members. Switched to manual swap via local bool. Build failed clean, fixed.
2. wq dtype/shape: public API requires uint32 (not uint8); my pack_factor formula assumed bytes. Fixed both the shape derivation (`32/bits` per uint32) and the qwen_smoke probe (`uint32` + `{Nq, Kq/8}`). Runtime threw clean, fixed.

## A3B punch-list delta

| Stub from k80_runtime_stubs.cpp | After this PR |
|---|---|
| affine_dequantize | real impl (#196) |
| affine_quantize | still stub (inference doesn't call) |
| **QuantizedMatmul::eval_gpu throws on K80** | **dequant + cuBLAS path** |
| GatherMM / cutlass_gather_mm / cutlass_grouped_gemm_unaligned | still stubs — MoE expert routing path |
| Gather / Scatter / SliceUpdate / Scan | still stubs — KV cache + DeltaNet state |

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)