### PR TITLE
Phase D.3 step 1: Go package skeleton + config parser (#189)

### DIFF
--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -100,6 +100,15 @@ CGO_DURATION=0
 CGO_STDOUT=""
 CGO_STDERR=""
 
+# qwen_runner (Phase D.3 step 1) — pure-Go exe; parses config.json and
+# prints the language-model config block. No cgo, no MLX, no GPU. This
+# is the entry point that future steps build the model assembly on.
+RUNNER_STATUS="skipped"
+RUNNER_EXIT_CODE=-1
+RUNNER_DURATION=0
+RUNNER_STDOUT=""
+RUNNER_STDERR=""
+
 GPU_DEVICE_COUNT=0
 GPU_NAMES=""
 
@@ -144,6 +153,11 @@ write_results() {
         --argjson cgo_duration "$CGO_DURATION" \
         --arg cgo_stdout "$CGO_STDOUT" \
         --arg cgo_stderr "$CGO_STDERR" \
+        --arg runner_status "$RUNNER_STATUS" \
+        --argjson runner_exit "$RUNNER_EXIT_CODE" \
+        --argjson runner_duration "$RUNNER_DURATION" \
+        --arg runner_stdout "$RUNNER_STDOUT" \
+        --arg runner_stderr "$RUNNER_STDERR" \
         --argjson gpu_count "$GPU_DEVICE_COUNT" \
         --arg gpu_names "$GPU_NAMES" \
         --argjson final_exit "$FINAL_EXIT" \
@@ -193,6 +207,13 @@ write_results() {
             "duration_sec": $cgo_duration,
             "stdout": $cgo_stdout,
             "stderr": $cgo_stderr
+          },
+          "runner": {
+            "status": $runner_status,
+            "exit_code": $runner_exit,
+            "duration_sec": $runner_duration,
+            "stdout": $runner_stdout,
+            "stderr": $runner_stderr
           },
           "gpu": {
             "device_count": $gpu_count,
@@ -268,6 +289,18 @@ else
             else
               echo "qwen_load_go: skipped Go build (mlx_cabi or mlx archive missing)"
             fi
+            # Phase D.3 step 1 (#189): pure-Go qwen_runner exe. No cgo, so
+            # build is fast and independent of the libmlx_cabi/libmlx.a
+            # state above. The GOFLAGS / GOCACHE / safe.directory setup
+            # earlier in the script covers this build too.
+            export GOCACHE="${GOCACHE:-/tmp/gocache}"
+            export GOFLAGS="${GOFLAGS:--buildvcs=false}"
+            mkdir -p "$GOCACHE"
+            git config --global --add safe.directory /src || true
+            (cd /src/x/mlxrunner/go && go build -buildvcs=false -o /build/qwen_runner ./cmd/qwen_runner) \
+                || echo "::warning::Go build of qwen_runner failed; see build.log"
+            (cd /src/x/mlxrunner/go && go test -buildvcs=false ./models/qwen3_6_a3b/...) \
+                || echo "::warning::Go tests for qwen3_6_a3b package failed; see build.log"
         ' > "$BUILD_DIR/build.log" 2>&1
     BUILD_RC=$?
     set -e
@@ -415,6 +448,47 @@ if [ -x "$BUILD_DIR/qwen_load_go" ] && [ -f "$MODEL_DIR/$LOAD_SHARD_FILE" ]; the
 else
     if [ ! -x "$BUILD_DIR/qwen_load_go" ]; then
         echo "qwen_load_go: skipped (Go cgo exe not built)"
+    fi
+fi
+
+# ------------------------------------------------------- qwen_runner -----
+# Phase D.3 step 1 (#189) — pure-Go config parser. No cgo, no GPU, no
+# safetensors I/O. Runs only if the exe built and the model dir has a
+# config.json. Failure DOES override FINAL_EXIT (load-bearing for D.3,
+# unlike the cgo block which was still in earliest plumbing stage).
+if [ -x "$BUILD_DIR/qwen_runner" ] && [ -f "$MODEL_DIR/config.json" ]; then
+    RUNNER_STATUS="running"
+    RUNNER_START=$(date +%s)
+    set +e
+    docker run --rm \
+        -v "$BUILD_DIR:/build:ro" \
+        -v "$MODEL_DIR:/models:ro" \
+        --entrypoint bash \
+        "$RUNTIME_IMAGE" \
+        -c "/build/qwen_runner -model /models" \
+        > "$BUILD_DIR/runner.stdout" 2> "$BUILD_DIR/runner.stderr"
+    RUNNER_RC=$?
+    set -e
+    RUNNER_DURATION=$(( $(date +%s) - RUNNER_START ))
+    RUNNER_STDOUT=$(tail -c 4000 "$BUILD_DIR/runner.stdout" || true)
+    RUNNER_STDERR=$(tail -c 4000 "$BUILD_DIR/runner.stderr" || true)
+    RUNNER_EXIT_CODE=$RUNNER_RC
+    if [ $RUNNER_RC -eq 0 ] && echo "$RUNNER_STDOUT" | grep -q "qwen_runner: OK"; then
+        RUNNER_STATUS="success"
+        echo "runner OK: qwen_runner completed in ${RUNNER_DURATION}s"
+    else
+        RUNNER_STATUS="failed"
+        echo "::error::qwen_runner failed (rc=$RUNNER_RC)"
+        if [ "$FINAL_EXIT" -eq 0 ]; then
+            FINAL_EXIT=2
+        fi
+    fi
+else
+    if [ ! -x "$BUILD_DIR/qwen_runner" ]; then
+        echo "qwen_runner: skipped (exe not built)"
+    fi
+    if [ ! -f "$MODEL_DIR/config.json" ]; then
+        echo "qwen_runner: skipped (no $MODEL_DIR/config.json)"
     fi
 fi
 

--- a/x/mlxrunner/go/cmd/qwen_runner/main.go
+++ b/x/mlxrunner/go/cmd/qwen_runner/main.go
@@ -1,0 +1,46 @@
+// qwen_runner — entry point for the Go-side Qwen3.6-35B-A3B-4bit runner
+// on K80 (Phase D.3, #189).
+//
+// Phase D.3 step 1: prints the model config so the package layout +
+// JSON parsing are validated independently of the cgo / MLX surface.
+// Subsequent steps will add weight loading and forward-pass dispatch.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	qwen "github.com/dogkeeper886/ollama37/x/mlxrunner/models/qwen3_6_a3b"
+)
+
+func main() {
+	var modelPath string
+	flag.StringVar(&modelPath, "model", "", "Path to model directory (containing config.json)")
+	flag.Parse()
+	if modelPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH")
+		os.Exit(2)
+	}
+
+	cfg, err := qwen.LoadConfig(modelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "qwen_runner: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("qwen_runner: architectures = %v\n", cfg.Architectures)
+	fmt.Printf("qwen_runner: model_type = %s\n", cfg.ModelType)
+	fmt.Printf("qwen_runner: tie_word_embeddings = %v\n", cfg.TieWordEmbeddings)
+	fmt.Printf("qwen_runner: text.model_type = %s\n", cfg.TextConfig.ModelType)
+	fmt.Printf("qwen_runner: text.num_hidden_layers = %d\n", cfg.TextConfig.NumHiddenLayers)
+	fmt.Printf("qwen_runner: text.hidden_size = %d\n", cfg.TextConfig.HiddenSize)
+	fmt.Printf("qwen_runner: text.num_attention_heads = %d\n", cfg.TextConfig.NumAttentionHeads)
+	fmt.Printf("qwen_runner: text.num_key_value_heads = %d\n", cfg.TextConfig.NumKeyValueHeads)
+	fmt.Printf("qwen_runner: text.vocab_size = %d\n", cfg.TextConfig.VocabSize)
+	fmt.Printf("qwen_runner: text.num_experts = %d\n", cfg.TextConfig.NumExperts)
+	fmt.Printf("qwen_runner: text.num_experts_per_tok = %d\n", cfg.TextConfig.NumExpertsPerTok)
+	fmt.Printf("qwen_runner: quant = bits=%d group_size=%d mode=%s\n",
+		cfg.Quantization.Bits, cfg.Quantization.GroupSize, cfg.Quantization.Mode)
+	fmt.Println("qwen_runner: OK")
+}

--- a/x/mlxrunner/go/models/qwen3_6_a3b/config.go
+++ b/x/mlxrunner/go/models/qwen3_6_a3b/config.go
@@ -1,0 +1,68 @@
+// Package qwen3_6_a3b assembles the qwen3.6-35b-a3b-4bit model (the
+// MLX-quantized A3B / MoE+DeltaNet flavor) on top of the mlx_cabi
+// cgo surface. Phase D.3 (#189).
+//
+// The model is multimodal in its config (vision_config present), but
+// the runner here only consumes the language portion under
+// text_config — the LLM forward pass is what the K80 path needs.
+package qwen3_6_a3b
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config mirrors config.json with only the fields the runner actually
+// reads. The full file has vision_config, transformers_version, per-
+// tensor quantization overrides, and assorted special-token IDs — add
+// fields here when the forward pass needs them, not before.
+type Config struct {
+	Architectures     []string     `json:"architectures"`
+	ModelType         string       `json:"model_type"`
+	TieWordEmbeddings bool         `json:"tie_word_embeddings"`
+	Quantization      Quantization `json:"quantization"`
+	TextConfig        TextConfig   `json:"text_config"`
+}
+
+// TextConfig is the language-model subtree under config.text_config.
+// Top-level config holds vision + multimodal wiring; the LLM lives here.
+type TextConfig struct {
+	ModelType         string `json:"model_type"`
+	NumHiddenLayers   int    `json:"num_hidden_layers"`
+	HiddenSize        int    `json:"hidden_size"`
+	NumAttentionHeads int    `json:"num_attention_heads"`
+	NumKeyValueHeads  int    `json:"num_key_value_heads"`
+	VocabSize         int    `json:"vocab_size"`
+	NumExperts        int    `json:"num_experts"`
+	NumExpertsPerTok  int    `json:"num_experts_per_tok"`
+}
+
+// Quantization captures the file-wide default quant params. The full
+// config also has per-tensor overrides (e.g. the 8-bit MoE router gate
+// at language_model.model.layers.N.mlp.gate); those are read on demand
+// by the weight loader, not parsed here.
+type Quantization struct {
+	GroupSize int    `json:"group_size"`
+	Bits      int    `json:"bits"`
+	Mode      string `json:"mode"`
+}
+
+// LoadConfig parses config.json from either a model directory or a
+// direct file path. Passing the model directory is the common case;
+// the file-path form is for tests with custom fixtures.
+func LoadConfig(path string) (*Config, error) {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		path = filepath.Join(path, "config.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return &c, nil
+}

--- a/x/mlxrunner/go/models/qwen3_6_a3b/config_test.go
+++ b/x/mlxrunner/go/models/qwen3_6_a3b/config_test.go
@@ -1,0 +1,53 @@
+package qwen3_6_a3b
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleConfigJSON = `{
+  "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+  "model_type": "qwen3_5_moe",
+  "tie_word_embeddings": true,
+  "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+  "text_config": {
+    "model_type": "qwen3_5_moe_text",
+    "num_hidden_layers": 40,
+    "hidden_size": 2048,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 2,
+    "vocab_size": 248320,
+    "num_experts": 256,
+    "num_experts_per_tok": 8
+  }
+}`
+
+func TestLoadConfigFromDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(sampleConfigJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got, want := c.ModelType, "qwen3_5_moe"; got != want {
+		t.Errorf("ModelType = %q, want %q", got, want)
+	}
+	if got, want := c.TextConfig.NumHiddenLayers, 40; got != want {
+		t.Errorf("NumHiddenLayers = %d, want %d", got, want)
+	}
+	if got, want := c.TextConfig.NumExperts, 256; got != want {
+		t.Errorf("NumExperts = %d, want %d", got, want)
+	}
+	if got, want := c.Quantization.Bits, 4; got != want {
+		t.Errorf("Quantization.Bits = %d, want %d", got, want)
+	}
+}
+
+func TestLoadConfigMissing(t *testing.T) {
+	if _, err := LoadConfig("/nonexistent/path/config.json"); err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

First brick of Phase D.3 — the Go-side model assembly. Pure Go, no cgo, no MLX. Validates package layout and JSON parsing independently of the cgo surface, so the rest of D.3 has a clean base.

## Adds

| File | Role |
|---|---|
| `x/mlxrunner/go/models/qwen3_6_a3b/config.go` | `Config` / `TextConfig` / `Quantization` + `LoadConfig(path)` |
| `x/mlxrunner/go/models/qwen3_6_a3b/config_test.go` | Unit tests with inline fixture (no model dep) |
| `x/mlxrunner/go/cmd/qwen_runner/main.go` | Runner entry point (this is where the real runner lives) |
| `cicd/scripts/test-mlx-smoke.sh` | Build, test, and run qwen_runner against the real model |

Only fields the runner actually reads are surfaced. `vision_config`, per-tensor quant overrides (8-bit MoE router gate), `transformers_version`, special-token IDs — all skipped, will be added on demand when the forward pass needs them. No speculative fields.

## CI proof — workflow `26562891268` green

```
qwen_runner: architectures = [Qwen3_5MoeForConditionalGeneration]
qwen_runner: model_type = qwen3_5_moe
qwen_runner: tie_word_embeddings = false
qwen_runner: text.model_type = qwen3_5_moe_text
qwen_runner: text.num_hidden_layers = 40
qwen_runner: text.hidden_size = 2048
qwen_runner: text.num_attention_heads = 16
qwen_runner: text.num_key_value_heads = 2
qwen_runner: text.vocab_size = 248320
qwen_runner: text.num_experts = 256
qwen_runner: text.num_experts_per_tok = 8
qwen_runner: quant = bits=4 group_size=64 mode=affine
qwen_runner: OK
```

All values match the manual `jq` inspection of `/home/jack/models/qwen3.6-35b-a3b-4bit/config.json`. The cgo + qwen_load blocks remain green; production gemma3:4b regression check still passes.

## Why a separate exe (not extend qwen_load_go)?

`qwen_load_go` is the cgo plumbing probe — it exists to prove the C ABI wrappers work and will eventually be deleted. `qwen_runner` is the permanent runner entry point that D.3 builds out (weight loader → layer dispatch → forward pass → token generation). Keeping them separate avoids tangling "still-experimental cgo surface" with "real runner."

## What's next (Phase D.3 plan)

| Step | Surface |
|---|---|
| **1** | **config.go (this PR)** |
| 2 | weights.go — load all 4 shards via mlx_load_safetensors, build name → handle map |
| 3 | First layer forward (DeltaNet, layer 0) — call existing cgo wrappers |
| 4 | Full 40-layer dispatch loop (30 DeltaNet + 10 self_attn) |
| 5 | MoE FFN forward (256 experts, top-8) |
| 6 | Token generation entry point |

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)