### PR TITLE
Phase C: conv1d probe on real layer-0 DeltaNet conv1d weight (#189)

### DIFF
--- a/x/mlxrunner/smoke/qwen_load.cpp
+++ b/x/mlxrunner/smoke/qwen_load.cpp
@@ -186,6 +186,28 @@ int main(int argc, char** argv) {
   std::cout << "qwen_load: in_proj_qkv [0,0]=" << qkv_proj_f32.data<float>()[0]
             << " [0,1]=" << qkv_proj_f32.data<float>()[1] << "\n";
 
-  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj OK\n";
+  // --- conv1d probe: real layer-0 DeltaNet conv1d ---
+  // Depthwise conv1d (groups = C_out = 8192) with kw=4 over the q/k/v stream.
+  // For an all-ones input [1, 4, 8192] with padding=0, output is [1, 1, 8192]
+  // where out[0, 0, c] = sum_k weight[c, k, 0] (kernel sum per channel).
+  // Exercises Phase A's gemm_conv path (PR #194 / commit 39abb387) on REAL
+  // BF16 conv weights for the first time.
+  const array& cv_w = get("language_model.model.layers.0.linear_attn.conv1d.weight");
+  array cv_input = ones({1, 4, 8192}, bfloat16);
+  array cv_out = conv1d(cv_input, cv_w,
+                        /*stride=*/1, /*padding=*/0,
+                        /*dilation=*/1, /*groups=*/8192);
+  array cv_out_f32 = astype(cv_out, float32);
+  array cv_abs_mean = mean(abs(cv_out_f32), /*keepdims=*/false);
+  eval({cv_out_f32, cv_abs_mean});
+  std::cout << "qwen_load: conv1d(ones, layer_0.conv1d.w) shape=["
+            << cv_out.shape(0) << "," << cv_out.shape(1) << "," << cv_out.shape(2) << "]"
+            << " abs_mean=" << cv_abs_mean.item<float>() << "\n";
+  std::cout << "qwen_load: conv1d out [0,0,0..2] = "
+            << cv_out_f32.data<float>()[0] << " "
+            << cv_out_f32.data<float>()[1] << " "
+            << cv_out_f32.data<float>()[2] << "\n";
+
+  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj + conv1d OK\n";
   return 0;
 }


### PR DESCRIPTION
## Summary

Sixth stage of the canonical DeltaNet forward pass, on real qwen3.6-A3B layer-0 weights. Depthwise conv1d with kw=4 over the 8192-channel q/k/v stream:

```
conv1d(input, layer_0.linear_attn.conv1d.weight,
       stride=1, padding=0, dilation=1, groups=8192)
```

For an all-ones input `[1, 4, 8192]` with padding=0, the depthwise output is just the kernel sum per channel:
```
out[0, 0, c] = sum_k weight[c, k, 0]
```

Easy ground truth — exercises Phase A's `gemm_conv` path (PR #194, commit `39abb387`) on **real BF16 conv weights** for the first time. qwen_smoke uses `random::uniform`.

## Test plan

Workflow `26491608555` against this branch — **green** (`final_exit=0`):

| | MLX (K80) | numpy ground truth | Relative err |
|---|---|---|---|
| out[0,0,0] | -0.0617676 | -0.061722 | 0.07% |
| out[0,0,1] | -0.0458984 | -0.045959 | 0.13% |
| out[0,0,2] |  0.0678711 |  0.067902 | 0.05% |
| abs_mean | 0.0465024 | — | — |

Well within BF16 precision (sum of 4 BF16 values at ~0.01-0.07 magnitude → BF16 step ~2e-5 → relative ~0.05-0.5%).

## Cumulative inference-path probe in qwen_load

```
load shard 1 (716 tensors)
  -> Gather embed row for token 42                  PR #201
  -> Dequantize real q4 packed row                   PR #202
  -> fast::rms_norm(., layer_0 input_layernorm)      PR #203
  -> quantized_matmul(., layer_0 in_proj_qkv)        PR #204
  -> conv1d(ones[1,4,8192], layer_0 conv1d.weight)   THIS PR
```

All six stages validated against numpy ground truth on the same raw safetensors bytes. Total runtime on K80: ~3 seconds end-to-end.

## What's next

DeltaNet recurrence: after conv1d, the layer applies SiLU/sigmoid activations on q/k/v gates, computes delta = softplus(dt) + dt_bias, then drives the state-space recurrence with A_log, dt_bias, and a scan over T. The **Scan stub** (`Scan::eval_gpu`) is still a throw — first new port the runner will trip.

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)