### PR TITLE
Phase C: quantized_matmul on real layer-0 in_proj_qkv (#189)

### DIFF
--- a/x/mlxrunner/smoke/qwen_load.cpp
+++ b/x/mlxrunner/smoke/qwen_load.cpp
@@ -151,6 +151,41 @@ int main(int argc, char** argv) {
   }
   std::cout << "\n";
 
-  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm OK\n";
+  // --- quantized_matmul probe: real layer-0 DeltaNet in_proj_qkv ---
+  // The next inference step for token 42 in layer 0 (a DeltaNet layer) is
+  // projecting the rms-normed embed to the qkv stream. The weight is real
+  // q4 packed: in_proj_qkv.weight U32 [8192, 256], dequant -> bf16
+  // [8192, 2048]. matmul shape: (1, 2048) @ (2048, 8192) -> (1, 8192).
+  //
+  // Exercises the K80 dequant+cuBLAS fallback from PR #197 on REAL packed
+  // weights for the first time (qwen_smoke uses hand-shaped zeros).
+  auto get = [&](const std::string& k) -> const array& {
+    auto it = tensors.find(k);
+    if (it == tensors.end()) {
+      std::cerr << "qwen_load: missing tensor '" << k << "'\n";
+      std::exit(5);
+    }
+    return it->second;
+  };
+  const std::string qkv_pre = "language_model.model.layers.0.linear_attn.in_proj_qkv";
+  const array& qkv_w = get(qkv_pre + ".weight");      // U32 [8192, 256]
+  const array& qkv_s = get(qkv_pre + ".scales");      // BF16 [8192, 32]
+  const array& qkv_b = get(qkv_pre + ".biases");      // BF16 [8192, 32]
+  array qkv_proj = quantized_matmul(
+      normed, qkv_w, qkv_s, qkv_b,
+      /*transpose=*/true,
+      /*group_size=*/64,
+      /*bits=*/4,
+      /*mode=*/"affine");
+  array qkv_proj_f32 = astype(qkv_proj, float32);
+  array qkv_proj_abs_mean = mean(abs(qkv_proj_f32), /*keepdims=*/false);
+  eval({qkv_proj_f32, qkv_proj_abs_mean});
+  std::cout << "qwen_load: in_proj_qkv(rms_normed) shape=["
+            << qkv_proj.shape(0) << "," << qkv_proj.shape(1) << "]"
+            << " abs_mean=" << qkv_proj_abs_mean.item<float>() << "\n";
+  std::cout << "qwen_load: in_proj_qkv [0,0]=" << qkv_proj_f32.data<float>()[0]
+            << " [0,1]=" << qkv_proj_f32.data<float>()[1] << "\n";
+
+  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj OK\n";
   return 0;
 }


### PR DESCRIPTION
## Summary

Extend qwen_load with the next forward-pass step for token 42 in layer 0 (a DeltaNet linear_attn layer):

```
qkv_proj = quantized_matmul(
    rms_normed_embed,                        bf16 [1, 2048]
    layer_0.linear_attn.in_proj_qkv.weight,  U32  [8192, 256]
    layer_0.linear_attn.in_proj_qkv.scales,  BF16 [8192, 32]
    layer_0.linear_attn.in_proj_qkv.biases,  BF16 [8192, 32]
    transpose=True, group=64, bits=4, mode=affine)
                                              bf16 [1, 8192]
```

Exercises the K80 **dequant + cuBLAS fallback** (PR #197) on **real q4 packed weights** for the first time. qwen_smoke uses hand-shaped uint32 zeros so the matmul math is trivially 0; this probe uses actual model weights where the result must match numpy ground truth.

## Test plan

Workflow `26491439761` against this branch — **green** (`final_exit=0`):

| | MLX (K80) | numpy ground truth | Relative err |
|---|---|---|---|
| in_proj_qkv [0,0] | 2.01562 | 2.013641 | 0.10% |
| in_proj_qkv [0,1] | -0.105469 | -0.103845 | 1.56% |
| abs_mean | 1.28103 | — | — |

All within BF16 precision bound (mantissa step at these magnitudes is ~2e-4 → relative ~0.2% per op; compounded across dequant + matmul + output cast can reach ~1.5%).

## Why this matters

Five stages of the canonical first transformer step are now validated on **real qwen3.6-A3B layer-0 bytes**:

```
load shard 1 -> Gather embed row -> Dequantize -> RMSNorm -> QuantizedMatmul (qkv projection)
```

The K80 dequant+cuBLAS path from PR #197 was previously only "compiles + runs on hand-shaped zeros" (qwen_smoke). This PR confirms it produces correct values on the actual matrix shapes and bit patterns the runner will hit at inference.

## What's next

DeltaNet (linear_attn) continues with:
- `conv1d(q/k/v gates, conv1d.weight)` — exercises Phase A's gemm_conv path on real weights
- The recurrence loop (`A_log`, `dt_bias`, state-space updates) — likely first stub trip (`Scan::eval_gpu`)

The conv1d probe is the cheap next step; Scan port is the next big lift.

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)