### PR TITLE
ci(test-mlx-smoke): add production GGML regression check (#187)

### DIFF
--- a/.github/workflows/test-mlx-smoke.yml
+++ b/.github/workflows/test-mlx-smoke.yml
@@ -45,6 +45,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Regression check — production GGML path still serves
+        # Safety net for the MLX rapid-merge cadence. Our changes only
+        # touch x/mlx/, x/mlxrunner/, this script, and this workflow —
+        # so the production llama.cpp/GGML serving path should be
+        # unaffected. If it isn't, fail loudly here BEFORE we stop
+        # the production container, instead of finding out a week later.
+        # gemma3:4b is small (~3 GB), no thinking mode, ~250 ms response.
+        run: |
+          if ! curl -sf http://localhost:11434/api/tags >/dev/null; then
+            echo "::error::production ollama37 /api/tags unreachable — pre-existing failure, not caused by this PR"
+            exit 1
+          fi
+          RESP=$(curl -s http://localhost:11434/api/generate -d '{
+            "model": "gemma3:4b",
+            "prompt": "Say hello in one word.",
+            "stream": false,
+            "options": {"num_predict": 8, "num_ctx": 256}
+          }')
+          TEXT=$(echo "$RESP" | jq -r '.response // ""')
+          EVAL=$(echo "$RESP" | jq -r '.eval_count // 0')
+          if [ -z "$TEXT" ] || [ "$EVAL" -lt 1 ]; then
+            echo "::error::production GGML path regressed — empty response or no tokens"
+            echo "$RESP" | jq '.'
+            exit 1
+          fi
+          echo "production OK: \"$TEXT\" ($EVAL tokens)"
+
       - name: Stop production ollama37
         run: |
           docker stop ollama37 || true


### PR DESCRIPTION
## Summary

Safety net for the MLX rapid-merge cadence (discussion in #189 / #187). Every MLX-only PR so far merged with only `test-mlx-smoke.yml` as gating — that workflow exercises our MLX code but never touched the existing GGML/llama.cpp production path. Isolation kept this safe in practice, but isolation isn't enforced by anything.

New first step in the workflow runs BEFORE the stop-production-ollama37 step: hit the running production `/api/generate` with `gemma3:4b` (small, no thinking mode, ~250 ms response). If the response is empty or `eval_count==0`, the step fails with `::error::production GGML path regressed` and the workflow goes red without our MLX changes ever getting evaluated.

That makes any accidental cross-contamination caught at the very first CI run after it's introduced.

## Test plan

Workflow `26552808239` against this branch — **green**:

```
✓ Regression check — production GGML path still serves
✓ Stop production ollama37
✓ Run mlx smoke
✓ Generate summary
✓ Restart production ollama37
✓ Verify production ollama37 recovered
```

The new step appears between Checkout and Stop. Adds ~1 s to total workflow time.

## Why gemma3:4b

- Small (~3 GB), fits comfortably on one K80 die.
- No thinking mode — `.response` is non-empty on a successful generation (qwen3 / deepseek-r1 send the actual content to `.thinking` and leave `.response` empty for short num_predict).
- Already loaded in the production container's model cache (verified this session).
- Doesn't require disturbing the existing model that production has loaded; just one short generate request.

## What this catches (and doesn't)

Catches:
- Anything that breaks `/api/tags` or `/api/generate` for an already-loaded GGML model on the existing path.

Doesn't catch:
- Performance regressions (would need test-throughput).
- Regressions in models not in the production cache.
- Build/runtime image regressions if we changed the Dockerfile (which we haven't been).

Good enough for the current cadence; bigger checks can be added when we touch areas outside MLX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)