### PR TITLE
Fix broken cicd/ links to deleted SKILL.md (#225)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,3 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
-
----
-
-## Open follow-ups
-
-- #225 — `.claude/skills/test-workflow-pattern/SKILL.md` was removed in #224 (STORY-001) but three live references remain in `cicd/README.md`, `cicd/docs/CICD.md`, `cicd/scripts/benchmark-throughput.sh`. Fix the broken links.

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -90,7 +90,7 @@ These workflows execute the YAML test suites via the TypeScript runner with the 
 
 ### Perf / experiment workflows (the unified test-workflow pattern)
 
-These follow the contract documented in [`.claude/skills/test-workflow-pattern/SKILL.md`](../.claude/skills/test-workflow-pattern/SKILL.md): one extracted bash script per workflow at `cicd/scripts/test-<name>.sh`, sourcing shared helpers from `cicd/scripts/lib/`, emitting structured JSON to `/tmp/test-<name>-results.json`.
+These follow a shared contract: one extracted bash script per workflow at `cicd/scripts/test-<name>.sh`, sourcing shared helpers from `cicd/scripts/lib/`, emitting structured JSON to `/tmp/test-<name>-results.json`. Full bullet list in [`docs/CICD.md`](docs/CICD.md) → "Perf / experiment workflows".
 
 | Workflow | Script | Description |
 |----------|--------|-------------|

--- a/cicd/docs/CICD.md
+++ b/cicd/docs/CICD.md
@@ -247,7 +247,7 @@ Runs all test suites in sequence: build → runtime → inference → models. Th
 
 ### Perf / experiment workflows (separate pattern)
 
-The TC framework above handles **correctness validation** — "did this model load and produce coherent output?". Performance benchmarks and experiments live alongside under a separate, simpler contract documented in [`.claude/skills/test-workflow-pattern/SKILL.md`](../../.claude/skills/test-workflow-pattern/SKILL.md):
+The TC framework above handles **correctness validation** — "did this model load and produce coherent output?". Performance benchmarks and experiments live alongside under a separate, simpler contract:
 
 - One extracted bash script per workflow at `cicd/scripts/test-<name>.sh`
 - Shared helpers in `cicd/scripts/lib/` (response capture, simple check, LLM judge wrapper, container log snip)

--- a/cicd/scripts/benchmark-throughput.sh
+++ b/cicd/scripts/benchmark-throughput.sh
@@ -25,10 +25,9 @@
 #
 # Exit status: non-zero if any model fails the output check (simple or dual).
 #
-# Implementation note: this script follows the unified test-workflow pattern
-# (.claude/skills/test-workflow-pattern/SKILL.md). Generic operations are
-# sourced from cicd/scripts/lib/ — only throughput-specific orchestration
-# (banner, GPU info, results table) lives here.
+# Implementation note: this script follows the unified test-workflow pattern.
+# Generic operations are sourced from cicd/scripts/lib/ — only throughput-specific
+# orchestration (banner, GPU info, results table) lives here.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Fixes #225 — three live hyperlinks/path references to the now-deleted `.claude/skills/test-workflow-pattern/SKILL.md` (removed in PR #224 / STORY-001) updated to drop the broken link, keep the prose.
- The contract the deleted file documented is already inlined at `cicd/docs/CICD.md` → "Perf / experiment workflows (separate pattern)" — single source of truth, no info loss.
- Also removes the temporary "Open follow-ups #225" tail line from `CLAUDE.md` (added in PR #224, resolved by this PR).

## Files

- `CLAUDE.md` — drop the "Open follow-ups #225" tail (now stale).
- `cicd/README.md:93` — drop hyperlink, add cross-link to `docs/CICD.md` for the bullet list.
- `cicd/docs/CICD.md:250` — drop hyperlink, keep the contract bullets that follow.
- `cicd/scripts/benchmark-throughput.sh:28-31` — drop the parenthetical reference in the comment.

## Test plan

- [ ] `grep -rn "\.claude/skills" cicd/` returns nothing.
- [ ] No broken `[\`.claude/skills/...\`]` markdown links anywhere in the diff.
- [ ] `cicd/README.md` and `cicd/docs/CICD.md` render in the GitHub PR view without orphan brackets.
- [ ] `CLAUDE.md` tail no longer references issue #225.

## Out of scope

- Two `.github/workflows/*.yml` comments use the phrase "test-workflow-pattern (#158)" as a concept name with backlink — not broken links, just terminology. Left alone.
- Historical docs (`docs/evolve/`, `docs/research/`, etc.) — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)