### PR TITLE
Phase D.3 step 5a: mlx Go op wrappers + qwen_runner mirrors qwen_load_go (#189)

### DIFF
--- a/cicd/scripts/test-mlx-smoke.sh
+++ b/cicd/scripts/test-mlx-smoke.sh
@@ -469,7 +469,7 @@ if [ -x "$BUILD_DIR/qwen_runner" ] && [ -f "$MODEL_DIR/config.json" ] && [ -f "$
         -e CUDA_VISIBLE_DEVICES=0 \
         --entrypoint bash \
         "$RUNTIME_IMAGE" \
-        -c "/build/qwen_runner -model /models -shard /models/$LOAD_SHARD_FILE -load-weights" \
+        -c "/build/qwen_runner -model /models -shard /models/$LOAD_SHARD_FILE -load-weights -probe-ops" \
         > "$BUILD_DIR/runner.stdout" 2> "$BUILD_DIR/runner.stderr"
     RUNNER_RC=$?
     set -e

--- a/x/mlxrunner/go/cmd/qwen_runner/main.go
+++ b/x/mlxrunner/go/cmd/qwen_runner/main.go
@@ -18,14 +18,18 @@ import (
 
 func main() {
 	var modelPath, shardPath string
-	var loadAll bool
+	var loadAll, probeOps bool
 	flag.StringVar(&modelPath, "model", "", "Path to model directory (containing config.json)")
 	flag.StringVar(&shardPath, "shard", "", "Optional .safetensors shard to load + probe via cgo")
 	flag.BoolVar(&loadAll, "load-weights", false, "Load all shards via index.json and probe a few tensors from different shards")
+	flag.BoolVar(&probeOps, "probe-ops", false, "Run the qwen_load_go op chain against real weights (mirrors PR #210/#216 output). Implies -load-weights.")
 	flag.Parse()
 	if modelPath == "" {
-		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH [-shard SHARD.safetensors] [-load-weights]")
+		fmt.Fprintln(os.Stderr, "usage: qwen_runner -model PATH [-shard SHARD.safetensors] [-load-weights] [-probe-ops]")
 		os.Exit(2)
+	}
+	if probeOps {
+		loadAll = true
 	}
 
 	cfg, err := qwen.LoadConfig(modelPath)
@@ -123,7 +127,197 @@ func main() {
 				name, w.ShardOf(name), a.DType(), a.Shape())
 			a.Release()
 		}
+
+		if probeOps {
+			if err := runProbeOps(w); err != nil {
+				fmt.Fprintf(os.Stderr, "qwen_runner: probe-ops: %v\n", err)
+				os.Exit(7)
+			}
+		}
 	}
 
 	fmt.Println("qwen_runner: OK")
+}
+
+// runProbeOps replays qwen_load_go's full 5-stage chain (#216) on real
+// layer-0 weights to validate the Go wrapper surface. Output should
+// match qwen_load_go byte-for-byte; any drift means a wrapper bug.
+//
+// Stages:
+//   1. take(embed, [42]) + dequantize     -> bf16 [1, 2048]
+//   2. rms_norm(stage1, input_layernorm)  -> bf16 [1, 2048]
+//   3. quantized_matmul(stage2, in_proj_qkv) -> bf16 [1, 8192]
+//   4. conv1d(ones([1,4,8192]), layer0.conv1d.w, groups=8192) -> bf16 [1,1,8192]
+//   5. silu(stage4) = sigmoid * x         -> bf16 [1, 1, 8192]
+func runProbeOps(w *qwen.Weights) error {
+	wq := w.Get("language_model.model.embed_tokens.weight")
+	sc := w.Get("language_model.model.embed_tokens.scales")
+	bs := w.Get("language_model.model.embed_tokens.biases")
+	if wq == nil || sc == nil || bs == nil {
+		return fmt.Errorf("missing embed_tokens tensors")
+	}
+	defer wq.Release()
+	defer sc.Release()
+	defer bs.Release()
+
+	// Stage 1: take + dequant of row 42.
+	idx, err := mlx.FromInt32([]int32{42})
+	if err != nil {
+		return err
+	}
+	defer idx.Release()
+	wqRow, err := wq.Take(idx, 0)
+	if err != nil {
+		return err
+	}
+	defer wqRow.Release()
+	scRow, err := sc.Take(idx, 0)
+	if err != nil {
+		return err
+	}
+	defer scRow.Release()
+	bsRow, err := bs.Take(idx, 0)
+	if err != nil {
+		return err
+	}
+	defer bsRow.Release()
+	full, err := mlx.Dequantize(wqRow, scRow, bsRow, 64, 4, "affine")
+	if err != nil {
+		return err
+	}
+	defer full.Release()
+	if err := mlx.Eval(full); err != nil {
+		return err
+	}
+	fmt.Printf("qwen_runner: dequantize(embed row 42)  dtype=%s shape=%v size=%d\n",
+		full.DType(), full.Shape(), full.Size())
+	if err := printFirst5(full, "dequant row 42"); err != nil {
+		return err
+	}
+
+	// Stage 2: rms_norm with layer-0 input_layernorm gain.
+	normGain := w.Get("language_model.model.layers.0.input_layernorm.weight")
+	if normGain == nil {
+		return fmt.Errorf("missing input_layernorm.weight")
+	}
+	defer normGain.Release()
+	normed, err := mlx.RMSNorm(full, normGain, 1e-6)
+	if err != nil {
+		return err
+	}
+	defer normed.Release()
+	if err := printFirst5(normed, "rms_norm(dequant row 42)"); err != nil {
+		return err
+	}
+	absMean, err := scalarAbsMean(normed)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("qwen_runner: rms_norm abs_mean=%g\n", absMean)
+
+	// Stage 3: quantized_matmul through layer-0 in_proj_qkv.
+	qkvW := w.Get("language_model.model.layers.0.linear_attn.in_proj_qkv.weight")
+	qkvS := w.Get("language_model.model.layers.0.linear_attn.in_proj_qkv.scales")
+	qkvB := w.Get("language_model.model.layers.0.linear_attn.in_proj_qkv.biases")
+	if qkvW == nil || qkvS == nil || qkvB == nil {
+		return fmt.Errorf("missing in_proj_qkv tensors")
+	}
+	defer qkvW.Release()
+	defer qkvS.Release()
+	defer qkvB.Release()
+	qkv, err := mlx.QuantizedMatmul(normed, qkvW, qkvS, qkvB, true, 64, 4, "affine")
+	if err != nil {
+		return err
+	}
+	defer qkv.Release()
+	fmt.Printf("qwen_runner: in_proj_qkv(rms_normed) shape=%v\n", qkv.Shape())
+	if err := printFirst5(qkv, "in_proj_qkv"); err != nil {
+		return err
+	}
+
+	// Stage 4: conv1d on synthetic ones input. Groups=8192 = depthwise.
+	convW := w.Get("language_model.model.layers.0.linear_attn.conv1d.weight")
+	if convW == nil {
+		return fmt.Errorf("missing conv1d.weight")
+	}
+	defer convW.Release()
+	convIn, err := mlx.Ones([]int64{1, 4, 8192}, "bfloat16")
+	if err != nil {
+		return err
+	}
+	defer convIn.Release()
+	convOut, err := mlx.Conv1d(convIn, convW, 1, 0, 1, 8192)
+	if err != nil {
+		return err
+	}
+	defer convOut.Release()
+	fmt.Printf("qwen_runner: conv1d(ones, layer_0.conv1d.w) shape=%v\n", convOut.Shape())
+	if err := printFirst5(convOut, "conv1d"); err != nil {
+		return err
+	}
+
+	// Stage 5: silu = sigmoid(x) * x.
+	sig, err := convOut.Sigmoid()
+	if err != nil {
+		return err
+	}
+	defer sig.Release()
+	silu, err := sig.Multiply(convOut)
+	if err != nil {
+		return err
+	}
+	defer silu.Release()
+	if err := printFirst5(silu, "silu(conv1d)"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// printFirst5 astype-fp32s, evals, copies the first 5 values to host,
+// and prints. Same shape as qwen_load_go's first5OfArray helper so
+// the output lines line up for byte-for-byte comparison.
+func printFirst5(arr *mlx.Array, label string) error {
+	f32, err := arr.ToFloat32()
+	if err != nil {
+		return err
+	}
+	defer f32.Release()
+	if err := mlx.Eval(f32); err != nil {
+		return err
+	}
+	out := make([]float32, 5)
+	n, err := f32.CopyFloat32(out)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("qwen_runner: %s first %d = %v\n", label, n, out[:n])
+	return nil
+}
+
+// scalarAbsMean evaluates abs(arr).mean() and extracts the scalar.
+func scalarAbsMean(arr *mlx.Array) (float32, error) {
+	a, err := arr.Abs()
+	if err != nil {
+		return 0, err
+	}
+	defer a.Release()
+	m, err := a.MeanAll()
+	if err != nil {
+		return 0, err
+	}
+	defer m.Release()
+	f32, err := m.ToFloat32()
+	if err != nil {
+		return 0, err
+	}
+	defer f32.Release()
+	if err := mlx.Eval(f32); err != nil {
+		return 0, err
+	}
+	out := make([]float32, 1)
+	if _, err := f32.CopyFloat32(out); err != nil {
+		return 0, err
+	}
+	return out[0], nil
 }

--- a/x/mlxrunner/go/mlx/ops.go
+++ b/x/mlxrunner/go/mlx/ops.go
@@ -1,0 +1,247 @@
+package mlx
+
+/*
+#include <stdlib.h>
+#include "mlx_cabi.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// ----- construction -----
+
+// FromInt32 wraps a Go []int32 as a 1-D int32 mlx::array. The data is
+// copied (the C side owns its own buffer afterward).
+func FromInt32(data []int32) (*Array, error) {
+	var ptr *C.int
+	if len(data) > 0 {
+		ptr = (*C.int)(unsafe.Pointer(&data[0]))
+	}
+	h := C.mlx_array_from_int32_1d(ptr, C.int(len(data)))
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_from_int32_1d failed (len=%d)", len(data))
+	}
+	return wrapArray(h), nil
+}
+
+// Ones constructs an all-ones array of the requested shape and dtype.
+// dtype is "float32" or "bfloat16" (the inference-path dtypes; other
+// names return an error).
+func Ones(shape []int64, dtype string) (*Array, error) {
+	var ptr *C.longlong
+	if len(shape) > 0 {
+		ptr = (*C.longlong)(unsafe.Pointer(&shape[0]))
+	}
+	cdt := C.CString(dtype)
+	defer C.free(unsafe.Pointer(cdt))
+	h := C.mlx_array_ones(ptr, C.int(len(shape)), cdt)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_ones failed (shape=%v dtype=%s)", shape, dtype)
+	}
+	return wrapArray(h), nil
+}
+
+// ----- unary ops -----
+
+// Sigmoid returns elementwise sigmoid(a). Combine with Multiply for silu.
+func (a *Array) Sigmoid() (*Array, error) {
+	if a == nil || a.h == nil {
+		return nil, fmt.Errorf("Sigmoid: nil array")
+	}
+	h := C.mlx_array_sigmoid(a.h)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_sigmoid failed")
+	}
+	return wrapArray(h), nil
+}
+
+// Abs returns elementwise absolute value.
+func (a *Array) Abs() (*Array, error) {
+	if a == nil || a.h == nil {
+		return nil, fmt.Errorf("Abs: nil array")
+	}
+	h := C.mlx_array_abs(a.h)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_abs failed")
+	}
+	return wrapArray(h), nil
+}
+
+// MeanAll reduces over all axes (no keepdims) and returns a scalar
+// array. For per-axis mean, add an axis-aware mean op later.
+func (a *Array) MeanAll() (*Array, error) {
+	if a == nil || a.h == nil {
+		return nil, fmt.Errorf("MeanAll: nil array")
+	}
+	h := C.mlx_array_mean_all(a.h)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_mean_all failed")
+	}
+	return wrapArray(h), nil
+}
+
+// ToFloat32 returns an astype'd copy in float32. Always call this
+// before CopyFloat32 — reading BF16/FP16 bytes through a float lens
+// gives denormal garbage (see PR #199).
+func (a *Array) ToFloat32() (*Array, error) {
+	if a == nil || a.h == nil {
+		return nil, fmt.Errorf("ToFloat32: nil array")
+	}
+	h := C.mlx_array_to_float32(a.h)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_to_float32 failed")
+	}
+	return wrapArray(h), nil
+}
+
+// ----- binary ops -----
+
+// Multiply returns elementwise a*b.
+func (a *Array) Multiply(b *Array) (*Array, error) {
+	if a == nil || a.h == nil || b == nil || b.h == nil {
+		return nil, fmt.Errorf("Multiply: nil array")
+	}
+	h := C.mlx_array_multiply(a.h, b.h)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_multiply failed")
+	}
+	return wrapArray(h), nil
+}
+
+// Take gathers rows along `axis` using the indices array. Equivalent
+// to numpy a[indices, ...] when axis=0.
+func (a *Array) Take(indices *Array, axis int) (*Array, error) {
+	if a == nil || a.h == nil || indices == nil || indices.h == nil {
+		return nil, fmt.Errorf("Take: nil array")
+	}
+	h := C.mlx_array_take(a.h, indices.h, C.int(axis))
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_take failed")
+	}
+	return wrapArray(h), nil
+}
+
+// ----- multi-arg numeric ops -----
+
+// Dequantize unpacks a quantized weight matrix. `biases` may be nil
+// for non-affine modes. mode is typically "affine" or "fp".
+func Dequantize(wq, scales, biases *Array, groupSize, bits int, mode string) (*Array, error) {
+	if wq == nil || wq.h == nil || scales == nil || scales.h == nil {
+		return nil, fmt.Errorf("Dequantize: wq and scales required")
+	}
+	var bh C.mlx_array_t
+	if biases != nil {
+		bh = biases.h
+	}
+	cmode := C.CString(mode)
+	defer C.free(unsafe.Pointer(cmode))
+	h := C.mlx_array_dequantize(wq.h, scales.h, bh, C.int(groupSize), C.int(bits), cmode)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_dequantize failed (gs=%d bits=%d mode=%s)",
+			groupSize, bits, mode)
+	}
+	return wrapArray(h), nil
+}
+
+// RMSNorm runs MLX's fast::rms_norm. `weight` may be nil for no-gain
+// (the implementation treats nil as a one-vector).
+func RMSNorm(x, weight *Array, eps float32) (*Array, error) {
+	if x == nil || x.h == nil {
+		return nil, fmt.Errorf("RMSNorm: nil x")
+	}
+	var wh C.mlx_array_t
+	if weight != nil {
+		wh = weight.h
+	}
+	h := C.mlx_array_rms_norm(x.h, wh, C.float(eps))
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_rms_norm failed (eps=%g)", eps)
+	}
+	return wrapArray(h), nil
+}
+
+// QuantizedMatmul runs MLX's quantized_matmul. biases may be nil for
+// non-affine modes; transpose toggles wq^T.
+func QuantizedMatmul(x, wq, scales, biases *Array, transpose bool,
+	groupSize, bits int, mode string) (*Array, error) {
+	if x == nil || x.h == nil || wq == nil || wq.h == nil || scales == nil || scales.h == nil {
+		return nil, fmt.Errorf("QuantizedMatmul: x, wq, scales required")
+	}
+	var bh C.mlx_array_t
+	if biases != nil {
+		bh = biases.h
+	}
+	cmode := C.CString(mode)
+	defer C.free(unsafe.Pointer(cmode))
+	var tr C.int
+	if transpose {
+		tr = 1
+	}
+	h := C.mlx_array_quantized_matmul(x.h, wq.h, scales.h, bh, tr,
+		C.int(groupSize), C.int(bits), cmode)
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_quantized_matmul failed (gs=%d bits=%d mode=%s)",
+			groupSize, bits, mode)
+	}
+	return wrapArray(h), nil
+}
+
+// Conv1d runs a 1-D convolution. Input shape (B, L, C_in); weight
+// shape (C_out, kernel_w, C_in/groups). All ints follow MLX's
+// convention (no auto-broadcast of group count, etc.).
+func Conv1d(input, weight *Array, stride, padding, dilation, groups int) (*Array, error) {
+	if input == nil || input.h == nil || weight == nil || weight.h == nil {
+		return nil, fmt.Errorf("Conv1d: input and weight required")
+	}
+	h := C.mlx_array_conv1d(input.h, weight.h,
+		C.int(stride), C.int(padding), C.int(dilation), C.int(groups))
+	if h == nil {
+		return nil, fmt.Errorf("mlx_array_conv1d failed")
+	}
+	return wrapArray(h), nil
+}
+
+// ----- evaluation + data extraction -----
+
+// Eval forces evaluation of zero or more arrays in place. Required
+// before reading data via CopyFloat32 (which only reads materialized
+// host buffers).
+func Eval(arrs ...*Array) error {
+	if len(arrs) == 0 {
+		return nil
+	}
+	handles := make([]C.mlx_array_t, len(arrs))
+	for i, a := range arrs {
+		if a == nil || a.h == nil {
+			return fmt.Errorf("Eval: arr[%d] is nil", i)
+		}
+		handles[i] = a.h
+	}
+	rc := C.mlx_eval(&handles[0], C.int(len(handles)))
+	if rc != 0 {
+		return fmt.Errorf("mlx_eval failed: rc=%d", int(rc))
+	}
+	return nil
+}
+
+// CopyFloat32 copies up to len(out) float values from the array's
+// host buffer into out. The array MUST be (a) eval'd already and (b)
+// dtype == float32 (call ToFloat32 first if needed). Returns the
+// number of values actually copied.
+func (a *Array) CopyFloat32(out []float32) (int, error) {
+	if a == nil || a.h == nil {
+		return 0, fmt.Errorf("CopyFloat32: nil array")
+	}
+	if len(out) == 0 {
+		return 0, nil
+	}
+	n := C.mlx_array_copy_float(a.h,
+		(*C.float)(unsafe.Pointer(&out[0])), C.int(len(out)))
+	if n < 0 {
+		return 0, fmt.Errorf("mlx_array_copy_float failed: rc=%d (likely wrong dtype — astype to float32 first)", int(n))
+	}
+	return int(n), nil
+}


### PR DESCRIPTION
## Summary

The Go wrapper surface for every cabi op, validated end-to-end by having qwen_runner replay qwen_load_go's full 5-stage chain via the new Go API. Output is byte-for-byte identical — the proof-of-correctness boundary for the wrappers.

## Surface added (mlx package)

```go
// Construction
mlx.FromInt32(data []int32) (*Array, error)
mlx.Ones(shape []int64, dtype string) (*Array, error)

// Unary (methods on *Array)
(*Array).Sigmoid()    (*Array, error)
(*Array).Abs()        (*Array, error)
(*Array).MeanAll()    (*Array, error)
(*Array).ToFloat32()  (*Array, error)

// Binary (methods)
(*Array).Multiply(b *Array)         (*Array, error)
(*Array).Take(indices *Array, axis int) (*Array, error)

// Multi-arg numeric (package funcs)
mlx.Dequantize(wq, scales, biases *Array, groupSize, bits int, mode string) (*Array, error)
mlx.RMSNorm(x, weight *Array, eps float32) (*Array, error)
mlx.QuantizedMatmul(x, wq, scales, biases *Array, transpose bool, groupSize, bits int, mode string) (*Array, error)
mlx.Conv1d(input, weight *Array, stride, padding, dilation, groups int) (*Array, error)

// Eval + data extraction
mlx.Eval(arrs ...*Array) error
(*Array).CopyFloat32(out []float32) (int, error)
```

Design choices:
- Methods for unary/binary that read naturally as `a.Sigmoid()` / `a.Multiply(b)`.
- Package funcs for multi-arg (3+ inputs).
- All ops return `(*Array, error)` — nil array + descriptive error if the underlying cabi call fails.
- biases / weight allowed as nil where MLX semantics permit it.

## CI proof — workflow `26615213283` green

| Stage | qwen_runner (this PR, Go wrappers) | qwen_load_go (PR #216, raw cgo) |
|---|---|---|
| dequant first 5 | `[0 0 -0.009643555 -0.009643555 0.006439209]` | identical |
| rms_norm first 5 | `[0 0 -1.09375 -1.0078125 0.7109375]` | identical |
| rms_norm abs_mean | `0.65234375` | identical |
| in_proj_qkv first 5 | `[2.015625 -0.10546875 -1.15625 -0.25976562 -0.059326172]` | identical |
| conv1d first 5 | `[-0.061767578 -0.045898438 0.067871094 0.04321289 0.037109375]` | identical |
| silu first 5 | `[-0.029907227 -0.022460938 0.03491211 0.022094727 0.018798828]` | identical |

Every wrapper produces the same bytes as the raw cgo call.

`-shard` + `-load-weights` blocks unchanged and still green; cgo block (qwen_load_go) still green; production gemma3:4b regression check still green.

## Why fold into qwen_runner instead of a unit test?

`go test` would need libmlx.a + libmlx_cabi.a + a GPU + 19GB of weights mounted. The CI workflow already has all of those wired up; replaying qwen_load_go's chain at the end of the qwen_runner invocation is the cheapest, most direct correctness check. The wrappers are static enough that a unit test would mostly be testing cgo, not behavior.

## Phase D.3 step count

| Step | PR | Surface |
|---|---|---|
| 1 | #217 | config.go + qwen_runner skeleton |
| 2 | #218 | mlx pkg: Init + SafeTensors |
| 3 | #219 | mlx.Array + SafeTensors.Get |
| 4 | #220 | WeightIndex + multi-shard Weights |
| **5a** | **THIS** | **All op wrappers + chain-correctness probe** |
| 5b | next | First DeltaNet layer forward (real Go-side layer, not just a probe replay) |
| 6+ | next | 40-layer dispatch / MoE / generation |

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)