### PR TITLE
Phase D.3 step 4: index.json parser + multi-shard Weights map (#189)

### DIFF
--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -469,7 +469,7 @@ if [ -x "$BUILD_DIR/qwen_runner" ] && [ -f "$MODEL_DIR/config.json" ] && [ -f "$
         -e CUDA_VISIBLE_DEVICES=0 \
         --entrypoint bash \
         "$RUNTIME_IMAGE" \
-        -c "/build/qwen_runner -model /models -shard /models/$LOAD_SHARD_FILE" \
+        -c "/build/qwen_runner -model /models -shard /models/$LOAD_SHARD_FILE -load-weights" \
         > "$BUILD_DIR/runner.stdout" 2> "$BUILD_DIR/runner.stderr"
     RUNNER_RC=$?
     set -e

--- a/x/mlxrunner/go/cmd/qwen_runner/main.go
+++ b/x/mlxrunner/go/cmd/qwen_runner/main.go
@@ -18,11 +18,13 @@ import (
 
 func main() {
 	var modelPath, shardPath string
+	var loadAll bool
 	flag.StringVar(&modelPath, "model", "", "Path to model directory (containing config.json)")
 	flag.StringVar(&shardPath, "shard", "", "Optional .safetensors shard to load + probe via cgo")
+	flag.BoolVar(&loadAll, "load-weights", false, "Load all shards via index.json and probe a few tensors from different shards")
 	flag.Parse()
 	if modelPath == "" {
-		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH [-shard SHARD.safetensors]")
+		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH [-shard SHARD.safetensors] [-load-weights]")
 		os.Exit(2)
 	}
 
@@ -83,6 +85,42 @@ func main() {
 			fmt.Printf("qwen_runner: %s correctly returned nil\n", missing)
 		} else {
 			fmt.Printf("qwen_runner: %s unexpectedly found, dtype=%s\n", missing, a.DType())
+			a.Release()
+		}
+	}
+
+	if loadAll {
+		if shardPath == "" {
+			// mlx.Init wasn't called above; do it now.
+			if err := mlx.Init(); err != nil {
+				fmt.Fprintf(os.Stderr, "qwen_runner: %v\n", err)
+				os.Exit(5)
+			}
+		}
+		w, err := qwen.LoadWeights(modelPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "qwen_runner: load-weights: %v\n", err)
+			os.Exit(6)
+		}
+		defer w.Release()
+		fmt.Printf("qwen_runner: weights loaded, %d tensors across %d shards\n",
+			w.Count(), w.NumShards())
+
+		// Probe tensors that live in different shards, to prove the
+		// index routing works end-to-end (not just shard-1 lookup).
+		probes := []string{
+			"language_model.model.embed_tokens.weight",         // shard 1
+			"language_model.model.layers.0.linear_attn.in_proj_qkv.weight", // shard 1 or 2
+			"language_model.lm_head.weight",                    // shard 4
+		}
+		for _, name := range probes {
+			a := w.Get(name)
+			if a == nil {
+				fmt.Printf("qwen_runner: %s NOT FOUND in index\n", name)
+				continue
+			}
+			fmt.Printf("qwen_runner: %s  shard=%s dtype=%s shape=%v\n",
+				name, w.ShardOf(name), a.DType(), a.Shape())
 			a.Release()
 		}
 	}

--- a/x/mlxrunner/go/models/qwen3_6_a3b/weights.go
+++ b/x/mlxrunner/go/models/qwen3_6_a3b/weights.go
@@ -1,0 +1,155 @@
+package qwen3_6_a3b
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/dogkeeper886/ollama37/x/mlxrunner/mlx"
+)
+
+// WeightIndex is the parsed model.safetensors.index.json: tensor name
+// -> shard filename. The `metadata` block is preserved opaquely so
+// future code can poke at fields like total_size without re-reading
+// the file.
+type WeightIndex struct {
+	Metadata  map[string]any    `json:"metadata"`
+	WeightMap map[string]string `json:"weight_map"`
+}
+
+// LoadIndex parses model.safetensors.index.json from the model dir.
+// Accepts either the dir itself or a direct path to the index file.
+func LoadIndex(path string) (*WeightIndex, error) {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		path = filepath.Join(path, "model.safetensors.index.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read index: %w", err)
+	}
+	var idx WeightIndex
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parse index: %w", err)
+	}
+	if len(idx.WeightMap) == 0 {
+		return nil, fmt.Errorf("index has empty weight_map")
+	}
+	return &idx, nil
+}
+
+// Shards returns the unique shard filenames referenced by the index,
+// sorted lexicographically.
+func (idx *WeightIndex) Shards() []string {
+	seen := map[string]struct{}{}
+	for _, s := range idx.WeightMap {
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Weights ties the index to the actually-loaded shards. Get routes
+// name lookups through the index to the right shard. Release frees
+// every loaded shard.
+type Weights struct {
+	dir    string
+	index  *WeightIndex
+	shards map[string]*mlx.SafeTensors // keyed by shard filename
+}
+
+// LoadWeights parses index.json and loads every shard it references.
+// Failure mid-way releases anything already loaded — leak-free.
+func LoadWeights(modelDir string) (*Weights, error) {
+	idx, err := LoadIndex(modelDir)
+	if err != nil {
+		return nil, err
+	}
+	shards := map[string]*mlx.SafeTensors{}
+	for _, name := range idx.Shards() {
+		st, err := mlx.LoadSafetensors(filepath.Join(modelDir, name))
+		if err != nil {
+			for _, loaded := range shards {
+				loaded.Release()
+			}
+			return nil, fmt.Errorf("load shard %s: %w", name, err)
+		}
+		shards[name] = st
+	}
+	return &Weights{dir: modelDir, index: idx, shards: shards}, nil
+}
+
+// Get fetches a tensor by name via the index. Returns nil if the name
+// isn't in the index or the resolved shard's Get returns nil (which
+// shouldn't happen if the file is consistent with its index, but we
+// don't crash on it). Caller owns the returned Array.
+func (w *Weights) Get(name string) *mlx.Array {
+	if w == nil {
+		return nil
+	}
+	shardName, ok := w.index.WeightMap[name]
+	if !ok {
+		return nil
+	}
+	st, ok := w.shards[shardName]
+	if !ok {
+		return nil
+	}
+	return st.Get(name)
+}
+
+// Count returns the total tensor count across all shards.
+func (w *Weights) Count() int {
+	if w == nil {
+		return 0
+	}
+	return len(w.index.WeightMap)
+}
+
+// NumShards returns how many distinct shard files were loaded.
+func (w *Weights) NumShards() int {
+	if w == nil {
+		return 0
+	}
+	return len(w.shards)
+}
+
+// Names returns all tensor names, sorted. Useful for diagnostics; if
+// you only need a few names, prefer Get directly.
+func (w *Weights) Names() []string {
+	if w == nil {
+		return nil
+	}
+	names := make([]string, 0, len(w.index.WeightMap))
+	for n := range w.index.WeightMap {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ShardOf returns which shard file contains `name`. Returns "" if not
+// in the index.
+func (w *Weights) ShardOf(name string) string {
+	if w == nil {
+		return ""
+	}
+	return w.index.WeightMap[name]
+}
+
+// Release frees every loaded shard. Safe to call on nil or an
+// already-released Weights.
+func (w *Weights) Release() {
+	if w == nil {
+		return
+	}
+	for _, st := range w.shards {
+		st.Release()
+	}
+	w.shards = nil
+}

--- a/x/mlxrunner/go/models/qwen3_6_a3b/weights_test.go
+++ b/x/mlxrunner/go/models/qwen3_6_a3b/weights_test.go
@@ -1,0 +1,64 @@
+package qwen3_6_a3b
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+const sampleIndexJSON = `{
+  "metadata": {"total_size": 12345},
+  "weight_map": {
+    "language_model.model.embed_tokens.weight": "model-00001-of-00004.safetensors",
+    "language_model.model.embed_tokens.scales": "model-00001-of-00004.safetensors",
+    "language_model.lm_head.weight":            "model-00004-of-00004.safetensors",
+    "language_model.model.layers.7.mlp.gate":   "model-00002-of-00004.safetensors",
+    "language_model.model.layers.7.mlp.up":     "model-00002-of-00004.safetensors",
+    "language_model.model.layers.13.norm.w":    "model-00003-of-00004.safetensors"
+  }
+}`
+
+func TestLoadIndex(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "model.safetensors.index.json"),
+		[]byte(sampleIndexJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := LoadIndex(dir)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if got, want := len(idx.WeightMap), 6; got != want {
+		t.Errorf("WeightMap len = %d, want %d", got, want)
+	}
+	want := []string{
+		"model-00001-of-00004.safetensors",
+		"model-00002-of-00004.safetensors",
+		"model-00003-of-00004.safetensors",
+		"model-00004-of-00004.safetensors",
+	}
+	got := idx.Shards()
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Shards = %v, want %v", got, want)
+	}
+}
+
+func TestLoadIndexEmptyMap(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "model.safetensors.index.json"),
+		[]byte(`{"metadata": {}, "weight_map": {}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadIndex(dir); err == nil {
+		t.Error("expected error for empty weight_map, got nil")
+	}
+}
+
+func TestLoadIndexMissing(t *testing.T) {
+	if _, err := LoadIndex("/nonexistent/path"); err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

The `Weights` map is the foundation the rest of D.3 builds on (layer dispatch, forward pass). Every tensor lookup in the inference path will go through here. This PR adds the data structure plus index.json parsing and end-to-end multi-shard verification.

## Surface added (qwen3_6_a3b package)

```go
type WeightIndex struct {
    Metadata  map[string]any
    WeightMap map[string]string  // tensor name -> shard filename
}
LoadIndex(path string) (*WeightIndex, error)
(*WeightIndex).Shards() []string

type Weights struct { /* index + loaded shards */ }
LoadWeights(modelDir string) (*Weights, error)
(*Weights).Get(name string) *mlx.Array      // routes via index
(*Weights).Count() int                       // total tensors
(*Weights).NumShards() int
(*Weights).Names() []string                  // sorted
(*Weights).ShardOf(name string) string
(*Weights).Release()                         // releases all shards
```

Failure mid-way in LoadWeights releases anything already loaded — no leaks.

## CI proof — workflow `26612364669` green

```
qwen_runner: weights loaded, 2090 tensors across 4 shards
qwen_runner: language_model.model.embed_tokens.weight  shard=model-00001-of-00004.safetensors dtype=uint32 shape=[248320 256]
qwen_runner: language_model.model.layers.0.linear_attn.in_proj_qkv.weight  shard=model-00001-of-00004.safetensors dtype=uint32 shape=[8192 256]
qwen_runner: language_model.lm_head.weight  shard=model-00004-of-00004.safetensors dtype=uint32 shape=[248320 256]
qwen_runner: OK
```

| Check | Value |
|---|---|
| Total tensors | 2090 (= 716 + 498 + 504 + 372 from manual `jq` inspection) |
| Routing — embed (shard 1) | ✅ |
| Routing — layer 0 in_proj_qkv (early shard) | ✅ |
| Routing — lm_head (shard 4) | ✅ |
| Cross-shard lookup not double-counted | ✅ |

Production gemma3:4b regression check still passes; cgo + load + p2p blocks unchanged.

## Why both `-shard` and `-load-weights`?

They test different code paths:
- `-shard` exercises `SafeTensors.Get` + metadata wrappers (PRs #218, #219).
- `-load-weights` exercises index routing + multi-shard `Weights.Get`.

Keeping both means a regression in either path surfaces immediately.

## Phase D.3 step count

| Step | PR | Surface |
|---|---|---|
| 1 | #217 | config.go + qwen_runner skeleton |
| 2 | #218 | mlx pkg: Init + SafeTensors load/count/release |
| 3 | #219 | mlx.Array + SafeTensors.Get |
| **4** | **THIS** | **WeightIndex + Weights multi-shard map** |
| 5 | next | First DeltaNet layer forward (real cgo ops, real weights) |
| 6+ | next | Full dispatch / MoE / generation |

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)