### PR TITLE
Add TS perf helpers (capture / gpu / content-check)

### DIFF
--- a/cicd/tests/src/perf/capture.ts
+++ b/cicd/tests/src/perf/capture.ts
@@ -57,8 +57,11 @@ export async function captureResponse(
     options: { temperature: 0, seed: 42, num_predict: numPredict, num_ctx: numCtx },
   });
 
-  if (!raw || typeof raw !== 'object') {
-    throw new Error(`captureResponse: no response from ${model} at ${host}`);
+  // fetch does not throw on HTTP 4xx; ollama returns {error: "..."} for an
+  // unknown/unloadable model. Treat that as a failure (parity with curl -sf)
+  // rather than reporting a misleading all-zeros record.
+  if (!raw || typeof raw !== 'object' || raw.error) {
+    throw new Error(`captureResponse: ${model} at ${host} — ${raw?.error ?? 'no/invalid response'}`);
   }
 
   const result: CaptureResult = {

--- a/cicd/tests/src/perf/capture.ts
+++ b/cicd/tests/src/perf/capture.ts
@@ -1,0 +1,81 @@
+/**
+ * Call ollama /api/generate and project an enriched, typed perf record
+ * (port of cicd/scripts/lib/response_capture.sh).
+ *
+ * Sequence: warmup (1-token prime → loads model) → deterministic benchmark
+ * generate (temperature 0, seed 42) → unload (keep_alive:0). `response` and
+ * `thinking` are kept separate so a thinking model with an empty `response`
+ * is still judged on its real output.
+ */
+export interface CaptureResult {
+  model: string;
+  inTokens: number;
+  outTokens: number;
+  promptEvalTps: number;
+  evalTps: number;
+  totalDurationS: number;
+  loadDurationS: number;
+  doneReason: string;
+  response: string;
+  thinking: string;
+}
+
+/** Round to 2 decimals, matching the bash `* 100 | round / 100`. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** tokens / (duration_ns / 1e9), or 0 when duration is non-positive. */
+function tps(count: number, durationNs: number): number {
+  return durationNs > 0 ? round2(count / (durationNs / 1e9)) : 0;
+}
+
+async function generate(host: string, body: Record<string, unknown>): Promise<any> {
+  const res = await fetch(`${host}/api/generate`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+export async function captureResponse(
+  host: string,
+  model: string,
+  prompt: string,
+  numPredict = 128,
+  numCtx = 2048
+): Promise<CaptureResult> {
+  // Warmup: load the model + prime caches (ignore failures).
+  await generate(host, { model, prompt: 'Hi', stream: false, options: { num_predict: 1, num_ctx: numCtx } }).catch(() => {});
+
+  // Benchmark call (deterministic).
+  const raw = await generate(host, {
+    model,
+    prompt,
+    stream: false,
+    options: { temperature: 0, seed: 42, num_predict: numPredict, num_ctx: numCtx },
+  });
+
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`captureResponse: no response from ${model} at ${host}`);
+  }
+
+  const result: CaptureResult = {
+    model,
+    inTokens: raw.prompt_eval_count ?? 0,
+    outTokens: raw.eval_count ?? 0,
+    promptEvalTps: tps(raw.prompt_eval_count ?? 0, raw.prompt_eval_duration ?? 0),
+    evalTps: tps(raw.eval_count ?? 0, raw.eval_duration ?? 0),
+    totalDurationS: round2((raw.total_duration ?? 0) / 1e9),
+    loadDurationS: round2((raw.load_duration ?? 0) / 1e9),
+    doneReason: raw.done_reason ?? '',
+    response: raw.response ?? '',
+    thinking: raw.thinking ?? '',
+  };
+
+  // Unload so the next caller starts clean (ignore failures).
+  await generate(host, { model, keep_alive: 0 }).catch(() => {});
+
+  return result;
+}

--- a/cicd/tests/src/perf/content-check.ts
+++ b/cicd/tests/src/perf/content-check.ts
@@ -1,0 +1,26 @@
+/**
+ * Deterministic non-empty-output check (port of cicd/scripts/lib/simple_check.sh).
+ *
+ * Returns pass:true if either the response or the thinking field is non-empty
+ * after a whitespace trim. An empty model output is a hard fail regardless of
+ * any semantic judge — this gates whether the agent judge is even worth running.
+ *
+ * Thinking models (qwen3.x, qwen3-vl, deepseek-r1, gemma4) can put coherent
+ * output entirely in `thinking` while `response` is empty when num_predict caps
+ * generation early, so either field counts.
+ */
+export interface ContentVerdict {
+  pass: boolean;
+  reason: string;
+  source: 'response' | 'thinking' | 'none';
+}
+
+export function simpleContentCheck(response: string, thinking: string): ContentVerdict {
+  if (response.trim()) {
+    return { pass: true, reason: 'non-empty response', source: 'response' };
+  }
+  if (thinking.trim()) {
+    return { pass: true, reason: 'non-empty thinking (response empty)', source: 'thinking' };
+  }
+  return { pass: false, reason: 'both response and thinking are empty/whitespace', source: 'none' };
+}

--- a/cicd/tests/src/perf/gpu.ts
+++ b/cicd/tests/src/perf/gpu.ts
@@ -1,0 +1,61 @@
+/**
+ * GPU introspection for the perf subcommands
+ * (port of the get_gpu_info / get_gpu_offload helpers in benchmark-throughput.sh).
+ *
+ * gpuInfo() reads per-GPU memory via nvidia-smi; gpuOffload() asks ollama
+ * /api/ps what fraction of a loaded model sits in VRAM. Both degrade to an
+ * empty/zero result when the tool or endpoint is unavailable.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export interface GpuRow {
+  index: number;
+  name: string;
+  usedMib: number;
+  totalMib: number;
+  freeMib: number;
+}
+
+/** Per-GPU memory via nvidia-smi; [] if nvidia-smi is absent or fails. */
+export async function gpuInfo(): Promise<GpuRow[]> {
+  try {
+    const { stdout } = await execFileAsync('nvidia-smi', [
+      '--query-gpu=index,name,memory.used,memory.total,memory.free',
+      '--format=csv,noheader,nounits',
+    ]);
+    return stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .map((line) => {
+        const [index, name, used, total, free] = line.split(',').map((c) => c.trim());
+        return {
+          index: Number(index),
+          name,
+          usedMib: Number(used),
+          totalMib: Number(total),
+          freeMib: Number(free),
+        };
+      });
+  } catch {
+    return [];
+  }
+}
+
+/** Percent of `model` resident in VRAM per ollama /api/ps; 0 if unknown. */
+export async function gpuOffload(host: string, model: string): Promise<number> {
+  try {
+    const res = await fetch(`${host}/api/ps`);
+    const ps: any = await res.json();
+    const m = (ps.models ?? []).find((x: any) => x.name === model || x.model === model);
+    if (m && m.size > 0) {
+      return Math.round((m.size_vram / m.size) * 100);
+    }
+    return 0;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Port the generic bash perf helpers to typed TS so the upcoming perf subcommands (#239, #240) reuse them and the one `AgentJudge`:
  - `perf/capture.ts` — `captureResponse()` (port of `lib/response_capture.sh`); fails on an ollama API-error response (parity with `curl -sf`).
  - `perf/gpu.ts` — `gpuInfo()` / `gpuOffload()` via `nvidia-smi` + `/api/ps`.
  - `perf/content-check.ts` — `simpleContentCheck()` (port of `lib/simple_check.sh`).
- No new judge code — coherence judging reuses the existing `AgentJudge`.

Smoke-tested on the live K80 stack: real gemma3:4b capture (outTokens 4, evalTps 19.8), 4× K80 `gpuInfo`, 100% offload, content-check good→pass/empty→fail.

Fixes #238
Part of STORY-002 · #237

## Test plan
- [ ] `cd cicd/tests && npm run build` → exit 0
- [ ] From `cicd/tests`, import the compiled helpers and run against a live stack: `captureResponse` returns real tok/s; `gpuInfo` lists GPUs; `gpuOffload` returns a %; `simpleContentCheck` good→pass, empty→fail
- [ ] No new judge code; `testcases/**` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)