### PR TITLE
fix(reduce): propagate AccT fp32 accumulator to row/col reduce (#187)

### DIFF
--- a/x/mlx/mlx/backend/cuda/reduce/col_reduce.cu
+++ b/x/mlx/mlx/backend/cuda/reduce/col_reduce.cu
@@ -118,11 +118,14 @@ __global__ void col_reduce_looped(
   in += elem_to_loc(tile_y, args.shape.data(), args.strides.data(), args.ndim) +
       tile_x * BN;
 
+  // K80 port: float accumulator for half/bf16. See all_reduce.cu / row_reduce.cu.
+  using AccT = cuda::std::conditional_t<(sizeof(U) < 4), float, U>;
+
   // Initialize the running totals
   Op op;
-  U totals[N_READS];
+  AccT totals[N_READS];
   for (int i = 0; i < N_READS; i++) {
-    totals[i] = ReduceInit<Op, T>::value();
+    totals[i] = cast_to<AccT>(ReduceInit<Op, T>::value());
   }
 
   size_t total = args.non_col_reductions * args.reduction_size;
@@ -145,7 +148,7 @@ __global__ void col_reduce_looped(
         T vals[N_READS];
         cub::LoadDirectBlockedVectorized(thread_x, in + loop.location(), vals);
         for (int i = 0; i < N_READS; i++) {
-          totals[i] = op(totals[i], cast_to<U>(vals[i]));
+          totals[i] = op(totals[i], cast_to<AccT>(vals[i]));
         }
         loop.next(BM, args.reduce_shape.data(), args.reduce_strides.data());
       }
@@ -154,7 +157,7 @@ __global__ void col_reduce_looped(
         T vals[N_READS];
         cub::LoadDirectBlocked(thread_x, in + loop.location(), vals);
         for (int i = 0; i < N_READS; i++) {
-          totals[i] = op(totals[i], cast_to<U>(vals[i]));
+          totals[i] = op(totals[i], cast_to<AccT>(vals[i]));
         }
         loop.next(BM, args.reduce_shape.data(), args.reduce_strides.data());
       }
@@ -169,7 +172,7 @@ __global__ void col_reduce_looped(
           args.reduction_stride - tile_x * BN,
           cast_to<T>(ReduceInit<Op, T>::value()));
       for (int i = 0; i < N_READS; i++) {
-        totals[i] = op(totals[i], cast_to<U>(vals[i]));
+        totals[i] = op(totals[i], cast_to<AccT>(vals[i]));
       }
       loop.next(BM, args.reduce_shape.data(), args.reduce_strides.data());
     }
@@ -178,7 +181,7 @@ __global__ void col_reduce_looped(
   // Do warp reduce for each output.
   constexpr int n_outputs = BN / threads_per_row;
   static_assert(BM == 32 && n_outputs == N_READS);
-  __shared__ __align__(16) unsigned char shared_vals_k80[(BM * BN) * sizeof(U)]; U* shared_vals = reinterpret_cast<U*>(shared_vals_k80);
+  __shared__ __align__(16) unsigned char shared_vals_k80[(BM * BN) * sizeof(AccT)]; AccT* shared_vals = reinterpret_cast<AccT*>(shared_vals_k80);
   short s_idx = thread_y * BN + thread_x * N_READS;
   for (int i = 0; i < N_READS; i++) {
     shared_vals[s_idx + i] = totals[i];
@@ -189,15 +192,20 @@ __global__ void col_reduce_looped(
     totals[i] = cg::reduce(warp, shared_vals[s_idx + i], op);
   }
 
-  // Write result.
+  // Write result. K80: cast AccT accumulators back to U for the U*-typed
+  // output buffer before cub::StoreDirectBlocked.
   if (warp.thread_rank() == 0) {
     if (BLOCKS > 1) {
       out += tile_out * out_size * args.reduction_stride;
     }
+    U totals_u[N_READS];
+    for (int i = 0; i < N_READS; i++) {
+      totals_u[i] = cast_to<U>(totals[i]);
+    }
     cub::StoreDirectBlocked(
         warp.meta_group_rank(),
         out + tile_y * args.reduction_stride + tile_x * BN,
-        totals,
+        totals_u,
         args.reduction_stride - tile_x * BN);
   }
 }
@@ -225,22 +233,30 @@ __global__ void col_reduce_small(
   in += offset;
   out += idx;
 
-  AlignedVector<U, N_READS> accumulator;
+  // K80 port: float accumulator for half/bf16. See all_reduce.cu.
+  using AccT = cuda::std::conditional_t<(sizeof(U) < 4), float, U>;
+
+  AlignedVector<AccT, N_READS> accumulator;
   for (int i = 0; i < N_READS; i++) {
-    accumulator[i] = ReduceInit<Op, T>::value();
+    accumulator[i] = cast_to<AccT>(ReduceInit<Op, T>::value());
   }
 
   for (int i = 0; i < args.reduction_size; i++) {
     auto values = load_vector<N_READS>(in, 0);
 
     for (int j = 0; j < N_READS; j++) {
-      accumulator[j] = op(accumulator[j], cast_to<U>(values[j]));
+      accumulator[j] = op(accumulator[j], cast_to<AccT>(values[j]));
     }
 
     in += args.reduction_stride;
   }
 
-  store_vector(out, 0, accumulator);
+  // K80: cast AccT accumulators back to U for the U*-typed output buffer.
+  AlignedVector<U, N_READS> accumulator_u;
+  for (int i = 0; i < N_READS; i++) {
+    accumulator_u[i] = cast_to<U>(accumulator[i]);
+  }
+  store_vector(out, 0, accumulator_u);
 }
 
 } // namespace cu

--- a/x/mlx/mlx/backend/cuda/reduce/row_reduce.cu
+++ b/x/mlx/mlx/backend/cuda/reduce/row_reduce.cu
@@ -87,11 +87,16 @@ row_reduce_simple(const T* in, U* out, size_t n_rows, int size) {
   auto block = cg::this_thread_block();
   auto warp = cg::tiled_partition<WARP_SIZE>(block);
 
-  const U init = cu::ReduceInit<ReduceOp, T>::value();
+  // K80 port: float accumulator for half/bf16 (BF16 8-bit mantissa
+  // saturates summing many small values). Matches the fix in
+  // all_reduce.cu and the softmax fp32-accumulator pattern.
+  using AccT = cuda::std::conditional_t<(sizeof(U) < 4), float, U>;
+
+  const AccT init = cast_to<AccT>(cu::ReduceInit<ReduceOp, T>::value());
   ReduceOp op;
 
   AlignedVector<T, N> vals[M];
-  AlignedVector<U, M> accs;
+  AlignedVector<AccT, M> accs;
   for (int i = 0; i < M; i++) {
     accs[i] = init;
   }
@@ -109,7 +114,7 @@ row_reduce_simple(const T* in, U* out, size_t n_rows, int size) {
     }
     for (int k = 0; k < M; k++) {
       for (int j = 0; j < N; j++) {
-        accs[k] = op(accs[k], cast_to<U>(vals[k][j]));
+        accs[k] = op(accs[k], cast_to<AccT>(vals[k][j]));
       }
     }
 
@@ -126,21 +131,26 @@ row_reduce_simple(const T* in, U* out, size_t n_rows, int size) {
     }
     for (int k = 0; k < M; k++) {
       for (int j = 0; j < N; j++) {
-        accs[k] = op(accs[k], cast_to<U>(vals[k][j]));
+        accs[k] = op(accs[k], cast_to<AccT>(vals[k][j]));
       }
     }
   }
 
-  __shared__ __align__(16) unsigned char shared_accumulators_k80[(32 * M) * sizeof(U)]; U* shared_accumulators = reinterpret_cast<U*>(shared_accumulators_k80);
+  __shared__ __align__(16) unsigned char shared_accumulators_k80[(32 * M) * sizeof(AccT)]; AccT* shared_accumulators = reinterpret_cast<AccT*>(shared_accumulators_k80);
   block_reduce(block, warp, accs.val, shared_accumulators, op, init);
 
   if (block.thread_rank() == 0) {
+    // K80: cast accumulators (AccT) back to U before storing to out (U*).
+    AlignedVector<U, M> accs_u;
+    for (int i = 0; i < M; i++) {
+      accs_u[i] = cast_to<U>(accs[i]);
+    }
     if (mlx_block_rank() * M + M <= n_rows) {
-      store_vector(out, 0, accs);
+      store_vector(out, 0, accs_u);
     } else {
       short offset = mlx_block_rank() * M + M - n_rows;
       for (int i = offset; i < M; i++) {
-        out[i] = accs[i];
+        out[i] = accs_u[i];
       }
     }
   }
@@ -155,12 +165,15 @@ __global__ void row_reduce_looped(
   auto block = cg::this_thread_block();
   auto warp = cg::tiled_partition<WARP_SIZE>(block);
 
+  // K80 port: float accumulator for half/bf16. See row_reduce_simple note.
+  using AccT = cuda::std::conditional_t<(sizeof(U) < 4), float, U>;
+
   size_t out_idx = mlx_block_rank();
 
   Op op;
 
-  U total[1];
-  U init = ReduceInit<Op, T>::value();
+  AccT total[1];
+  AccT init = cast_to<AccT>(ReduceInit<Op, T>::value());
   total[0] = init;
   LoopedElemToLoc<NDIM, (NDIM > 2)> loop(args.reduce_ndim);
   const size_t full_blocks = args.row_size / (block.size() * N_READS);
@@ -183,7 +196,7 @@ __global__ void row_reduce_looped(
       for (size_t r = 0; r < full_blocks; r++) {
         auto vals = load_vector<N_READS>(inlocal, 0);
         for (int i = 0; i < N_READS; i++) {
-          total[0] = op(total[0], cast_to<U>(vals[i]));
+          total[0] = op(total[0], cast_to<AccT>(vals[i]));
         }
         inlocal += block.size() * N_READS;
       }
@@ -194,7 +207,7 @@ __global__ void row_reduce_looped(
           vals[i] = mask[i] ? inlocal[i] : cast_to<T>(init);
         }
         for (int i = 0; i < N_READS; i++) {
-          total[0] = op(total[0], cast_to<U>(vals[i]));
+          total[0] = op(total[0], cast_to<AccT>(vals[i]));
         }
       }
 
@@ -210,7 +223,7 @@ __global__ void row_reduce_looped(
       for (size_t r = 0; r < full_blocks; r++) {
         auto vals = load_vector<N_READS>(inlocal, 0);
         for (int i = 0; i < N_READS; i++) {
-          total[0] = op(total[0], cast_to<U>(vals[i]));
+          total[0] = op(total[0], cast_to<AccT>(vals[i]));
         }
         inlocal += block.size() * N_READS;
       }
@@ -219,11 +232,11 @@ __global__ void row_reduce_looped(
     }
   }
 
-  __shared__ __align__(16) unsigned char shared_accumulators_k80[(32) * sizeof(U)]; U* shared_accumulators = reinterpret_cast<U*>(shared_accumulators_k80);
+  __shared__ __align__(16) unsigned char shared_accumulators_k80[(32) * sizeof(AccT)]; AccT* shared_accumulators = reinterpret_cast<AccT*>(shared_accumulators_k80);
   block_reduce(block, warp, total, shared_accumulators, op, init);
 
   if (block.thread_rank() == 0) {
-    out[out_idx] = total[0];
+    out[out_idx] = cast_to<U>(total[0]);
   }
 }
 


### PR DESCRIPTION
## Summary

Apply the same float-accumulator pattern from `all_reduce.cu` (PR #199) to `row_reduce.cu` and `col_reduce.cu`. Four kernels touched: `row_reduce_simple`, `row_reduce_looped`, `col_reduce_small`, `col_reduce_looped`.

Same root cause as #199: `ReduceResult<Sum, T>::type` returns `T` for floating types, so the kernel was accumulating in `U = bf16/half`. BF16 has 8-bit mantissa — sums of many small values saturate near ~256 and lose all subsequent additions.

Each kernel now does:
- `using AccT = std::conditional_t<sizeof(U) < 4, float, U>;`
- Accumulator variables → AccT-typed.
- `cast_to<U>(input)` for the running update → `cast_to<AccT>`.
- `__shared__` buffer sized + reinterpreted as AccT.
- On output write: cast AccT back to U via local U-typed copy (`cub::StoreDirectBlocked` and `store_vector` require matching element type).

## Why now

These kernels fire for partial-axis reductions: `rms_norm`, `softmax`, `logsumexp`, and any per-row/per-col sum. The qwen3.5/3.6 forward pass calls them constantly. Doing this preemptively while the pattern is fresh (vs. waiting for the runner to surface the bug at inference time on real bf16 weights, which would silently produce wrong outputs).

## Test plan

Workflow `26487886726` against this branch — **green**. qwen_load numerics unchanged from PR #199:

| | This PR | PR #199 (all_reduce fix) | numpy ground truth |
|---|---|---|---|
| scales mean | 1.13249e-05 | 1.13249e-05 | 1.135132e-05 |
| biases mean | -0.000123024 | -0.000123024 | -1.226708e-04 |

No regression on the all_reduce path (which my changes don't touch). Row/col reduce paths now have the same fp32 accumulator pattern but aren't exercised by qwen_load (it does a full all-reduce); they'll be validated indirectly via rms_norm/softmax once the runner runs a forward pass.

## Scope I'm not touching

- Intermediate buffers in `all_reduce.cu` (line 110) and `col_reduce_two_pass` (line 367) still allocated as `out.dtype()` (BF16 for BF16 input). The cast-between-stages BF16 rounding gives ~0.2% relative error in PR #199's measured case — adequate. Could promote to fp32 for max precision if/when something needs it.
- Other reduce ops (Min/Max/And/Or/Prod) — the AccT branch only changes behavior when sizeof(U)<4, and Min/Max in float are idempotent enough not to matter much. Prod could overflow but rarely used.

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)