### PR TITLE
Phase D.2 step 1: minimal C ABI + Go cgo scaffolding (#189)

### DIFF
--- a/.github/workflows/test-mlx-smoke.yml
+++ b/.github/workflows/test-mlx-smoke.yml
@@ -109,6 +109,9 @@ jobs:
           P2P_STATUS=$(jq -r '.p2p.status' /tmp/test-mlx-smoke-results.json)
           P2P_EXIT=$(jq -r '.p2p.exit_code' /tmp/test-mlx-smoke-results.json)
           P2P_DUR=$(jq -r '.p2p.duration_sec' /tmp/test-mlx-smoke-results.json)
+          CGO_STATUS=$(jq -r '.cgo.status' /tmp/test-mlx-smoke-results.json)
+          CGO_EXIT=$(jq -r '.cgo.exit_code' /tmp/test-mlx-smoke-results.json)
+          CGO_DUR=$(jq -r '.cgo.duration_sec' /tmp/test-mlx-smoke-results.json)
           FINAL_EXIT=$(jq -r '.final_exit' /tmp/test-mlx-smoke-results.json)
           LDD_MISSING=$(jq -r '.run.ldd_missing' /tmp/test-mlx-smoke-results.json)
 
@@ -123,6 +126,7 @@ jobs:
             echo "| run     | ${RUN_STATUS} | ${RUN_DUR}s | exit=${RUN_EXIT} (forward-surface) |"
             echo "| load    | ${LOAD_STATUS} | ${LOAD_DUR}s | exit=${LOAD_EXIT} (shard=${LOAD_SHARD}) |"
             echo "| p2p     | ${P2P_STATUS} | ${P2P_DUR}s | exit=${P2P_EXIT} (multi-die spike, informational) |"
+            echo "| cgo     | ${CGO_STATUS} | ${CGO_DUR}s | exit=${CGO_EXIT} (Go cgo plumbing probe, informational) |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$RUN_STATUS" != "success" ] && [ -n "$LDD_MISSING" ]; then
@@ -202,6 +206,25 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
+          if [ "$CGO_STATUS" = "failed" ] || [ "$CGO_STATUS" = "success" ]; then
+            {
+              echo ""
+              echo "### qwen_load_go (Go cgo plumbing probe)"
+              echo ""
+              echo '```'
+              jq -r '.cgo.stdout' /tmp/test-mlx-smoke-results.json
+              echo '```'
+              if [ "$CGO_STATUS" = "failed" ]; then
+                echo ""
+                echo "### qwen_load_go stderr (tail)"
+                echo ""
+                echo '```'
+                jq -r '.cgo.stderr' /tmp/test-mlx-smoke-results.json
+                echo '```'
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Restart production ollama37
         if: always()
         run: |
@@ -241,3 +264,5 @@ jobs:
             /tmp/test-mlx-smoke-build/load.stderr
             /tmp/test-mlx-smoke-build/p2p.stdout
             /tmp/test-mlx-smoke-build/p2p.stderr
+            /tmp/test-mlx-smoke-build/cgo.stdout
+            /tmp/test-mlx-smoke-build/cgo.stderr

--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -248,7 +248,11 @@ else
             # commonly: libmlx_cabi.a archive missing -> means cmake didn'\''t
             # finish; reported by the cmake build above).
             if [ -f /build/libmlx_cabi.a ] && [ -f /build/mlx_build/libmlx.a ]; then
-              export CGO_LDFLAGS="-L/build -L/build/mlx_build -L/usr/local/cuda-11.4/lib64"
+              # /usr/local/cuda-11.4/lib64/stubs holds libcuda.so (the
+              # driver lib stub for link-time resolution; runtime uses the
+              # real libcuda.so.1 from /usr/local/nvidia/lib64 via the
+              # nvidia-container mount).
+              export CGO_LDFLAGS="-L/build -L/build/mlx_build -L/usr/local/cuda-11.4/lib64 -L/usr/local/cuda-11.4/lib64/stubs"
               export GOCACHE=/tmp/gocache
               # GOFLAGS env applies before any go subcommand, including
               # module-load-time VCS discovery (cmdline -buildvcs=false alone

--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -91,6 +91,15 @@ P2P_DURATION=0
 P2P_STDOUT=""
 P2P_STDERR=""
 
+# qwen_load_go (Phase D.2 step 1) — Go cgo binary that drives libmlx.a via
+# the C ABI shim. Mirrors qwen_load's first line ("loaded N tensors") to
+# prove the cgo plumbing works end-to-end.
+CGO_STATUS="skipped"
+CGO_EXIT_CODE=-1
+CGO_DURATION=0
+CGO_STDOUT=""
+CGO_STDERR=""
+
 GPU_DEVICE_COUNT=0
 GPU_NAMES=""
 
@@ -130,6 +139,11 @@ write_results() {
         --argjson p2p_duration "$P2P_DURATION" \
         --arg p2p_stdout "$P2P_STDOUT" \
         --arg p2p_stderr "$P2P_STDERR" \
+        --arg cgo_status "$CGO_STATUS" \
+        --argjson cgo_exit "$CGO_EXIT_CODE" \
+        --argjson cgo_duration "$CGO_DURATION" \
+        --arg cgo_stdout "$CGO_STDOUT" \
+        --arg cgo_stderr "$CGO_STDERR" \
         --argjson gpu_count "$GPU_DEVICE_COUNT" \
         --arg gpu_names "$GPU_NAMES" \
         --argjson final_exit "$FINAL_EXIT" \
@@ -172,6 +186,13 @@ write_results() {
             "duration_sec": $p2p_duration,
             "stdout": $p2p_stdout,
             "stderr": $p2p_stderr
+          },
+          "cgo": {
+            "status": $cgo_status,
+            "exit_code": $cgo_exit,
+            "duration_sec": $cgo_duration,
+            "stdout": $cgo_stdout,
+            "stderr": $cgo_stderr
           },
           "gpu": {
             "device_count": $gpu_count,
@@ -222,6 +243,19 @@ else
             set -euo pipefail
             cmake -S /src/x/mlxrunner -B /build -DCMAKE_BUILD_TYPE=Release
             cmake --build /build -j"$(nproc)"
+            # Phase D.2 step 1 (#189): Go cgo binary that drives libmlx.a
+            # via the C ABI shim. Skip cleanly if anything errors (most
+            # commonly: libmlx_cabi.a archive missing -> means cmake didn'\''t
+            # finish; reported by the cmake build above).
+            if [ -f /build/libmlx_cabi.a ] && [ -f /build/mlx_build/libmlx.a ]; then
+              export CGO_LDFLAGS="-L/build -L/build/mlx_build -L/usr/local/cuda-11.4/lib64"
+              export GOCACHE=/tmp/gocache
+              mkdir -p "$GOCACHE"
+              (cd /src/x/mlxrunner/go && go build -o /build/qwen_load_go ./cmd/qwen_load_go) \
+                  || echo "::warning::Go cgo build of qwen_load_go failed; see build.log"
+            else
+              echo "qwen_load_go: skipped Go build (mlx_cabi or mlx archive missing)"
+            fi
         ' > "$BUILD_DIR/build.log" 2>&1
     BUILD_RC=$?
     set -e
@@ -333,6 +367,42 @@ else
     fi
     if [ ! -x "$BUILD_DIR/qwen_load" ]; then
         echo "qwen_load: skipped (exe not built)"
+    fi
+fi
+
+# ------------------------------------------------------- qwen_load_go ----
+# Phase D.2 step 1 (#189) — Go cgo plumbing probe. Runs only if the Go
+# binary built AND MODEL_DIR resolves to a shard. Mirrors qwen_load's
+# behavior via cgo; informational (failure doesn't override FINAL_EXIT
+# since the cgo runner is still in its earliest stage).
+if [ -x "$BUILD_DIR/qwen_load_go" ] && [ -f "$MODEL_DIR/$LOAD_SHARD_FILE" ]; then
+    CGO_STATUS="running"
+    CGO_START=$(date +%s)
+    set +e
+    docker run --rm --gpus all \
+        -v "$BUILD_DIR:/build:ro" \
+        -v "$MODEL_DIR:/models:ro" \
+        -e CUDA_VISIBLE_DEVICES=0 \
+        --entrypoint bash \
+        "$RUNTIME_IMAGE" \
+        -c "/build/qwen_load_go /models/$LOAD_SHARD_FILE" \
+        > "$BUILD_DIR/cgo.stdout" 2> "$BUILD_DIR/cgo.stderr"
+    CGO_RC=$?
+    set -e
+    CGO_DURATION=$(( $(date +%s) - CGO_START ))
+    CGO_STDOUT=$(tail -c 4000 "$BUILD_DIR/cgo.stdout" || true)
+    CGO_STDERR=$(tail -c 4000 "$BUILD_DIR/cgo.stderr" || true)
+    CGO_EXIT_CODE=$CGO_RC
+    if [ $CGO_RC -eq 0 ] && echo "$CGO_STDOUT" | grep -q "qwen_load_go: cgo OK"; then
+        CGO_STATUS="success"
+        echo "cgo OK: qwen_load_go completed in ${CGO_DURATION}s"
+    else
+        CGO_STATUS="failed"
+        echo "::warning::qwen_load_go failed (rc=$CGO_RC) — informational at this stage"
+    fi
+else
+    if [ ! -x "$BUILD_DIR/qwen_load_go" ]; then
+        echo "qwen_load_go: skipped (Go cgo exe not built)"
     fi
 fi
 

--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -250,9 +250,15 @@ else
             if [ -f /build/libmlx_cabi.a ] && [ -f /build/mlx_build/libmlx.a ]; then
               export CGO_LDFLAGS="-L/build -L/build/mlx_build -L/usr/local/cuda-11.4/lib64"
               export GOCACHE=/tmp/gocache
+              # GOFLAGS env applies before any go subcommand, including
+              # module-load-time VCS discovery (cmdline -buildvcs=false alone
+              # isn'\''t enough — first CI run still hit "error obtaining VCS
+              # status" despite the flag). Belt-and-suspenders: also tell git
+              # the bind-mounted source is safe to read (the .git dir is
+              # owned by the host user, root inside the container).
+              export GOFLAGS="-buildvcs=false"
               mkdir -p "$GOCACHE"
-              # -buildvcs=false: source is bind-mounted read-only so git
-              # stamping fails; we don't need it anyway.
+              git config --global --add safe.directory /src || true
               (cd /src/x/mlxrunner/go && go build -buildvcs=false -o /build/qwen_load_go ./cmd/qwen_load_go) \
                   || echo "::warning::Go cgo build of qwen_load_go failed; see build.log"
             else

--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -251,7 +251,9 @@ else
               export CGO_LDFLAGS="-L/build -L/build/mlx_build -L/usr/local/cuda-11.4/lib64"
               export GOCACHE=/tmp/gocache
               mkdir -p "$GOCACHE"
-              (cd /src/x/mlxrunner/go && go build -o /build/qwen_load_go ./cmd/qwen_load_go) \
+              # -buildvcs=false: source is bind-mounted read-only so git
+              # stamping fails; we don't need it anyway.
+              (cd /src/x/mlxrunner/go && go build -buildvcs=false -o /build/qwen_load_go ./cmd/qwen_load_go) \
                   || echo "::warning::Go cgo build of qwen_load_go failed; see build.log"
             else
               echo "qwen_load_go: skipped Go build (mlx_cabi or mlx archive missing)"

--- a/x/mlxrunner/CMakeLists.txt
+++ b/x/mlxrunner/CMakeLists.txt
@@ -24,6 +24,19 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../mlx mlx_build)
 
 find_package(CUDAToolkit REQUIRED)
 
+# Phase D.2 step 1 (#189): C ABI shim so Go cgo can drive libmlx.a.
+# Static archive linked into the Go binary at cgo-build time.
+add_library(mlx_cabi STATIC cabi/mlx_cabi.cc)
+target_include_directories(mlx_cabi PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/cabi
+    ${CMAKE_CURRENT_SOURCE_DIR}/../mlx
+)
+target_link_libraries(mlx_cabi PUBLIC mlx)
+set_target_properties(mlx_cabi PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CXX_STANDARD 17
+)
+
 add_executable(qwen_smoke smoke/qwen_surface.cpp)
 add_executable(qwen_load smoke/qwen_load.cpp)
 # Phase D spike: pure-CUDA P2P / multi-die probe. No MLX dependency — answers

--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -1,0 +1,47 @@
+// mlx_cabi.cc — C ABI implementation. See mlx_cabi.h for the contract.
+
+#include "mlx_cabi.h"
+
+#include "mlx/mlx.h"
+
+#include <new>
+#include <utility>
+
+// Opaque struct definition; only visible inside this TU. The Go side
+// only ever holds the pointer.
+struct mlx_safetensors_s {
+  // load_safetensors returns std::pair<unordered_map<string, array>,
+  // unordered_map<string, string>>. Store as-is; lookups + metadata
+  // access become trivial extensions later.
+  mlx::core::SafetensorsLoad data;
+};
+
+int mlx_init(void) {
+  try {
+    mlx::core::set_default_device(
+        mlx::core::Device(mlx::core::Device::gpu));
+    return 0;
+  } catch (...) {
+    return -1;
+  }
+}
+
+mlx_safetensors_t mlx_load_safetensors(const char* path) {
+  if (!path) return nullptr;
+  try {
+    auto* st = new (std::nothrow) mlx_safetensors_s{
+        mlx::core::load_safetensors(path)};
+    return st;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+int mlx_safetensors_count(mlx_safetensors_t st) {
+  if (!st) return -1;
+  return static_cast<int>(st->data.first.size());
+}
+
+void mlx_safetensors_release(mlx_safetensors_t st) {
+  delete st;
+}

--- a/x/mlxrunner/cabi/mlx_cabi.h
+++ b/x/mlxrunner/cabi/mlx_cabi.h
@@ -1,0 +1,48 @@
+// mlx_cabi.h — C ABI shim around libmlx.a so Go cgo can call into MLX.
+//
+// Phase D.2 step 1 (#189). Minimum surface to load a safetensors file
+// from Go and report the tensor count. The C++ MLX API uses templates,
+// std::optional, std::variant, and other things cgo can't see directly;
+// every C-callable function here translates to plain C types and opaque
+// pointers, with C++ exceptions caught at the boundary and reported as
+// integer error codes.
+//
+// Ownership / lifetimes:
+//   - Every constructor-shaped function returns a handle (pointer) the
+//     caller must release via the matching mlx_*_release.
+//   - Handles are opaque (forward-declared structs); no Go code peeks
+//     inside.
+//   - Functions returning int use 0 for success and negative for error
+//     (-1 generic, more specific codes added as the API grows).
+//
+// Build: x/mlxrunner/CMakeLists.txt adds an mlx_cabi STATIC library that
+// includes this header + mlx_cabi.cc and links libmlx.a transitively.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque handle to a loaded safetensors file (name -> array map + metadata).
+typedef struct mlx_safetensors_s* mlx_safetensors_t;
+
+// Initialize MLX state and pin the default stream to the GPU device.
+// Returns 0 on success, negative on error.
+int mlx_init(void);
+
+// Load a safetensors file at `path`. Returns NULL on failure (file not
+// found, parse error, exception thrown). Caller must release via
+// mlx_safetensors_release.
+mlx_safetensors_t mlx_load_safetensors(const char* path);
+
+// Number of tensors in a loaded safetensors handle. Returns -1 on a
+// NULL handle.
+int mlx_safetensors_count(mlx_safetensors_t st);
+
+// Release a safetensors handle. Safe to call on NULL.
+void mlx_safetensors_release(mlx_safetensors_t st);
+
+#ifdef __cplusplus
+}
+#endif

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -26,6 +26,7 @@ package main
 /*
 #cgo CFLAGS: -I${SRCDIR}/../../../cabi
 #cgo LDFLAGS: -lmlx_cabi -lmlx -lcublas -lcublasLt -lcudart -lcuda -lstdc++ -lpthread -ldl -lm -lrt
+#include <stdlib.h>
 #include "mlx_cabi.h"
 */
 import "C"

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -13,18 +13,21 @@
 
 package main
 
-// Library NAMES only here; -L paths supplied by CGO_LDFLAGS env at build
-// time so the cgo pragma works whether the build dir is /build,
-// /tmp/runner-X, or elsewhere. The CI script (test-mlx-smoke.sh) sets
-// the right -L flags.
+// cgo preamble notes (kept OUTSIDE the C block — every line in the C
+// preamble is fed to the C compiler, including the human-readable text
+// of `//` comments, so prose with `-lrt` and `C++` in it tripped the
+// first build):
 //
-// Link order matters: mlx_cabi calls into mlx, mlx calls into CUDA libs.
-// stdc++ is needed because libmlx.a is C++; -lrt -ldl -lpthread are
-// libmlx.a transitive deps.
-//
-// #cgo CFLAGS: -I${SRCDIR}/../../../cabi
-// #cgo LDFLAGS: -lmlx_cabi -lmlx -lcublas -lcublasLt -lcudart -lcuda -lstdc++ -lpthread -ldl -lm -lrt
-// #include "mlx_cabi.h"
+//   * LDFLAGS lists library NAMES only; -L paths come from CGO_LDFLAGS
+//     env at build time (CI script supplies them).
+//   * Link order: mlx_cabi -> mlx -> CUDA. Plus stdc++ (libmlx.a is C++)
+//     and libmlx.a transitive deps (pthread, dl, m, rt).
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../../cabi
+#cgo LDFLAGS: -lmlx_cabi -lmlx -lcublas -lcublasLt -lcudart -lcuda -lstdc++ -lpthread -ldl -lm -lrt
+#include "mlx_cabi.h"
+*/
 import "C"
 
 import (

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -1,0 +1,61 @@
+// qwen_load_go — Phase D.2 step 1 (#189) cgo plumbing probe.
+//
+// Mirrors qwen_load.cpp's first line of output ("loaded N tensors") via
+// the C ABI shim. Validates that Go can drive libmlx.a end-to-end:
+//   - cgo headers find mlx_cabi.h
+//   - linker resolves libmlx_cabi.a + libmlx.a + CUDA runtime libs
+//   - C++ exceptions in libmlx.a don't cross the cgo boundary
+//   - safetensors load actually works from a Go context
+//
+// Run via cicd/scripts/test-mlx-smoke.sh; the CI script bind-mounts the
+// model dir into the runtime container and passes shard 1's path as
+// argv[1].
+
+package main
+
+// Library NAMES only here; -L paths supplied by CGO_LDFLAGS env at build
+// time so the cgo pragma works whether the build dir is /build,
+// /tmp/runner-X, or elsewhere. The CI script (test-mlx-smoke.sh) sets
+// the right -L flags.
+//
+// Link order matters: mlx_cabi calls into mlx, mlx calls into CUDA libs.
+// stdc++ is needed because libmlx.a is C++; -lrt -ldl -lpthread are
+// libmlx.a transitive deps.
+//
+// #cgo CFLAGS: -I${SRCDIR}/../../../cabi
+// #cgo LDFLAGS: -lmlx_cabi -lmlx -lcublas -lcublasLt -lcudart -lcuda -lstdc++ -lpthread -ldl -lm -lrt
+// #include "mlx_cabi.h"
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: qwen_load_go <shard.safetensors>")
+		os.Exit(2)
+	}
+
+	if rc := C.mlx_init(); rc != 0 {
+		fmt.Fprintf(os.Stderr, "qwen_load_go: mlx_init failed: rc=%d\n", int(rc))
+		os.Exit(3)
+	}
+
+	cpath := C.CString(os.Args[1])
+	defer C.free(unsafe.Pointer(cpath))
+
+	st := C.mlx_load_safetensors(cpath)
+	if st == nil {
+		fmt.Fprintf(os.Stderr, "qwen_load_go: mlx_load_safetensors failed for %s\n",
+			os.Args[1])
+		os.Exit(4)
+	}
+	defer C.mlx_safetensors_release(st)
+
+	count := int(C.mlx_safetensors_count(st))
+	fmt.Printf("qwen_load_go: loaded %d tensors\n", count)
+	fmt.Println("qwen_load_go: cgo OK")
+}

--- a/x/mlxrunner/go/go.mod
+++ b/x/mlxrunner/go/go.mod
@@ -1,0 +1,11 @@
+// Phase D.2 (#189) — Go cgo runner for MLX on K80.
+//
+// Standalone module (separate from the main github.com/ollama/ollama
+// go.mod) so the MLX runner can be developed without touching ollama's
+// dependency graph until the API surface stabilizes. Will be folded
+// into the main module or wired via replace directive once the runner
+// is usable.
+
+module github.com/dogkeeper886/ollama37/x/mlxrunner
+
+go 1.24.0


### PR DESCRIPTION
## Summary

First step of the runner skeleton (Phase D.2 per refined plan in #189 comment). Smallest meaningful PR that validates **Go can drive libmlx.a end-to-end via cgo**.

What lands:

### `x/mlxrunner/cabi/` — C ABI shim around libmlx.a
- `mlx_cabi.h` — pure C declarations behind `extern "C"` guard, opaque handle pattern for C++ objects, integer error codes, caller-owned release semantics.
- `mlx_cabi.cc` — thin C++ impl, catches every exception at the boundary so libmlx.a internals never throw across cgo.
- Initial surface: `mlx_init` (sets default device GPU), `mlx_load_safetensors`, `mlx_safetensors_count`, `mlx_safetensors_release`.

### `x/mlxrunner/CMakeLists.txt`
- New `STATIC` target `mlx_cabi` linking `PUBLIC mlx`, with `POSITION_INDEPENDENT_CODE ON` so cgo can link the `.a`.

### `x/mlxrunner/go/` — Go cgo wrapper (standalone module for now)
- `go.mod` — separate from main `github.com/ollama/ollama` module so the runner can evolve without churning ollama's dep graph; folds in later when API stabilizes.
- `cmd/qwen_load_go/main.go` — mirrors `qwen_load.cpp`'s "loaded N tensors" line via cgo. Validates header path resolves, linker finds `libmlx_cabi + libmlx + CUDA libs`, C++ exceptions caught at boundary, safetensors load works from Go.
- cgo preamble in `/* ... */` block (NOT `//` comments — those get fed to the C compiler line-by-line and broke on hyphens in prose). LDFLAGS lists library names only; `-L` paths from `CGO_LDFLAGS` env.

### `cicd/scripts/test-mlx-smoke.sh`
- Build phase: after cmake build, build the Go binary if both `libmlx_cabi.a` and `libmlx.a` exist. Sets `CGO_LDFLAGS` with `-L` for `/build`, `/build/mlx_build`, `/usr/local/cuda-11.4/lib64`, and `/usr/local/cuda-11.4/lib64/stubs` (for `-lcuda` link-time stub). `GOCACHE=/tmp/gocache`, `GOFLAGS=-buildvcs=false`, `git config safe.directory /src` (read-only mount + foreign uid combo).
- Run phase: new cgo block after qwen_load. Same docker invocation pattern (runtime image, model dir bind-mounted). Informational only — failure doesn't override FINAL_EXIT.
- Results JSON gets a `"cgo"` section; workflow summary table grows a row.

## Test plan

Workflow `26550553566` against this branch — **green**:

```
qwen_load_go: loaded 716 tensors
qwen_load_go: cgo OK
```

Same tensor count as `qwen_load.cpp` reports for shard 1 (validated in PR #198). Runtime 3 s; build duration including Go cgo is well within the existing CI envelope.

## Iterations to land (4 fixes)

1. `error obtaining VCS status: exit status 128` — Go 1.18+ embeds git info; bind-mounted read-only source + UID mismatch made git refuse. Fixed via `GOFLAGS=-buildvcs=false` + `git config safe.directory`.
2. `error: expected identifier or '(' before '-' token` — cgo treats EVERY `//` line of the preamble as C code. My explanatory comment with hyphens (`-lrt`) tripped it. Switched to `/* */` block.
3. `could not determine what C.free refers to` — needed `#include <stdlib.h>` in the preamble.
4. `cannot find -lcuda` — builder image's `lib64/` has cudart/cublas but not libcuda (driver lib). Added `/usr/local/cuda-11.4/lib64/stubs/` to CGO_LDFLAGS; runtime still picks up real `libcuda.so.1` from the nvidia-container mount.

## What this unblocks

Next D.2 steps can extend the C ABI incrementally — get tensor by name, dtype/shape, take, dequantize, mean, item, eval — and the Go side becomes the substrate for the eventual `x/models/qwen3_6_a3b` model definition. cgo plumbing is no longer the unknown.

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)