### PR TITLE
Phase D.2 step 3: C ABI for take + dequantize + eval (#189)

### DIFF
--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -6,12 +6,27 @@
 #include "mlx/mlx.h"
 #include "mlx/dtype_utils.h"  // dtype_to_string
 
+#include <cstdio>
 #include <cstring>
+#include <exception>
 #include <new>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+
+// Surface the exception what() to stderr so Go-side errors are debuggable.
+// Returns the passed-through error code unchanged so callers don't need to
+// change behavior.
+static int report_exc(const char* where, int rc) {
+  try { throw; }
+  catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: %s: %s\n", where, e.what());
+  } catch (...) {
+    std::fprintf(stderr, "mlx_cabi: %s: <non-std exception>\n", where);
+  }
+  return rc;
+}
 
 // Opaque struct definition; only visible inside this TU. The Go side
 // only ever holds the pointer.
@@ -155,6 +170,6 @@ int mlx_eval(mlx_array_t* arrs, int count) {
     mlx::core::eval(std::move(to_eval));
     return 0;
   } catch (...) {
-    return -3;
+    return report_exc("mlx_eval", -3);
   }
 }

--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -2,11 +2,16 @@
 
 #include "mlx_cabi.h"
 
+#include "mlx/allocator.h"
 #include "mlx/mlx.h"
 #include "mlx/dtype_utils.h"  // dtype_to_string
 
+#include <cstring>
 #include <new>
+#include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 // Opaque struct definition; only visible inside this TU. The Go side
 // only ever holds the pointer.
@@ -89,4 +94,67 @@ long long mlx_array_dim(mlx_array_t arr, int axis) {
   if (!arr) return -1;
   if (axis < 0 || axis >= static_cast<int>(arr->data.ndim())) return -1;
   return static_cast<long long>(arr->data.shape(axis));
+}
+
+long long mlx_array_size(mlx_array_t arr) {
+  if (!arr) return -1;
+  return static_cast<long long>(arr->data.size());
+}
+
+mlx_array_t mlx_array_from_int32_1d(const int* data, int count) {
+  if (count < 0 || (count > 0 && !data)) return nullptr;
+  try {
+    mlx::core::array a(mlx::core::Shape{count}, mlx::core::int32, nullptr, {});
+    a.set_data(mlx::core::allocator::malloc(a.nbytes()));
+    if (count > 0) {
+      std::memcpy(a.data<int32_t>(), data, a.nbytes());
+    }
+    return new (std::nothrow) mlx_array_s{std::move(a)};
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+// ----- ops -----
+
+mlx_array_t mlx_array_take(mlx_array_t arr, mlx_array_t indices, int axis) {
+  if (!arr || !indices) return nullptr;
+  try {
+    return new (std::nothrow) mlx_array_s{
+        mlx::core::take(arr->data, indices->data, axis)};
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+mlx_array_t mlx_array_dequantize(
+    mlx_array_t wq, mlx_array_t scales, mlx_array_t biases,
+    int group_size, int bits, const char* mode) {
+  if (!wq || !scales) return nullptr;
+  try {
+    std::optional<mlx::core::array> bs;
+    if (biases) bs = biases->data;
+    std::string m = mode ? mode : "affine";
+    auto out = mlx::core::dequantize(
+        wq->data, scales->data, bs, group_size, bits, m);
+    return new (std::nothrow) mlx_array_s{std::move(out)};
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+int mlx_eval(mlx_array_t* arrs, int count) {
+  if (count < 0 || (count > 0 && !arrs)) return -1;
+  try {
+    std::vector<mlx::core::array> to_eval;
+    to_eval.reserve(count);
+    for (int i = 0; i < count; i++) {
+      if (!arrs[i]) return -2;
+      to_eval.push_back(arrs[i]->data);
+    }
+    mlx::core::eval(std::move(to_eval));
+    return 0;
+  } catch (...) {
+    return -3;
+  }
 }

--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -119,12 +119,20 @@ long long mlx_array_size(mlx_array_t arr) {
 mlx_array_t mlx_array_from_int32_1d(const int* data, int count) {
   if (count < 0 || (count > 0 && !data)) return nullptr;
   try {
-    mlx::core::array a(mlx::core::Shape{count}, mlx::core::int32, nullptr, {});
-    a.set_data(mlx::core::allocator::malloc(a.nbytes()));
+    // Allocate via MLX's allocator + memcpy + array(Buffer, Shape, Dtype)
+    // produces a "leaf-with-data" array. The (Shape, Dtype, nullptr, {})
+    // + set_data combo leaves the array in a state MLX's eval walker
+    // rejects ("Attempting to eval an array without a primitive").
+    const size_t nbytes = static_cast<size_t>(count) * sizeof(int32_t);
+    auto buf = mlx::core::allocator::malloc(nbytes);
     if (count > 0) {
-      std::memcpy(a.data<int32_t>(), data, a.nbytes());
+      std::memcpy(buf.raw_ptr(), data, nbytes);
     }
+    mlx::core::array a(buf, mlx::core::Shape{count}, mlx::core::int32);
     return new (std::nothrow) mlx_array_s{std::move(a)};
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: mlx_array_from_int32_1d: %s\n", e.what());
+    return nullptr;
   } catch (...) {
     return nullptr;
   }

--- a/x/mlxrunner/cabi/mlx_cabi.h
+++ b/x/mlxrunner/cabi/mlx_cabi.h
@@ -71,6 +71,30 @@ int mlx_array_ndim(mlx_array_t arr);
 // axis.
 long long mlx_array_dim(mlx_array_t arr, int axis);
 
+// Total number of elements (product of dims). Returns -1 on NULL.
+long long mlx_array_size(mlx_array_t arr);
+
+// Construct a 1-D int32 array from Go-owned data; data is copied into a
+// new mlx::core::array. Returns NULL on alloc failure.
+mlx_array_t mlx_array_from_int32_1d(const int* data, int count);
+
+// ----- ops -----
+
+// take(arr, indices, axis) — gather rows along `axis`. Returns NULL on
+// error (incompatible shapes, etc.). Caller owns the result.
+mlx_array_t mlx_array_take(mlx_array_t arr, mlx_array_t indices, int axis);
+
+// dequantize(wq, scales, biases, group_size, bits, mode="affine") — un-
+// quantize a packed weight matrix. `biases` may be NULL for non-affine
+// modes; pass mode = "affine" or "fp".
+mlx_array_t mlx_array_dequantize(
+    mlx_array_t wq, mlx_array_t scales, mlx_array_t biases,
+    int group_size, int bits, const char* mode);
+
+// Force evaluation of the given arrays (in-place). Returns 0 on success,
+// negative on exception.
+int mlx_eval(mlx_array_t* arrs, int count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -89,7 +89,78 @@ func main() {
 		C.mlx_array_release(arr)
 	}
 
+	// --- take + dequantize chain on embed row 42 ---
+	// Mirror qwen_load.cpp's take(scales, [42], 0) + dequantize lines.
+	// Gets the packed weight row + scales/biases row, runs dequant on GPU,
+	// reports the resulting shape (full bf16 [1, 2048] for a q4 group=64
+	// embed row).
+	wqArr := getTensor(st, "language_model.model.embed_tokens.weight")
+	scalesArr := getTensor(st, "language_model.model.embed_tokens.scales")
+	biasesArr := getTensor(st, "language_model.model.embed_tokens.biases")
+	defer C.mlx_array_release(wqArr)
+	defer C.mlx_array_release(scalesArr)
+	defer C.mlx_array_release(biasesArr)
+
+	tokenID := []int32{42}
+	idx := C.mlx_array_from_int32_1d(
+		(*C.int)(unsafe.Pointer(&tokenID[0])),
+		C.int(len(tokenID)),
+	)
+	if idx == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: failed to build index array")
+		os.Exit(6)
+	}
+	defer C.mlx_array_release(idx)
+
+	wqRow := C.mlx_array_take(wqArr, idx, 0)
+	scRow := C.mlx_array_take(scalesArr, idx, 0)
+	bsRow := C.mlx_array_take(biasesArr, idx, 0)
+	defer C.mlx_array_release(wqRow)
+	defer C.mlx_array_release(scRow)
+	defer C.mlx_array_release(bsRow)
+	if wqRow == nil || scRow == nil || bsRow == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: take failed")
+		os.Exit(7)
+	}
+
+	modeC := C.CString("affine")
+	full := C.mlx_array_dequantize(wqRow, scRow, bsRow,
+		C.int(64), C.int(4), modeC)
+	C.free(unsafe.Pointer(modeC))
+	if full == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: dequantize failed")
+		os.Exit(8)
+	}
+	defer C.mlx_array_release(full)
+
+	// Force eval — without this all the ops above are lazy and never run.
+	toEval := []C.mlx_array_t{full}
+	if rc := C.mlx_eval(&toEval[0], C.int(len(toEval))); rc != 0 {
+		fmt.Fprintf(os.Stderr, "qwen_load_go: eval failed: rc=%d\n", int(rc))
+		os.Exit(9)
+	}
+
+	fullNdim := int(C.mlx_array_ndim(full))
+	fullDims := make([]int64, fullNdim)
+	for i := 0; i < fullNdim; i++ {
+		fullDims[i] = int64(C.mlx_array_dim(full, C.int(i)))
+	}
+	fmt.Printf("qwen_load_go: dequantize(embed row 42)  dtype=%s shape=%v size=%d\n",
+		C.GoString(C.mlx_array_dtype_name(full)), fullDims,
+		int64(C.mlx_array_size(full)))
+
 	fmt.Println("qwen_load_go: cgo OK")
+}
+
+func getTensor(st C.mlx_safetensors_t, name string) C.mlx_array_t {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	arr := C.mlx_safetensors_get(st, cname)
+	if arr == nil {
+		fmt.Fprintf(os.Stderr, "qwen_load_go: missing tensor '%s'\n", name)
+		os.Exit(5)
+	}
+	return arr
 }
 
 // Strip the long "language_model.model." prefix for log readability.


### PR DESCRIPTION
## Summary

Extend the C ABI with the minimum ops needed for the embedding-lookup chain. Go now mirrors `qwen_load.cpp`'s "take(scales, [42], 0) + dequantize(embed row 42)" lines.

## C ABI additions

```c
long long   mlx_array_size(mlx_array_t arr);
mlx_array_t mlx_array_from_int32_1d(const int* data, int count);
mlx_array_t mlx_array_take(mlx_array_t arr, mlx_array_t indices, int axis);
mlx_array_t mlx_array_dequantize(
    mlx_array_t wq, mlx_array_t scales, mlx_array_t biases,
    int group_size, int bits, const char* mode);
int         mlx_eval(mlx_array_t* arrs, int count);    // 0 = OK, <0 = exc
```

Plus `report_exc()` helper that surfaces in-flight C++ exception `what()` to stderr before returning the C error code — without this the first iteration just returned `rc=-3` with no detail.

## Iterations to land (2)

1. First run: `mlx_eval: [eval] Attempting to eval an array without a primitive.` — my `mlx_array_from_int32_1d` used `array(Shape, Dtype, nullptr, {}) + set_data()` which apparently leaves the array in a state MLX's eval walker rejects. Switched to `array(allocator::Buffer, Shape, Dtype)` which produces a proper leaf-with-data array.
2. With that fix in (`941ba70e`), CI run `26558191239` green.

## Test plan

Workflow `26558191239` against this branch — **green** including production-path regression check (PR #211):

```
qwen_load_go: loaded 716 tensors
qwen_load_go: embed_tokens.weight  dtype=uint32 shape=[248320 256]
qwen_load_go: embed_tokens.scales  dtype=bfloat16 shape=[248320 32]
qwen_load_go: dequantize(embed row 42)  dtype=bfloat16 shape=[1 2048] size=2048
qwen_load_go: cgo OK
```

`shape=[1 2048]` matches what `qwen_load.cpp` reports for the same dequant chain (PR #202).

## What this unblocks

Next D.2 steps:
- step 4: `mlx_array_data_float(arr, out, len)` to materialize values from GPU back to Go — lets us verify actual values (`first 5 = 0 0 -0.00964 -0.00964 0.00644`) match numpy ground truth.
- step 5: matmul / rms_norm / conv1d / sigmoid wrappers — continue the chain Go-side.
- step 6: device/stream handles for multi-die layer placement.

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)