### PR TITLE
Phase D.1: silu probe on conv1d output (#189)

### DIFF
--- a/x/mlxrunner/smoke/qwen_load.cpp
+++ b/x/mlxrunner/smoke/qwen_load.cpp
@@ -208,6 +208,22 @@ int main(int argc, char** argv) {
             << cv_out_f32.data<float>()[1] << " "
             << cv_out_f32.data<float>()[2] << "\n";
 
-  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj + conv1d OK\n";
+  // --- silu probe: next op after conv1d on DeltaNet q/k/v gates ---
+  // DeltaNet applies silu (a.k.a. swish: x * sigmoid(x)) to the conv1d
+  // output before splitting into q/k/v streams. Exercises the elementwise
+  // unary kernels in libmlx.a (sigmoid + multiply, both wired since Phase A).
+  // Ground truth: silu(-0.061722) = -0.02991, silu(-0.045959) = -0.02245,
+  // silu(0.067902) = 0.03510.
+  array silu_out = sigmoid(cv_out) * cv_out;  // silu = sigmoid(x) * x
+  array silu_out_f32 = astype(silu_out, float32);
+  array silu_abs_mean = mean(abs(silu_out_f32), /*keepdims=*/false);
+  eval({silu_out_f32, silu_abs_mean});
+  std::cout << "qwen_load: silu(conv1d) abs_mean=" << silu_abs_mean.item<float>() << "\n";
+  std::cout << "qwen_load: silu out [0,0,0..2] = "
+            << silu_out_f32.data<float>()[0] << " "
+            << silu_out_f32.data<float>()[1] << " "
+            << silu_out_f32.data<float>()[2] << "\n";
+
+  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj + conv1d + silu OK\n";
   return 0;
 }


### PR DESCRIPTION
## Summary

Next reactive-port step after PR #205 (conv1d). DeltaNet applies silu (swish, `x * sigmoid(x)`) to the conv1d output before splitting into q/k/v streams. This is the first Phase-D step under the refined plan (see #189 comment for full sequence).

Exercises:
- `sigmoid()` — wired in libmlx.a since Phase A (basic unary)
- elementwise multiply — wired since Phase A

## Test plan

Workflow `26499743839` against this branch — **green**:

| | MLX (K80) | numpy ground truth | Relative err |
|---|---|---|---|
| silu out[0] | -0.0299072 | -0.02991 | exact |
| silu out[1] | -0.0224609 | -0.02245 | 0.05% |
| silu out[2] | 0.0349121 | 0.03510 | 0.5% |

All within BF16 precision (~0.5% upper bound for these magnitudes).

## Cumulative chain on real A3B bytes

```
load shard 1 (716 tensors)
  → take(embed_tokens.weight, [42], 0)            PR #201
  → dequantize(embed row, scales, biases, …)      PR #196 + #202
  → fast::rms_norm(., layer_0 input_layernorm.w)  PR #200 + #203
  → quantized_matmul(., layer_0 in_proj_qkv.w)    PR #196 + #197 + #204
  → conv1d(ones[1,4,8192], layer_0 conv1d.w)      PR #205
  → silu(.)                                       THIS PR
```

Seven inference-path stages validated end-to-end on real qwen3.6-A3B layer-0 bytes, all matching numpy ground truth within BF16 precision.

## What's next

DeltaNet recurrence path next — softplus(dt) + dt_bias add, then the actual state-space scan (where the `Scan::eval_gpu` stub will trip, becoming the next focused port).

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)