### PR TITLE
Phase D.2 step 4: C ABI for astype + data copy to Go (#189)

### DIFF
--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -6,6 +6,7 @@
 #include "mlx/mlx.h"
 #include "mlx/dtype_utils.h"  // dtype_to_string
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <exception>
@@ -179,5 +180,37 @@ int mlx_eval(mlx_array_t* arrs, int count) {
     return 0;
   } catch (...) {
     return report_exc("mlx_eval", -3);
+  }
+}
+
+mlx_array_t mlx_array_to_float32(mlx_array_t arr) {
+  if (!arr) return nullptr;
+  try {
+    return new (std::nothrow) mlx_array_s{
+        mlx::core::astype(arr->data, mlx::core::float32)};
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: mlx_array_to_float32: %s\n", e.what());
+    return nullptr;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+int mlx_array_copy_float(mlx_array_t arr, float* out, int max_count) {
+  if (!arr || !out || max_count <= 0) return -1;
+  if (arr->data.dtype() != mlx::core::float32) {
+    std::fprintf(stderr,
+        "mlx_cabi: mlx_array_copy_float: dtype must be float32; got %s\n",
+        mlx::core::dtype_to_string(arr->data.dtype()));
+    return -2;
+  }
+  try {
+    int n = std::min(
+        static_cast<int>(arr->data.size()),
+        max_count);
+    std::memcpy(out, arr->data.data<float>(), n * sizeof(float));
+    return n;
+  } catch (...) {
+    return report_exc("mlx_array_copy_float", -3);
   }
 }

--- a/x/mlxrunner/cabi/mlx_cabi.h
+++ b/x/mlxrunner/cabi/mlx_cabi.h
@@ -95,6 +95,19 @@ mlx_array_t mlx_array_dequantize(
 // negative on exception.
 int mlx_eval(mlx_array_t* arrs, int count);
 
+// astype(arr, float32). Returns NULL on error. Use this BEFORE
+// mlx_array_copy_float — copying raw BF16/FP16 bytes through a float* lens
+// reads denormal garbage (see PR #199 for the same bug on the C++ side).
+mlx_array_t mlx_array_to_float32(mlx_array_t arr);
+
+// Copy at most `max_count` float values from `arr`'s host buffer into
+// `out`. The array MUST be (a) eval'd already and (b) dtype == float32.
+// Returns number of values copied, or negative on error:
+//   -1: NULL arg / max_count <= 0
+//   -2: wrong dtype (the message goes to stderr via report_exc)
+//   -3: other exception
+int mlx_array_copy_float(mlx_array_t arr, float* out, int max_count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -149,6 +149,33 @@ func main() {
 		C.GoString(C.mlx_array_dtype_name(full)), fullDims,
 		int64(C.mlx_array_size(full)))
 
+	// --- Materialize first 5 values to host for verification against numpy ---
+	// astype-to-float32 BEFORE copying — copying raw BF16 bytes through a
+	// float* lens gives denormal junk (same PR #199 trap on the C++ side).
+	fullF32 := C.mlx_array_to_float32(full)
+	if fullF32 == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: astype-float32 failed")
+		os.Exit(10)
+	}
+	defer C.mlx_array_release(fullF32)
+
+	// astype is lazy too; eval again.
+	toEval2 := []C.mlx_array_t{fullF32}
+	if rc := C.mlx_eval(&toEval2[0], C.int(len(toEval2))); rc != 0 {
+		fmt.Fprintf(os.Stderr, "qwen_load_go: eval(f32) failed: rc=%d\n", int(rc))
+		os.Exit(11)
+	}
+
+	const N = 5
+	vals := make([]float32, N)
+	got := int(C.mlx_array_copy_float(
+		fullF32, (*C.float)(unsafe.Pointer(&vals[0])), C.int(N)))
+	if got < 0 {
+		fmt.Fprintf(os.Stderr, "qwen_load_go: copy_float failed: rc=%d\n", got)
+		os.Exit(12)
+	}
+	fmt.Printf("qwen_load_go: dequant row 42 first %d = %v\n", got, vals[:got])
+
 	fmt.Println("qwen_load_go: cgo OK")
 }
 


### PR DESCRIPTION
## Summary

Add `mlx_array_to_float32` + `mlx_array_copy_float` so Go can materialize values back from GPU-eval'd arrays for numpy-comparable verification.

```c
mlx_array_t mlx_array_to_float32(mlx_array_t arr);              // wraps astype
int         mlx_array_copy_float(mlx_array_t arr, float* out, int max_count);
```

The copy step requires float32 dtype and surfaces a clear stderr message otherwise. **Copying raw BF16 bytes through a float* lens reads denormal junk** — same bug PR #199 fixed on the C++ side. Callers must `astype` first; the API enforces it.

## Test plan

Workflow `26558743037` against this branch — **green**:

```
qwen_load_go: loaded 716 tensors
qwen_load_go: embed_tokens.weight  dtype=uint32 shape=[248320 256]
qwen_load_go: embed_tokens.scales  dtype=bfloat16 shape=[248320 32]
qwen_load_go: dequantize(embed row 42)  dtype=bfloat16 shape=[1 2048] size=2048
qwen_load_go: dequant row 42 first 5 = [0 0 -0.009643555 -0.009643555 0.006439209]
qwen_load_go: cgo OK
```

| | Value |
|---|---|
| **Go (this PR)** | `[0, 0, -0.009643555, -0.009643555, 0.006439209]` |
| **C++ (PR #202)** | `[0, 0, -0.00964355, -0.00964355, 0.00643921]` |
| **numpy on raw bytes** | `[0, 0, -0.00966, -0.00966, 0.00644]` |

Go matches the C++ output byte-for-byte (different print precision). Both within BF16 precision of numpy ground truth.

## What this unblocks

End-to-end inference-path validation is now possible **from Go** — load → take → dequantize → astype → materialize. Subsequent steps add: rms_norm / quantized_matmul / conv1d / sigmoid wrappers, and eventually a runner that builds the full A3B forward pass via this surface.

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)