### PR TITLE
Phase D.1: DeltaNet SSM-setup probe — exp(A_log) + softplus(dt_bias) (#189)

### DIFF
--- a/x/mlxrunner/smoke/qwen_load.cpp
+++ b/x/mlxrunner/smoke/qwen_load.cpp
@@ -224,6 +224,37 @@ int main(int argc, char** argv) {
             << silu_out_f32.data<float>()[1] << " "
             << silu_out_f32.data<float>()[2] << "\n";
 
-  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj + conv1d + silu OK\n";
+  // --- DeltaNet state-space setup: exp(A_log) + softplus(dt_bias) ---
+  // Two elementwise ops that prepare the recurrence coefficients:
+  //   A = -exp(A_log)            -- the SSM transition coefficient
+  //   delta = softplus(dt_proj_out + dt_bias) -- per-step time delta
+  // For probe purposes we just exercise the kernels on the real model
+  // tensors (A_log, dt_bias) to validate exp + softplus on BF16.
+  // Both are wired in libmlx.a since Phase A.
+  const array& a_log = get("language_model.model.layers.0.linear_attn.A_log");
+  const array& dt_bias = get("language_model.model.layers.0.linear_attn.dt_bias");
+
+  array neg_exp_A = negative(exp(a_log));
+  array sp_dtbias = softplus(dt_bias);
+  array neg_exp_A_f32 = astype(neg_exp_A, float32);
+  array sp_dtbias_f32 = astype(sp_dtbias, float32);
+  array neg_exp_A_abs_mean = mean(abs(neg_exp_A_f32), /*keepdims=*/false);
+  array sp_dtbias_mean = mean(sp_dtbias_f32, /*keepdims=*/false);
+  eval({neg_exp_A_f32, sp_dtbias_f32, neg_exp_A_abs_mean, sp_dtbias_mean});
+
+  std::cout << "qwen_load: -exp(A_log) shape=[" << neg_exp_A.shape(0) << "]"
+            << " abs_mean=" << neg_exp_A_abs_mean.item<float>() << "\n";
+  std::cout << "qwen_load: -exp(A_log) first 3 = "
+            << neg_exp_A_f32.data<float>()[0] << " "
+            << neg_exp_A_f32.data<float>()[1] << " "
+            << neg_exp_A_f32.data<float>()[2] << "\n";
+  std::cout << "qwen_load: softplus(dt_bias) shape=[" << sp_dtbias.shape(0) << "]"
+            << " mean=" << sp_dtbias_mean.item<float>() << "\n";
+  std::cout << "qwen_load: softplus(dt_bias) first 3 = "
+            << sp_dtbias_f32.data<float>()[0] << " "
+            << sp_dtbias_f32.data<float>()[1] << " "
+            << sp_dtbias_f32.data<float>()[2] << "\n";
+
+  std::cout << "qwen_load: load + reduce + take + dequant + rms_norm + qproj + conv1d + silu + ssm_setup OK\n";
   return 0;
 }

--- a/x/mlxrunner/smoke/qwen_load.cpp
+++ b/x/mlxrunner/smoke/qwen_load.cpp
@@ -235,7 +235,10 @@ int main(int argc, char** argv) {
   const array& dt_bias = get("language_model.model.layers.0.linear_attn.dt_bias");
 
   array neg_exp_A = negative(exp(a_log));
-  array sp_dtbias = softplus(dt_bias);
+  // MLX doesn't expose softplus at ops.h; compose log1p(exp(x)) which is
+  // numerically OK for our dt_bias range (-4 to +10). Real DeltaNet uses
+  // a clamped variant for large inputs; we don't need it for this probe.
+  array sp_dtbias = log1p(exp(dt_bias));
   array neg_exp_A_f32 = astype(neg_exp_A, float32);
   array sp_dtbias_f32 = astype(sp_dtbias, float32);
   array neg_exp_A_abs_mean = mean(abs(neg_exp_A_f32), /*keepdims=*/false);


### PR DESCRIPTION
## Summary

Two elementwise ops on real layer-0 DeltaNet tensors that prepare the state-space recurrence coefficients:
- `A = -exp(A_log)` — SSM transition coefficient
- `softplus(dt_bias)` — delta-time bias passed through softplus

Validates `negative`, `exp`, `log1p` on real BF16 model tensors (`A_log` BF16[32], `dt_bias` BF16[32]). All wired in libmlx.a since Phase A. Note: MLX doesn't expose `softplus` at ops.h — composed manually as `log1p(exp(x))` (numerically OK for our `dt_bias` range -4 to +10).

## Test plan

Workflow `26501220687` against this branch — **green** (`final_exit=0`):

| | MLX (K80) | numpy ground truth |
|---|---|---|
| `-exp(A_log)` first 3 | -0.0364, -0.0232, -0.0311 | -0.0364, -0.0232, -0.0312 |
| `-exp(A_log)` abs_mean | 10.8544 | 10.84 |
| `softplus(dt_bias)` first 3 | 0.0176, 0.0564, 0.0610 | 0.0176, 0.0566, 0.0610 |
| `softplus(dt_bias)` mean | 1.79028 | 1.79 |

All within BF16 precision (~0.1% individual, <0.5% aggregate).

## Cumulative chain (8 stages)

```
load shard 1 (716 tensors)
  → take(embed_tokens.weight, [42], 0)            PR #201
  → dequantize(embed row, scales, biases, …)      PR #196 + #202
  → fast::rms_norm(., layer_0 input_layernorm.w)  PR #200 + #203
  → quantized_matmul(., layer_0 in_proj_qkv.w)    PR #196 + #197 + #204
  → conv1d(ones[1,4,8192], layer_0 conv1d.w)      PR #205
  → silu(.)                                       PR #208
  → -exp(layer_0 A_log)                           THIS PR
  → log1p(exp(layer_0 dt_bias))                   THIS PR
```

## What's next (the real test)

The DeltaNet recurrence proper — combining all of the above into a state-space scan over T tokens. That's where `Scan::eval_gpu` will trip (still a throw-stub in `k80_runtime_stubs.cpp`), becoming the next real kernel port.

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)