### PR TITLE
Phase D.3 step 3: mlx.Array wrapper + SafeTensors.Get (#189)

### DIFF
--- a/x/mlxrunner/go/cmd/qwen_runner/main.go
+++ b/x/mlxrunner/go/cmd/qwen_runner/main.go
@@ -58,6 +58,33 @@ func main() {
 		}
 		defer st.Release()
 		fmt.Printf("qwen_runner: shard %s loaded, %d tensors\n", shardPath, st.Count())
+
+		// Spot-check a couple of known tensors. embed_tokens lives in
+		// shard 1; the values mirror qwen_load_go's first lines so a
+		// regression in the Go wrapper would surface here.
+		probe := []string{
+			"language_model.model.embed_tokens.weight",
+			"language_model.model.embed_tokens.scales",
+		}
+		for _, name := range probe {
+			a := st.Get(name)
+			if a == nil {
+				fmt.Printf("qwen_runner: %s NOT FOUND (skipping)\n", name)
+				continue
+			}
+			fmt.Printf("qwen_runner: %s  dtype=%s shape=%v size=%d\n",
+				name, a.DType(), a.Shape(), a.Size())
+			a.Release()
+		}
+
+		// Negative-case probe: missing tensor returns nil.
+		missing := "language_model.NOT_A_REAL_TENSOR"
+		if a := st.Get(missing); a == nil {
+			fmt.Printf("qwen_runner: %s correctly returned nil\n", missing)
+		} else {
+			fmt.Printf("qwen_runner: %s unexpectedly found, dtype=%s\n", missing, a.DType())
+			a.Release()
+		}
 	}
 
 	fmt.Println("qwen_runner: OK")

--- a/x/mlxrunner/go/mlx/array.go
+++ b/x/mlxrunner/go/mlx/array.go
@@ -1,0 +1,81 @@
+package mlx
+
+/*
+#include "mlx_cabi.h"
+*/
+import "C"
+
+// Array wraps a single mlx::core::array, ref-counted on the C++ side.
+// Each handle holds one reference; calling Release drops it. If you
+// want to keep the array alive past the SafeTensors that produced it,
+// the underlying ref-count makes that safe — but ownership of the
+// Array handle is still yours.
+type Array struct {
+	h C.mlx_array_t
+}
+
+// wrapArray adopts a C-returned handle; not exported because raw
+// handles aren't part of the Go-facing API.
+func wrapArray(h C.mlx_array_t) *Array {
+	if h == nil {
+		return nil
+	}
+	return &Array{h: h}
+}
+
+// Release drops the array's reference. Safe to call on nil or on an
+// already-released Array.
+func (a *Array) Release() {
+	if a == nil || a.h == nil {
+		return
+	}
+	C.mlx_array_release(a.h)
+	a.h = nil
+}
+
+// DType returns the dtype name ("bfloat16", "uint32", "float32", ...).
+// Returns "unknown" if the array is nil or already released.
+func (a *Array) DType() string {
+	if a == nil || a.h == nil {
+		return "unknown"
+	}
+	return C.GoString(C.mlx_array_dtype_name(a.h))
+}
+
+// Ndim returns the number of dimensions; -1 if released.
+func (a *Array) Ndim() int {
+	if a == nil || a.h == nil {
+		return -1
+	}
+	return int(C.mlx_array_ndim(a.h))
+}
+
+// Dim returns the size of `axis`; -1 if released or out of range.
+func (a *Array) Dim(axis int) int64 {
+	if a == nil || a.h == nil {
+		return -1
+	}
+	return int64(C.mlx_array_dim(a.h, C.int(axis)))
+}
+
+// Size returns the product of all dimensions; -1 if released.
+func (a *Array) Size() int64 {
+	if a == nil || a.h == nil {
+		return -1
+	}
+	return int64(C.mlx_array_size(a.h))
+}
+
+// Shape returns the shape as a fresh slice. Convenient for logging
+// (Printf("shape=%v", arr.Shape())).
+func (a *Array) Shape() []int64 {
+	n := a.Ndim()
+	if n <= 0 {
+		return nil
+	}
+	out := make([]int64, n)
+	for i := 0; i < n; i++ {
+		out[i] = a.Dim(i)
+	}
+	return out
+}

--- a/x/mlxrunner/go/mlx/safetensors.go
+++ b/x/mlxrunner/go/mlx/safetensors.go
@@ -42,6 +42,19 @@ func (s *SafeTensors) Count() int {
 	return int(C.mlx_safetensors_count(s.h))
 }
 
+// Get looks up a tensor by name. Returns nil if the tensor isn't in
+// the file. The returned Array holds its own reference and remains
+// valid after the SafeTensors is released — caller still owns it and
+// must Release it.
+func (s *SafeTensors) Get(name string) *Array {
+	if s == nil || s.h == nil {
+		return nil
+	}
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	return wrapArray(C.mlx_safetensors_get(s.h, cname))
+}
+
 // Release frees the underlying safetensors handle. Safe to call on a
 // nil receiver or one whose handle has already been released.
 func (s *SafeTensors) Release() {


### PR DESCRIPTION
## Summary

Extend the mlx Go package with `Array` + `SafeTensors.Get(name)`. qwen_runner can now look up a tensor by name and inspect its metadata (dtype/shape/size) entirely through Go-level idioms — no cgo at the call site.

## Surface added

```go
type Array struct { /* opaque */ }
(*Array).Release()
(*Array).DType()  string      // "bfloat16", "uint32", ...
(*Array).Ndim()   int
(*Array).Dim(axis int) int64
(*Array).Size()   int64
(*Array).Shape()  []int64

(*SafeTensors).Get(name string) *Array   // nil if name not in file
```

## CI proof — workflow `26564659293` green

```
qwen_runner: shard /models/model-00001-of-00004.safetensors loaded, 716 tensors
qwen_runner: language_model.model.embed_tokens.weight  dtype=uint32 shape=[248320 256] size=63569920
qwen_runner: language_model.model.embed_tokens.scales  dtype=bfloat16 shape=[248320 32] size=7946240
qwen_runner: language_model.NOT_A_REAL_TENSOR correctly returned nil
qwen_runner: OK
```

Matches qwen_load_go's baseline from #210 exactly:

| | qwen_runner | qwen_load_go |
|---|---|---|
| embed_tokens.weight | `uint32 [248320, 256]` | `uint32 [248320, 256]` |
| embed_tokens.scales | `bfloat16 [248320, 32]` | `bfloat16 [248320, 32]` |

Negative case also verified: looking up a non-existent name returns nil, no crash.

## Phase D.3 step count

| Step | PR | Surface |
|---|---|---|
| 1 | #217 | config.go + qwen_runner skeleton |
| 2 | #218 | mlx pkg: Init + SafeTensors load/count/release |
| **3** | **THIS** | **mlx.Array + SafeTensors.Get** |
| 4 | next | Index.json parser + multi-shard Weights map |
| 5 | next | First layer forward (DeltaNet, layer 0) |
| 6+ | next | Full dispatch / MoE / generation |

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)