### PR TITLE
Phase D.3 step 5b: Model struct in qwen3_6_a3b package (#189)

### DIFF
--- a/x/mlxrunner/go/cmd/qwen_runner/main.go
+++ b/x/mlxrunner/go/cmd/qwen_runner/main.go
@@ -37,6 +37,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "qwen_runner: %v\n", err)
 		os.Exit(1)
 	}
+	// Config is read first (always) so the config-only path doesn't
+	// need cgo / GPU. Model construction (config + weights bundled) is
+	// only triggered when -load-weights or -probe-ops asks for it.
 
 	fmt.Printf("qwen_runner: architectures = %v\n", cfg.Architectures)
 	fmt.Printf("qwen_runner: model_type = %s\n", cfg.ModelType)
@@ -101,12 +104,16 @@ func main() {
 				os.Exit(5)
 			}
 		}
-		w, err := qwen.LoadWeights(modelPath)
+		// Use LoadModel so the Config + Weights live behind one handle
+		// — that's the receiver the forward-pass methods will hang off
+		// in subsequent D.3 steps.
+		m, err := qwen.LoadModel(modelPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "qwen_runner: load-weights: %v\n", err)
+			fmt.Fprintf(os.Stderr, "qwen_runner: load-model: %v\n", err)
 			os.Exit(6)
 		}
-		defer w.Release()
+		defer m.Close()
+		w := m.Weights
 		fmt.Printf("qwen_runner: weights loaded, %d tensors across %d shards\n",
 			w.Count(), w.NumShards())
 

--- a/x/mlxrunner/go/models/qwen3_6_a3b/model.go
+++ b/x/mlxrunner/go/models/qwen3_6_a3b/model.go
@@ -1,0 +1,36 @@
+package qwen3_6_a3b
+
+import "fmt"
+
+// Model bundles parsed config + loaded weights into one handle. The
+// forward-pass methods (added in subsequent D.3 steps) hang off this
+// type. Caller must Close to release the underlying shards.
+type Model struct {
+	Config  *Config
+	Weights *Weights
+}
+
+// LoadModel reads config.json from modelDir, then loads every shard
+// referenced by model.safetensors.index.json. Failure mid-way releases
+// whatever already loaded — no leaks.
+func LoadModel(modelDir string) (*Model, error) {
+	cfg, err := LoadConfig(modelDir)
+	if err != nil {
+		return nil, fmt.Errorf("LoadModel: %w", err)
+	}
+	w, err := LoadWeights(modelDir)
+	if err != nil {
+		return nil, fmt.Errorf("LoadModel: %w", err)
+	}
+	return &Model{Config: cfg, Weights: w}, nil
+}
+
+// Close releases the weights. Safe to call on a nil Model or one
+// that's already been closed.
+func (m *Model) Close() {
+	if m == nil {
+		return
+	}
+	m.Weights.Release()
+	m.Weights = nil
+}


### PR DESCRIPTION
## Summary

Small but load-bearing refactor: bundle Config + Weights behind a single `Model` handle. This is the receiver that the forward-pass methods will hang off in subsequent D.3 steps — establishing the seam before any layer code lands.

## Surface added

```go
type Model struct {
    Config  *Config
    Weights *Weights
}

LoadModel(modelDir string) (*Model, error)  // failure-safe (no leaks)
(*Model).Close()
```

`LoadModel` chains `LoadConfig` → `LoadWeights` with proper cleanup on partial failure.

## qwen_runner change

`-load-weights` path now constructs a `Model` instead of calling `LoadWeights` directly. Behavior identical:

```
qwen_runner: rms_norm(dequant row 42) first 5 = [0 0 -1.09375 -1.0078125 0.7109375]
qwen_runner: rms_norm abs_mean=0.65234375
qwen_runner: in_proj_qkv(rms_normed) shape=[1 8192]
qwen_runner: in_proj_qkv first 5 = [2.015625 -0.10546875 -1.15625 -0.25976562 -0.059326172]
qwen_runner: conv1d(ones, layer_0.conv1d.w) shape=[1 1 8192]
qwen_runner: conv1d first 5 = [-0.061767578 -0.045898438 0.067871094 0.04321289 0.037109375]
qwen_runner: silu(conv1d) first 5 = [-0.029907227 -0.022460938 0.03491211 0.022094727 0.018798828]
qwen_runner: OK
```

Workflow `26615673405` — green. Output matches PR #221 byte-for-byte.

## Why this is a separate (small) PR

The DeltaNet forward pass needs a handful of ops we haven't wrapped yet (split, exp, softplus, regular matmul) plus the recurrence body. Rather than land a half-built layer in one PR, this carves off the foundational seam (`Model` as receiver) cleanly so the next PR can focus purely on op gaps + layer logic.

## Phase D.3 step count

| Step | PR | Surface |
|---|---|---|
| 1 | #217 | config.go + qwen_runner skeleton |
| 2 | #218 | mlx pkg: Init + SafeTensors |
| 3 | #219 | mlx.Array + SafeTensors.Get |
| 4 | #220 | WeightIndex + multi-shard Weights |
| 5a | #221 | All op wrappers + probe-ops chain |
| **5b** | **THIS** | **Model struct (Config + Weights) + LoadModel** |
| 5c | next | Missing ops (split, exp, softplus, matmul, ...) + cabi additions |
| 5d | next | Real Layer0Forward (input -> output through real DeltaNet attention) |

Part of #187 / #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)