### PR TITLE
Phase C: dequantize on real q4 packed embed row (#189)

### DIFF
--- a/x/mlxrunner/smoke/qwen_load.cpp
+++ b/x/mlxrunner/smoke/qwen_load.cpp
@@ -90,21 +90,40 @@ int main(int argc, char** argv) {
 
   // --- Gather (embed-lookup) probe ---
   // Look up a specific row of embed_tokens.scales via `take(scales, [42], axis=0)`.
-  // Compares against scales[42, 0] which we expect from numpy to be a small
-  // bf16 value (~1e-3). Validates Gather::eval_gpu on real safetensors data.
+  // Validates Gather::eval_gpu on real safetensors data.
   array token_id = array({42}, {1}, int32);
-  array embed_row = take(scales, token_id, /*axis=*/0);  // shape [1, 32]
-  array embed_row_f32 = astype(embed_row, float32);
-  array embed_row_mean = mean(embed_row_f32, /*keepdims=*/false);
-  eval({embed_row_f32, embed_row_mean});
+  array scales_row = take(scales, token_id, /*axis=*/0);  // shape [1, 32]
+  array scales_row_f32 = astype(scales_row, float32);
+  array scales_row_mean = mean(scales_row_f32, /*keepdims=*/false);
+  eval({scales_row_f32, scales_row_mean});
   std::cout << "qwen_load: take(scales, [42], 0) shape=["
-            << embed_row.shape(0) << "," << embed_row.shape(1) << "]"
-            << " mean=" << embed_row_mean.item<float>() << "\n";
-  // Spot-check first element (read by dereferencing on host — astype already
-  // gave us fp32 so this is correct).
+            << scales_row.shape(0) << "," << scales_row.shape(1) << "]"
+            << " mean=" << scales_row_mean.item<float>() << "\n";
   std::cout << "qwen_load: take(scales, [42], 0)[0,0] = "
-            << embed_row_f32.data<float>()[0] << "\n";
+            << scales_row_f32.data<float>()[0] << "\n";
 
-  std::cout << "qwen_load: load + reduce + take OK\n";
+  // --- Dequantize (real packed weights) probe ---
+  // Gather row 42 from weight + biases too, then dequantize. Exercises
+  // affine_dequantize (PR #196) + fast::Quantize::eval_gpu on REAL q4
+  // packed weights — not the hand-shaped uint32 zeros qwen_smoke uses.
+  // For bits=4 group=64: wq [1, 256] uint32 -> w [1, 2048] bf16.
+  array biases_row = take(biases, token_id, /*axis=*/0);  // [1, 32]
+  array wq_row = take(wq, token_id, /*axis=*/0);          // [1, 256] uint32
+  array w_full_row =
+      dequantize(wq_row, scales_row, biases_row,
+                 /*group_size=*/64, /*bits=*/4, /*mode=*/"affine");
+  array w_full_row_f32 = astype(w_full_row, float32);
+  array w_full_row_mean = mean(w_full_row_f32, /*keepdims=*/false);
+  eval({w_full_row_f32, w_full_row_mean});
+  std::cout << "qwen_load: dequantize(embed row 42) shape=["
+            << w_full_row.shape(0) << "," << w_full_row.shape(1) << "]"
+            << " mean=" << w_full_row_mean.item<float>() << "\n";
+  std::cout << "qwen_load: dequant row 42 first 5: ";
+  for (int i = 0; i < 5; i++) {
+    std::cout << w_full_row_f32.data<float>()[i] << " ";
+  }
+  std::cout << "\n";
+
+  std::cout << "qwen_load: load + reduce + take + dequant OK\n";
   return 0;
 }


### PR DESCRIPTION
## Summary

Extend qwen_load with a dequantize probe on a real qwen3.6-A3B embed_tokens row. This is the very first compute step of any forward pass, end-to-end on the K80, on actual q4 packed weights — not the hand-shaped zeros qwen_smoke uses.

Probe chain:
```
load shard 1
  -> take(embed_tokens.weight, [42], axis=0)   uint32 [1, 256]
  -> take(embed_tokens.scales, [42], axis=0)   bf16   [1, 32]
  -> take(embed_tokens.biases, [42], axis=0)   bf16   [1, 32]
  -> dequantize(wq_row, scales_row, biases_row, group=64, bits=4, "affine")
                                                bf16  [1, 2048]
```

Exercises:
- safetensors load (PR #198)
- Gather embed-lookup case (PR #201)
- affine_dequantize on REAL packed q4 weights (PR #196)
- fast::Quantize::eval_gpu (already wired in PR #194 / quantized.cpp dispatch)
- BF16 → fp32 conversion in astype for inspection (PR #199 host-side fix)

## Test plan

Workflow `26489147616` against this branch — **green** (`final_exit=0`):

| | MLX (K80) | numpy ground truth | Relative err |
|---|---|---|---|
| dequant row 42 [0] | 0 | 0.0 | exact |
| dequant row 42 [1] | 0 | 0.0 | exact |
| dequant row 42 [2] | -0.00964355 | -0.0096588 | 0.16% (BF16 step) |
| dequant row 42 [3] | -0.00964355 | -0.0096588 | 0.16% |
| dequant row 42 [4] | 0.00643921 | 0.0064392 | exact |
| dequant row 42 **mean** | **1.70544e-05** | **1.707e-05** | 0.09% |

Differences are all within BF16's ~0.4% mantissa precision bound. Confirms:
- The quantization scheme matches what we expect (MLX-published `mlx-community/Qwen3.6-35B-A3B-4bit` uses `mode="affine"`, `group_size=64`, `bits=4`).
- Our `affine_dequantize` kernel produces the right bytes for real q4 packed weights.
- Gather + dequantize compose correctly.

## What's still ahead on the inference path

After this, the next forward-pass step would be `rms_norm(dequant_row, input_layernorm.weight, eps=1e-6)`. That exercises the **row_reduce_simple** AccT pattern from PR #200 on real BF16 data. Will be the next focused probe.

After rms_norm comes a chain of quantized matmuls (q_proj, k_proj, v_proj) which already work via PR #197's K80 dequant+cuBLAS fallback. Then sdpa (already in libmlx.a). Then output proj. Then the MoE FFN — which will trip the first NEW stub (`cutlass_grouped_gemm_unaligned`).

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)