### PR TITLE
Phase D.3 step 2: mlx Go package + safetensors loading from qwen_runner (#189)

### DIFF
--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -286,19 +286,20 @@ else
               git config --global --add safe.directory /src || true
               (cd /src/x/mlxrunner/go && go build -buildvcs=false -o /build/qwen_load_go ./cmd/qwen_load_go) \
                   || echo "::warning::Go cgo build of qwen_load_go failed; see build.log"
+              # Phase D.3 step 2 (#189): qwen_runner imports the mlx Go
+              # package, so its build is now also gated on libmlx_cabi
+              # and libmlx.a (same conditional as qwen_load_go).
+              (cd /src/x/mlxrunner/go && go build -buildvcs=false -o /build/qwen_runner ./cmd/qwen_runner) \
+                  || echo "::warning::Go build of qwen_runner failed; see build.log"
             else
               echo "qwen_load_go: skipped Go build (mlx_cabi or mlx archive missing)"
+              echo "qwen_runner: skipped Go build (mlx_cabi or mlx archive missing)"
             fi
-            # Phase D.3 step 1 (#189): pure-Go qwen_runner exe. No cgo, so
-            # build is fast and independent of the libmlx_cabi/libmlx.a
-            # state above. The GOFLAGS / GOCACHE / safe.directory setup
-            # earlier in the script covers this build too.
+            # Pure-Go package tests still always run (don't need libmlx).
             export GOCACHE="${GOCACHE:-/tmp/gocache}"
             export GOFLAGS="${GOFLAGS:--buildvcs=false}"
             mkdir -p "$GOCACHE"
             git config --global --add safe.directory /src || true
-            (cd /src/x/mlxrunner/go && go build -buildvcs=false -o /build/qwen_runner ./cmd/qwen_runner) \
-                || echo "::warning::Go build of qwen_runner failed; see build.log"
             (cd /src/x/mlxrunner/go && go test -buildvcs=false ./models/qwen3_6_a3b/...) \
                 || echo "::warning::Go tests for qwen3_6_a3b package failed; see build.log"
         ' > "$BUILD_DIR/build.log" 2>&1
@@ -452,20 +453,23 @@ else
 fi
 
 # ------------------------------------------------------- qwen_runner -----
-# Phase D.3 step 1 (#189) — pure-Go config parser. No cgo, no GPU, no
-# safetensors I/O. Runs only if the exe built and the model dir has a
-# config.json. Failure DOES override FINAL_EXIT (load-bearing for D.3,
-# unlike the cgo block which was still in earliest plumbing stage).
-if [ -x "$BUILD_DIR/qwen_runner" ] && [ -f "$MODEL_DIR/config.json" ]; then
+# Phase D.3 step 1 (#189) — config parser; pure Go.
+# Phase D.3 step 2 (#189) — also loads shard 1 via the mlx Go wrapper
+# (now cgo + GPU required). Runs only if the exe built and the model
+# dir has both config.json and shard 1. Failure DOES override
+# FINAL_EXIT (load-bearing for D.3, unlike the still-experimental cgo
+# block).
+if [ -x "$BUILD_DIR/qwen_runner" ] && [ -f "$MODEL_DIR/config.json" ] && [ -f "$MODEL_DIR/$LOAD_SHARD_FILE" ]; then
     RUNNER_STATUS="running"
     RUNNER_START=$(date +%s)
     set +e
-    docker run --rm \
+    docker run --rm --gpus all \
         -v "$BUILD_DIR:/build:ro" \
         -v "$MODEL_DIR:/models:ro" \
+        -e CUDA_VISIBLE_DEVICES=0 \
         --entrypoint bash \
         "$RUNTIME_IMAGE" \
-        -c "/build/qwen_runner -model /models" \
+        -c "/build/qwen_runner -model /models -shard /models/$LOAD_SHARD_FILE" \
         > "$BUILD_DIR/runner.stdout" 2> "$BUILD_DIR/runner.stderr"
     RUNNER_RC=$?
     set -e
@@ -489,6 +493,9 @@ else
     fi
     if [ ! -f "$MODEL_DIR/config.json" ]; then
         echo "qwen_runner: skipped (no $MODEL_DIR/config.json)"
+    fi
+    if [ ! -f "$MODEL_DIR/$LOAD_SHARD_FILE" ]; then
+        echo "qwen_runner: skipped (no $MODEL_DIR/$LOAD_SHARD_FILE)"
     fi
 fi
 

--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -295,7 +295,7 @@ else
               echo "qwen_load_go: skipped Go build (mlx_cabi or mlx archive missing)"
               echo "qwen_runner: skipped Go build (mlx_cabi or mlx archive missing)"
             fi
-            # Pure-Go package tests still always run (don't need libmlx).
+            # Pure-Go package tests always run; no libmlx dependency.
             export GOCACHE="${GOCACHE:-/tmp/gocache}"
             export GOFLAGS="${GOFLAGS:--buildvcs=false}"
             mkdir -p "$GOCACHE"

--- a/x/mlxrunner/go/cmd/qwen_runner/main.go
+++ b/x/mlxrunner/go/cmd/qwen_runner/main.go
@@ -1,9 +1,10 @@
 // qwen_runner — entry point for the Go-side Qwen3.6-35B-A3B-4bit runner
 // on K80 (Phase D.3, #189).
 //
-// Phase D.3 step 1: prints the model config so the package layout +
-// JSON parsing are validated independently of the cgo / MLX surface.
-// Subsequent steps will add weight loading and forward-pass dispatch.
+// Phase D.3 step 1: print the model config (independent of cgo).
+// Phase D.3 step 2: optionally load a safetensors shard via the mlx
+// Go wrapper and report tensor count. Subsequent steps add the
+// multi-shard merge, layer dispatch, and forward pass.
 package main
 
 import (
@@ -11,15 +12,17 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dogkeeper886/ollama37/x/mlxrunner/mlx"
 	qwen "github.com/dogkeeper886/ollama37/x/mlxrunner/models/qwen3_6_a3b"
 )
 
 func main() {
-	var modelPath string
+	var modelPath, shardPath string
 	flag.StringVar(&modelPath, "model", "", "Path to model directory (containing config.json)")
+	flag.StringVar(&shardPath, "shard", "", "Optional .safetensors shard to load + probe via cgo")
 	flag.Parse()
 	if modelPath == "" {
-		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH")
+		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH [-shard SHARD.safetensors]")
 		os.Exit(2)
 	}
 
@@ -42,5 +45,20 @@ func main() {
 	fmt.Printf("qwen_runner: text.num_experts_per_tok = %d\n", cfg.TextConfig.NumExpertsPerTok)
 	fmt.Printf("qwen_runner: quant = bits=%d group_size=%d mode=%s\n",
 		cfg.Quantization.Bits, cfg.Quantization.GroupSize, cfg.Quantization.Mode)
+
+	if shardPath != "" {
+		if err := mlx.Init(); err != nil {
+			fmt.Fprintf(os.Stderr, "qwen_runner: %v\n", err)
+			os.Exit(3)
+		}
+		st, err := mlx.LoadSafetensors(shardPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "qwen_runner: %v\n", err)
+			os.Exit(4)
+		}
+		defer st.Release()
+		fmt.Printf("qwen_runner: shard %s loaded, %d tensors\n", shardPath, st.Count())
+	}
+
 	fmt.Println("qwen_runner: OK")
 }

--- a/x/mlxrunner/go/mlx/mlx.go
+++ b/x/mlxrunner/go/mlx/mlx.go
@@ -1,0 +1,34 @@
+// Package mlx wraps libmlx.a via the C ABI shim in x/mlxrunner/cabi.
+// Phase D.3 step 2 (#189). Built out incrementally as the runner needs
+// more of the cabi surface — start with init + safetensors loading.
+//
+// The cgo preamble lives in this single file (not duplicated across
+// every .go file in the package); other files in the package see the
+// C declarations through the shared cgo header.
+package mlx
+
+// cgo preamble notes:
+//
+//   * Path is package-relative: x/mlxrunner/go/mlx -> ../../cabi.
+//   * LDFLAGS names only; -L paths come from CGO_LDFLAGS at build time
+//     (CI script supplies them, mirroring qwen_load_go's setup).
+//   * Link order: mlx_cabi -> mlx -> CUDA + C++ runtime deps.
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../cabi
+#cgo LDFLAGS: -lmlx_cabi -lmlx -lcublas -lcublasLt -lcudart -lcuda -lstdc++ -lpthread -ldl -lm -lrt
+#include <stdlib.h>
+#include "mlx_cabi.h"
+*/
+import "C"
+
+import "fmt"
+
+// Init pins the default MLX device to GPU and initializes runtime
+// state. Calling more than once is safe but pointless.
+func Init() error {
+	if rc := C.mlx_init(); rc != 0 {
+		return fmt.Errorf("mlx_init failed: rc=%d", int(rc))
+	}
+	return nil
+}

--- a/x/mlxrunner/go/mlx/safetensors.go
+++ b/x/mlxrunner/go/mlx/safetensors.go
@@ -1,0 +1,53 @@
+package mlx
+
+/*
+#include <stdlib.h>
+#include "mlx_cabi.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// SafeTensors is a loaded .safetensors file (name -> array map plus
+// metadata). Release with .Release() when done. Array handles obtained
+// via future Get calls keep their own references and stay valid even
+// after the SafeTensors is released.
+type SafeTensors struct {
+	h C.mlx_safetensors_t
+}
+
+// LoadSafetensors parses a .safetensors file at `path` and pins all
+// tensors into MLX-managed buffers. Errors out on missing files,
+// parse errors, or any exception thrown across the C ABI boundary.
+func LoadSafetensors(path string) (*SafeTensors, error) {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	h := C.mlx_load_safetensors(cpath)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_load_safetensors: failed to load %s", path)
+	}
+	return &SafeTensors{h: h}, nil
+}
+
+// Count returns the number of tensors in the file. Returns -1 if the
+// handle has already been released (programming error — caller is
+// expected to honor lifetime).
+func (s *SafeTensors) Count() int {
+	if s == nil || s.h == nil {
+		return -1
+	}
+	return int(C.mlx_safetensors_count(s.h))
+}
+
+// Release frees the underlying safetensors handle. Safe to call on a
+// nil receiver or one whose handle has already been released.
+func (s *SafeTensors) Release() {
+	if s == nil || s.h == nil {
+		return
+	}
+	C.mlx_safetensors_release(s.h)
+	s.h = nil
+}


### PR DESCRIPTION
## Summary

Extract the cgo surface into a reusable `x/mlxrunner/go/mlx` package, so future model packages don't carry their own cgo preambles. Surface starts with `Init` + `SafeTensors` (load/count/release) — exactly what qwen_runner needs to load shard 1 and prove the wiring works end-to-end.

## Adds

```
x/mlxrunner/go/mlx/
├── mlx.go            # cgo preamble (single source) + Init()
└── safetensors.go    # SafeTensors handle wrapper
```

## Surface (this PR)

```go
mlx.Init() error
mlx.LoadSafetensors(path string) (*mlx.SafeTensors, error)
(*mlx.SafeTensors).Count() int
(*mlx.SafeTensors).Release()
```

Future steps extend with `Array` (release/dtype/dim/size), `Get`, ops wrappers, etc. — incremental, mirroring the C ABI growth.

## qwen_runner changes

`qwen_runner` gets a new `-shard` flag. If set, it imports the mlx package and calls Init + LoadSafetensors + Count + Release. If unset, behavior is unchanged (config-only print). This keeps the pure-Go config path testable independently.

## CI proof — workflow `26564276794` green

```
qwen_runner: architectures = [Qwen3_5MoeForConditionalGeneration]
... (config block unchanged from step 1)
qwen_runner: shard /models/model-00001-of-00004.safetensors loaded, 716 tensors
qwen_runner: OK
```

`716 tensors` matches qwen_load_go's first-line output from PR #210 — the mlx Go wrapper produces the same answer as the bare cgo call, confirming the wrapper is faithful.

The first CI run hit a bash syntax error: an apostrophe inside a `bash -c '...'` heredoc closed the outer quote. Fixed by rewording the comment. Future lint-ci runs should add `bash -n` to catch this class of error locally (one-liner; will fold into a follow-up).

## Phase D.3 step count

| Step | PR | Surface |
|---|---|---|
| 1 | #217 | config.go + qwen_runner skeleton |
| **2** | **THIS** | **mlx pkg: Init + SafeTensors; qwen_runner -shard** |
| 3 | next | Array wrapper + Get; multi-shard merge into Weights map |
| 4 | next | First layer forward (DeltaNet, layer 0) |
| 5 | next | Full 40-layer dispatch loop |
| 6 | next | MoE FFN (256 experts, top-8) |
| 7 | next | Token generation |

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)