### PR TITLE
Phase D.2 step 2: C ABI for tensor get + metadata (#189)

### DIFF
--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -3,6 +3,7 @@
 #include "mlx_cabi.h"
 
 #include "mlx/mlx.h"
+#include "mlx/dtype_utils.h"  // dtype_to_string
 
 #include <new>
 #include <utility>
@@ -14,6 +15,13 @@ struct mlx_safetensors_s {
   // unordered_map<string, string>>. Store as-is; lookups + metadata
   // access become trivial extensions later.
   mlx::core::SafetensorsLoad data;
+};
+
+// mlx::core::array is reference-counted internally, so we hold a copy
+// per handle. Releasing the handle drops the ref; if it was the last
+// ref the underlying buffer goes away.
+struct mlx_array_s {
+  mlx::core::array data;
 };
 
 int mlx_init(void) {
@@ -44,4 +52,41 @@ int mlx_safetensors_count(mlx_safetensors_t st) {
 
 void mlx_safetensors_release(mlx_safetensors_t st) {
   delete st;
+}
+
+// ----- mlx_array -----
+
+mlx_array_t mlx_safetensors_get(mlx_safetensors_t st, const char* name) {
+  if (!st || !name) return nullptr;
+  try {
+    auto it = st->data.first.find(name);
+    if (it == st->data.first.end()) return nullptr;
+    return new (std::nothrow) mlx_array_s{it->second};
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void mlx_array_release(mlx_array_t arr) {
+  delete arr;
+}
+
+const char* mlx_array_dtype_name(mlx_array_t arr) {
+  if (!arr) return "unknown";
+  try {
+    return mlx::core::dtype_to_string(arr->data.dtype());
+  } catch (...) {
+    return "unknown";
+  }
+}
+
+int mlx_array_ndim(mlx_array_t arr) {
+  if (!arr) return -1;
+  return static_cast<int>(arr->data.ndim());
+}
+
+long long mlx_array_dim(mlx_array_t arr, int axis) {
+  if (!arr) return -1;
+  if (axis < 0 || axis >= static_cast<int>(arr->data.ndim())) return -1;
+  return static_cast<long long>(arr->data.shape(axis));
 }

--- a/x/mlxrunner/cabi/mlx_cabi.h
+++ b/x/mlxrunner/cabi/mlx_cabi.h
@@ -27,6 +27,12 @@ extern "C" {
 // Opaque handle to a loaded safetensors file (name -> array map + metadata).
 typedef struct mlx_safetensors_s* mlx_safetensors_t;
 
+// Opaque handle to a single mlx::core::array. Owned by the caller; release
+// with mlx_array_release. Handles obtained from mlx_safetensors_get hold a
+// copy of the underlying array's reference, so it's safe to release the
+// safetensors handle before releasing arrays obtained from it.
+typedef struct mlx_array_s* mlx_array_t;
+
 // Initialize MLX state and pin the default stream to the GPU device.
 // Returns 0 on success, negative on error.
 int mlx_init(void);
@@ -42,6 +48,28 @@ int mlx_safetensors_count(mlx_safetensors_t st);
 
 // Release a safetensors handle. Safe to call on NULL.
 void mlx_safetensors_release(mlx_safetensors_t st);
+
+// ----- mlx_array -----
+
+// Look up a named tensor inside a loaded safetensors handle. Returns
+// NULL if `name` isn't in the file (or `st` is NULL). Caller must
+// release with mlx_array_release.
+mlx_array_t mlx_safetensors_get(mlx_safetensors_t st, const char* name);
+
+// Release an array handle. Safe to call on NULL.
+void mlx_array_release(mlx_array_t arr);
+
+// Dtype name as a static string ("bfloat16", "uint32", "float32", ...).
+// Returns "unknown" for NULL or unrecognized dtype. The returned pointer
+// has static storage; caller MUST NOT free it.
+const char* mlx_array_dtype_name(mlx_array_t arr);
+
+// Number of dimensions. Returns -1 on NULL.
+int mlx_array_ndim(mlx_array_t arr);
+
+// Size of dimension `axis` (0-indexed). Returns -1 on NULL or out-of-range
+// axis.
+long long mlx_array_dim(mlx_array_t arr, int axis);
 
 #ifdef __cplusplus
 }

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -61,5 +61,42 @@ func main() {
 
 	count := int(C.mlx_safetensors_count(st))
 	fmt.Printf("qwen_load_go: loaded %d tensors\n", count)
+
+	// Mirror qwen_load.cpp's "embed_tokens.weight ..." and ".scales ..." lines.
+	// Validates: name lookup, dtype string accessor, ndim/dim accessors,
+	// ownership pattern (get + release per array).
+	for _, name := range []string{
+		"language_model.model.embed_tokens.weight",
+		"language_model.model.embed_tokens.scales",
+	} {
+		cname := C.CString(name)
+		arr := C.mlx_safetensors_get(st, cname)
+		C.free(unsafe.Pointer(cname))
+		if arr == nil {
+			fmt.Fprintf(os.Stderr, "qwen_load_go: missing tensor '%s'\n", name)
+			os.Exit(5)
+		}
+
+		dtype := C.GoString(C.mlx_array_dtype_name(arr))
+		ndim := int(C.mlx_array_ndim(arr))
+		dims := make([]int64, ndim)
+		for i := 0; i < ndim; i++ {
+			dims[i] = int64(C.mlx_array_dim(arr, C.int(i)))
+		}
+		fmt.Printf("qwen_load_go: %s  dtype=%s shape=%v\n",
+			shortName(name), dtype, dims)
+
+		C.mlx_array_release(arr)
+	}
+
 	fmt.Println("qwen_load_go: cgo OK")
+}
+
+// Strip the long "language_model.model." prefix for log readability.
+func shortName(s string) string {
+	const prefix = "language_model.model."
+	if len(s) > len(prefix) && s[:len(prefix)] == prefix {
+		return s[len(prefix):]
+	}
+	return s
 }


### PR DESCRIPTION
## Summary

Extend the C ABI shim with the minimum surface for Go to fetch tensors by name and introspect dtype/shape. Mirrors `qwen_load.cpp`'s `embed_tokens.{weight,scales}` dtype+shape lines on the Go side.

## C ABI additions

```c
mlx_array_t mlx_safetensors_get(mlx_safetensors_t st, const char* name);
void        mlx_array_release(mlx_array_t arr);
const char* mlx_array_dtype_name(mlx_array_t arr);   // static; no free
int         mlx_array_ndim(mlx_array_t arr);
long long   mlx_array_dim(mlx_array_t arr, int axis);
```

Ownership: `mlx_array_s` holds a copy of the array's reference (MLX arrays are internally ref-counted), so releasing the safetensors handle before the array handles is safe.

## Test plan

Workflow `26553538437` against this branch — **green** including the new production-path regression check (PR #211):

```
qwen_load_go: loaded 716 tensors
qwen_load_go: embed_tokens.weight  dtype=uint32 shape=[248320 256]
qwen_load_go: embed_tokens.scales  dtype=bfloat16 shape=[248320 32]
qwen_load_go: cgo OK
```

Identical dtype + shape to what `qwen_load.cpp` reports (validated in PR #198).

## What this unblocks

Next steps in Phase D.2 can extend the surface to actual ops:
- `mlx_array_take(arr, indices, axis)` — embedding row lookup
- `mlx_array_dequantize(wq, scales, biases, group, bits)` — un-quantize
- `mlx_eval(handles[], count)` — force computation
- `mlx_array_data_float(arr, out, len)` — materialize to host

Same incremental pattern: one PR per logical chunk, each validated against `qwen_load.cpp`'s output.

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)