### PR TITLE
Structured workflows: JUDGE_MODE env + Claude secret; drop deprecated flags

### DIFF
--- a/.github/workflows/test-inference.yml
+++ b/.github/workflows/test-inference.yml
@@ -8,18 +8,13 @@ on:
         required: false
         type: string
       judge_mode:
-        description: "Test judge mode (simple = SimpleJudge only; dual = also run LLMJudge)"
+        description: "Test judge mode (simple = SimpleJudge only; dual = also run the keyless agent judge)"
         required: false
         default: "simple"
         type: choice
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -31,11 +26,6 @@ on:
         description: "Test judge mode (simple, dual)"
         required: false
         default: "simple"
-        type: string
-      judge_model:
-        description: "LLM model for judging"
-        required: false
-        default: "gemma3:12b-judge"
         type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
@@ -75,20 +65,14 @@ jobs:
 
       - name: Run inference tests
         id: inference-tests
+        env:
+          # dual mode runs the keyless agent judge; the runner reads JUDGE_MODE.
+          JUDGE_MODE: ${{ inputs.judge_mode || 'simple' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           cd cicd/tests
+          echo "Judge mode: ${JUDGE_MODE}"
 
-          # Build judge flags based on input. Default is simple (SimpleJudge
-          # only); dual adds the LLMJudge via --llm.
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "dual" ]; then
-            JUDGE_FLAGS="--llm --judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
-          fi
-
-          echo "Judge mode: ${{ inputs.judge_mode || 'simple' }}"
-          echo "Judge flags: $JUDGE_FLAGS"
-
-          # Run tests with JSON output
           # Build test ID flag if provided
           ID_FLAG=""
           if [ -n "${{ inputs.test_id }}" ]; then
@@ -96,7 +80,7 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite inference $ID_FLAG $JUDGE_FLAGS --format json > /tmp/inference-results.json || true
+          npx tsx src/cli.ts run --suite inference $ID_FLAG --format json > /tmp/inference-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/inference-results.json

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -8,18 +8,13 @@ on:
         required: false
         type: string
       judge_mode:
-        description: "Test judge mode (simple = SimpleJudge only; dual = also run LLMJudge)"
+        description: "Test judge mode (simple = SimpleJudge only; dual = also run the keyless agent judge)"
         required: false
         default: "simple"
         type: choice
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -31,11 +26,6 @@ on:
         description: "Test judge mode (simple, dual)"
         required: false
         default: "simple"
-        type: string
-      judge_model:
-        description: "LLM model for judging"
-        required: false
-        default: "gemma3:12b-judge"
         type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
@@ -72,18 +62,13 @@ jobs:
 
       - name: Run models tests
         id: models-tests
+        env:
+          # dual mode runs the keyless agent judge; the runner reads JUDGE_MODE.
+          JUDGE_MODE: ${{ inputs.judge_mode || 'simple' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           cd cicd/tests
-
-          # Build judge flags based on input. Default is simple (SimpleJudge
-          # only); dual adds the LLMJudge via --llm.
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "dual" ]; then
-            JUDGE_FLAGS="--llm --judge-model ${{ inputs.judge_model || 'gemma3:12b-judge' }}"
-          fi
-
-          echo "Judge mode: ${{ inputs.judge_mode || 'simple' }}"
-          echo "Judge flags: $JUDGE_FLAGS"
+          echo "Judge mode: ${JUDGE_MODE}"
 
           # Build test ID flag if provided
           ID_FLAG=""
@@ -93,7 +78,7 @@ jobs:
           fi
 
           # Run models tests
-          npx tsx src/cli.ts run --suite models $ID_FLAG $JUDGE_FLAGS --format json > /tmp/models-results.json || true
+          npx tsx src/cli.ts run --suite models $ID_FLAG --format json > /tmp/models-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/models-results.json

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -4,18 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       judge_mode:
-        description: "Test judge mode for inference + models (simple = SimpleJudge only; dual = also run LLMJudge)"
+        description: "Test judge mode for inference + models (simple = SimpleJudge only; dual = also run the keyless agent judge)"
         required: false
         default: "simple"
         type: choice
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       debug:
         description: "Enable OLLAMA_DEBUG=1 in container"
         required: false
@@ -40,16 +35,17 @@ jobs:
     name: Inference Tests
     needs: runtime
     uses: ./.github/workflows/test-inference.yml
+    # Pass CLAUDE_CODE_OAUTH_TOKEN down to the keyless agent judge (dual mode).
+    secrets: inherit
     with:
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       debug: ${{ inputs.debug }}
 
   models:
     name: Models Tests
     needs: inference
     uses: ./.github/workflows/test-models.yml
+    secrets: inherit
     with:
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       debug: ${{ inputs.debug }}

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -35,9 +35,6 @@ program
   .option('-s, --suite <suite>', 'Run only tests from this suite (build, runtime, inference, models)')
   .option('-i, --id <id>', 'Run only the test with this ID')
   .option('--dry-run', 'Show what would run without executing', false)
-  .option('--llm', 'Deprecated alias for JUDGE_MODE=dual (runs the agent judge)', false)
-  .option('--judge-url <url>', 'Deprecated, ignored (the agent judge needs no Ollama URL)')
-  .option('--judge-model <model>', 'Deprecated, ignored (model selection lives in the ACP agent)')
   .option('-o, --output-dir <dir>', 'Output directory for results')
   .option('-f, --format <format>', 'Output format (console, json)', 'console')
   .action(async (options) => {
@@ -59,10 +56,8 @@ program
       mkdirSync(outputDir, { recursive: true });
     }
 
-    // Agent judge runs in 'dual' mode — enabled via JUDGE_MODE=dual or the
-    // deprecated --llm alias.
-    const judgeMode: RunConfig['judgeMode'] =
-      options.llm || CONFIG.judge.mode === 'dual' ? 'dual' : 'simple';
+    // Agent judge runs in 'dual' mode — enabled via the JUDGE_MODE env var.
+    const judgeMode: RunConfig['judgeMode'] = CONFIG.judge.mode === 'dual' ? 'dual' : 'simple';
 
     const config: RunConfig = {
       suite: options.suite as RunConfig['suite'],


### PR DESCRIPTION
## Summary
- `cli.ts run` drops the deprecated `--llm` / `--judge-url` / `--judge-model` flags; `judgeMode` now comes only from the `JUDGE_MODE` env (`CONFIG.judge.mode`).
- `test-inference.yml` / `test-models.yml`: pass `JUDGE_MODE=dual` env + `CLAUDE_CODE_OAUTH_TOKEN` secret instead of building `--llm --judge-model`; drop the `judge_model` input and the "LLMJudge" wording.
- `test-pipeline.yml`: drop `judge_model`; add `secrets: inherit` so the token reaches the called inference/models workflows.

Verified: build + YAML clean; `run --help` has no judge flags; `JUDGE_MODE=dual`→enabled / `simple`→disabled; no workflow/script still passes the removed flags.

Fixes #241
Part of STORY-002 · #237

## Test plan
- [ ] `cd cicd/tests && npm run build` → exit 0
- [ ] `JUDGE_MODE=dual npx tsx src/cli.ts run --suite inference --dry-run` → "Agent Judge: enabled (dual)"
- [ ] `grep -rn '--llm\|judge_model\|gemma3:12b-judge' .github/workflows/test-{inference,models,pipeline}.yml` → none
- [ ] CI: a `test-pipeline.yml` run with `judge_mode=dual` reaches the agent judge in inference/models (needs the `CLAUDE_CODE_OAUTH_TOKEN` secret in `cicd-1`; ambient `~/.claude` covers the runner meanwhile)

> Note: 6 stale `--llm` references remain in `cicd/README.md` + `cicd/docs/CICD.md` — these are reconciled in #242 (the docs sweep + grep-clean), not split into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)