### PR TITLE
Phase D.2 step 6: C ABI for conv1d + sigmoid + multiply + ones (#189)

### DIFF
--- a/x/mlxrunner/cabi/mlx_cabi.cc
+++ b/x/mlxrunner/cabi/mlx_cabi.cc
@@ -274,3 +274,69 @@ mlx_array_t mlx_array_quantized_matmul(
     return nullptr;
   }
 }
+
+mlx_array_t mlx_array_conv1d(
+    mlx_array_t input, mlx_array_t weight,
+    int stride, int padding, int dilation, int groups) {
+  if (!input || !weight) return nullptr;
+  try {
+    return new (std::nothrow) mlx_array_s{mlx::core::conv1d(
+        input->data, weight->data, stride, padding, dilation, groups)};
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: mlx_array_conv1d: %s\n", e.what());
+    return nullptr;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+mlx_array_t mlx_array_sigmoid(mlx_array_t arr) {
+  if (!arr) return nullptr;
+  try {
+    return new (std::nothrow) mlx_array_s{mlx::core::sigmoid(arr->data)};
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: mlx_array_sigmoid: %s\n", e.what());
+    return nullptr;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+mlx_array_t mlx_array_multiply(mlx_array_t a, mlx_array_t b) {
+  if (!a || !b) return nullptr;
+  try {
+    return new (std::nothrow) mlx_array_s{
+        mlx::core::multiply(a->data, b->data)};
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: mlx_array_multiply: %s\n", e.what());
+    return nullptr;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+mlx_array_t mlx_array_ones(const long long* dims, int ndim,
+                           const char* dtype_name) {
+  if (ndim < 0 || (ndim > 0 && !dims) || !dtype_name) return nullptr;
+  mlx::core::Dtype dt = mlx::core::float32;
+  std::string n = dtype_name;
+  if (n == "float32") dt = mlx::core::float32;
+  else if (n == "bfloat16") dt = mlx::core::bfloat16;
+  else {
+    std::fprintf(stderr,
+        "mlx_cabi: mlx_array_ones: unsupported dtype '%s' "
+        "(only float32 and bfloat16 currently)\n", dtype_name);
+    return nullptr;
+  }
+  try {
+    mlx::core::Shape shape;
+    shape.reserve(ndim);
+    for (int i = 0; i < ndim; i++) shape.push_back(static_cast<int>(dims[i]));
+    return new (std::nothrow) mlx_array_s{mlx::core::ones(shape, dt)};
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "mlx_cabi: mlx_array_ones: %s\n", e.what());
+    return nullptr;
+  } catch (...) {
+    return nullptr;
+  }
+}

--- a/x/mlxrunner/cabi/mlx_cabi.h
+++ b/x/mlxrunner/cabi/mlx_cabi.h
@@ -124,6 +124,23 @@ mlx_array_t mlx_array_quantized_matmul(
     mlx_array_t x, mlx_array_t wq, mlx_array_t scales, mlx_array_t biases,
     int transpose, int group_size, int bits, const char* mode);
 
+// conv1d(input, weight, stride, padding, dilation, groups). Input shape
+// (B, L, C_in); weight shape (C_out, kw, C_in/groups). Returns NULL on
+// shape mismatch / exception.
+mlx_array_t mlx_array_conv1d(
+    mlx_array_t input, mlx_array_t weight,
+    int stride, int padding, int dilation, int groups);
+
+// Elementwise sigmoid + multiply (compose for silu = sigmoid(x) * x).
+mlx_array_t mlx_array_sigmoid(mlx_array_t arr);
+mlx_array_t mlx_array_multiply(mlx_array_t a, mlx_array_t b);
+
+// Construct an all-ones array. `dtype_name` accepts "float32" or "bfloat16"
+// (the dtypes we exercise on the inference path); other names return NULL
+// with a stderr message.
+mlx_array_t mlx_array_ones(const long long* dims, int ndim,
+                           const char* dtype_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/x/mlxrunner/go/cmd/qwen_load_go/main.go
+++ b/x/mlxrunner/go/cmd/qwen_load_go/main.go
@@ -229,6 +229,57 @@ func main() {
 	fmt.Printf("qwen_load_go: in_proj_qkv(rms_normed) shape=%v\n", qkvDims)
 	first5OfArray(qkvProj, "in_proj_qkv")
 
+	// --- conv1d probe (mirrors qwen_load.cpp PR #205) ---
+	// Depthwise conv1d (groups=8192, kw=4) on a synthetic all-ones input.
+	// For ones input + padding=0 the output is just the per-channel kernel
+	// sum. Ground truth from PR #205: [-0.0617676, -0.0458984, 0.0678711].
+	convW := getTensor(st, "language_model.model.layers.0.linear_attn.conv1d.weight")
+	defer C.mlx_array_release(convW)
+
+	convDims := []int64{1, 4, 8192}
+	dtypeBF16 := C.CString("bfloat16")
+	convIn := C.mlx_array_ones(
+		(*C.longlong)(unsafe.Pointer(&convDims[0])),
+		C.int(len(convDims)), dtypeBF16)
+	C.free(unsafe.Pointer(dtypeBF16))
+	if convIn == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: ones() failed")
+		os.Exit(23)
+	}
+	defer C.mlx_array_release(convIn)
+
+	convOut := C.mlx_array_conv1d(convIn, convW,
+		C.int(1),    // stride
+		C.int(0),    // padding
+		C.int(1),    // dilation
+		C.int(8192)) // groups (depthwise)
+	if convOut == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: conv1d failed")
+		os.Exit(24)
+	}
+	defer C.mlx_array_release(convOut)
+	fmt.Printf("qwen_load_go: conv1d(ones, layer_0.conv1d.w) shape=%v\n",
+		dimsOf(convOut))
+	first5OfArray(convOut, "conv1d")
+
+	// --- silu probe (mirrors qwen_load.cpp PR #208) ---
+	// silu(x) = sigmoid(x) * x. Composed from two ops since MLX exposes
+	// silu only via the higher-level fast namespace, not ops.h.
+	sigOut := C.mlx_array_sigmoid(convOut)
+	if sigOut == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: sigmoid failed")
+		os.Exit(25)
+	}
+	defer C.mlx_array_release(sigOut)
+
+	siluOut := C.mlx_array_multiply(sigOut, convOut)
+	if siluOut == nil {
+		fmt.Fprintln(os.Stderr, "qwen_load_go: multiply (silu) failed")
+		os.Exit(26)
+	}
+	defer C.mlx_array_release(siluOut)
+	first5OfArray(siluOut, "silu(conv1d)")
+
 	fmt.Println("qwen_load_go: cgo OK")
 }
 


### PR DESCRIPTION
## Summary

Final wrappers to mirror `qwen_load.cpp`'s full chain from Go. After this PR, **every primitive the C++ chain uses is exposed via the cgo surface.**

## C ABI additions

```c
mlx_array_t mlx_array_conv1d(input, weight, stride, padding, dilation, groups);
mlx_array_t mlx_array_sigmoid(arr);
mlx_array_t mlx_array_multiply(a, b);
mlx_array_t mlx_array_ones(dims, ndim, dtype_name);   // "float32" | "bfloat16"
```

## Test plan

Workflow `26562066265` against this branch — **green**:

| | Go (this PR) | C++ (PR #205 / #208) |
|---|---|---|
| conv1d first 3 | `[-0.0617676, -0.045898438, 0.067871094]` | `[-0.0617676, -0.0458984, 0.0678711]` |
| silu   first 3 | `[-0.029907227, -0.022460938, 0.03491211]` | `[-0.0299072, -0.0224609, 0.0349121]` |

Identical BF16 values; just different decimal print precision.

## Full Go-side chain (qwen_load_go output)

```
qwen_load_go: loaded 716 tensors
qwen_load_go: embed_tokens.weight  dtype=uint32 shape=[248320 256]
qwen_load_go: embed_tokens.scales  dtype=bfloat16 shape=[248320 32]
qwen_load_go: dequantize(embed row 42)  dtype=bfloat16 shape=[1 2048] size=2048
qwen_load_go: dequant row 42 first 5 = [0 0 -0.009643555 -0.009643555 0.006439209]
qwen_load_go: rms_norm(dequant row 42) first 5 = [0 0 -1.09375 -1.0078125 0.7109375]
qwen_load_go: rms_norm abs_mean=0.65234375
qwen_load_go: in_proj_qkv(rms_normed) shape=[1 8192]
qwen_load_go: in_proj_qkv first 5 = [2.015625 -0.10546875 -1.15625 -0.25976562 -0.059326172]
qwen_load_go: conv1d(ones, layer_0.conv1d.w) shape=[1 1 8192]
qwen_load_go: conv1d first 5 = [-0.061767578 -0.045898438 0.067871094 0.04321289 0.037109375]
qwen_load_go: silu(conv1d) first 5 = [-0.029907227 -0.022460938 0.03491211 0.022094727 0.018798828]
qwen_load_go: cgo OK
```

10 stages of inference-path computation, all driven from Go via cgo, all matching the C++ side byte-for-byte.

## Phase D.2 step count

| Step | PR | Surface |
|---|---|---|
| 1 | #210 | mlx_init, load_safetensors, count, release |
| 2 | #212 | safetensors_get, array_release, dtype_name, ndim, dim |
| 3 | #213 | array_size, from_int32_1d, take, dequantize, eval |
| 4 | #214 | to_float32, copy_float |
| 5 | #215 | abs, mean_all, rms_norm, quantized_matmul |
| **6** | **THIS** | **conv1d, sigmoid, multiply, ones** |

## What's left for Phase D.2

Step 7 — device/stream handles for multi-die layer placement. After that the cgo layer is "good enough to build an actual model" and Phase D.3 (`x/models/qwen3_6_a3b` Go-side definition) can begin.

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)