### PR TITLE
Add server-agnostic MCP host for model tool-call testing

### DIFF
--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.44.0",
         "@agentclientprotocol/sdk": "^0.25.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "glob": "^10.3.10",

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.44.0",
     "@agentclientprotocol/sdk": "^0.25.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "glob": "^10.3.10",

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -1,0 +1,164 @@
+/**
+ * Server-agnostic MCP host: let an Ollama model drive a real stdio MCP server's
+ * tools end-to-end (no mock).
+ *
+ * Connect to a stdio MCP server (any one — the spawn config is passed in),
+ * list its tools, translate them to Ollama's /api/chat `tools[]` format, then
+ * run the tool loop: chat → on tool_calls, execute each against the *real*
+ * server via callTool → feed results back → chat again → final answer.
+ *
+ * What's being tested is the MODEL: given a real menu, does it pick the right
+ * tool with valid args and use the result? A model whose template lacks tool
+ * support is reported `supported:false` — a clean verdict, not a crash (mirrors
+ * the catch-returns-FAIL shape in perf/fa.ts). The server choice + its
+ * credentials are config, not code.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+/** How to spawn the stdio MCP server. testlink-mcp is just one such config. */
+export interface McpServerConfig {
+  command: string;
+  args: string[];
+  cwd?: string;
+  /** Extra env the server needs (e.g. TESTLINK_URL / TESTLINK_API_KEY) — merged
+   *  over a minimal default environment; never hardcoded in this module. */
+  env?: Record<string, string>;
+}
+
+export interface McpHostOptions {
+  /** Ollama host, e.g. http://localhost:11434 */
+  host: string;
+  model: string;
+  prompt: string;
+  server: McpServerConfig;
+  numCtx?: number;
+  /** Max chat↔tool rounds before giving up (guards against a tool loop). */
+  maxIters?: number;
+}
+
+export interface ToolCallRecord {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolResultRecord {
+  name: string;
+  content: string;
+  isError: boolean;
+}
+
+export interface McpTrajectory {
+  model: string;
+  /** false ⇢ the model's template can't do tools (Ollama rejected `tools`). */
+  supported: boolean;
+  /** Tool names the MCP server exposed. */
+  toolNames: string[];
+  toolCalls: ToolCallRecord[];
+  toolResults: ToolResultRecord[];
+  finalAnswer: string;
+  error?: string;
+}
+
+/** MCP tool {name, description?, inputSchema} → Ollama tools[] entry (near 1:1). */
+export function mcpToOllamaTools(tools: Array<{ name: string; description?: string; inputSchema?: unknown }>): unknown[] {
+  return tools.map((t) => ({
+    type: 'function',
+    function: {
+      name: t.name,
+      description: t.description ?? '',
+      parameters: t.inputSchema ?? { type: 'object', properties: {} },
+    },
+  }));
+}
+
+async function chat(host: string, model: string, messages: unknown[], tools: unknown[], numCtx: number): Promise<any> {
+  const res = await fetch(`${host}/api/chat`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model, messages, tools, stream: false, options: { temperature: 0, seed: 42, num_ctx: numCtx } }),
+  });
+  return res.json();
+}
+
+/** Join an MCP CallToolResult's content blocks into a single text payload. */
+function resultText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : JSON.stringify(c)))
+    .join('\n');
+}
+
+export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
+  const numCtx = opts.numCtx ?? 4096;
+  const maxIters = opts.maxIters ?? 5;
+
+  const transport = new StdioClientTransport({
+    command: opts.server.command,
+    args: opts.server.args,
+    cwd: opts.server.cwd,
+    env: { ...getDefaultEnvironment(), ...(opts.server.env ?? {}) },
+  });
+  const client = new Client({ name: 'ollama37-mcp-host', version: '1.0.0' });
+
+  const traj: McpTrajectory = {
+    model: opts.model,
+    supported: true,
+    toolNames: [],
+    toolCalls: [],
+    toolResults: [],
+    finalAnswer: '',
+  };
+
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    traj.toolNames = listed.tools.map((t) => t.name);
+    const tools = mcpToOllamaTools(listed.tools);
+
+    const messages: any[] = [{ role: 'user', content: opts.prompt }];
+
+    for (let i = 0; i < maxIters; i++) {
+      const raw = await chat(opts.host, opts.model, messages, tools, numCtx);
+
+      // Ollama returns {error: "...does not support tools"} when the model's
+      // template can't do tool calling — a clean capability verdict, not a crash.
+      if (raw?.error) {
+        if (/does not support tools/i.test(String(raw.error))) {
+          traj.supported = false;
+          traj.error = String(raw.error);
+          return traj;
+        }
+        throw new Error(`ollama /api/chat: ${raw.error}`);
+      }
+
+      const msg = raw?.message;
+      const toolCalls: any[] = msg?.tool_calls ?? [];
+
+      if (toolCalls.length === 0) {
+        traj.finalAnswer = msg?.content ?? '';
+        return traj;
+      }
+
+      // Echo the assistant's tool-call turn, then run each call for real.
+      messages.push(msg);
+      for (const tc of toolCalls) {
+        const name = tc.function?.name ?? '';
+        const args = (tc.function?.arguments ?? {}) as Record<string, unknown>;
+        traj.toolCalls.push({ name, arguments: args });
+
+        const result: any = await client.callTool({ name, arguments: args });
+        const content = resultText(result?.content);
+        traj.toolResults.push({ name, content, isError: Boolean(result?.isError) });
+
+        messages.push({ role: 'tool', content, tool_name: name });
+      }
+    }
+
+    // Ran out of iterations still calling tools — report what we have.
+    traj.error = `no final answer within ${maxIters} tool rounds`;
+    return traj;
+  } finally {
+    await client.close().catch(() => {});
+  }
+}

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -89,6 +89,19 @@ function resultText(content: unknown): string {
     .join('\n');
 }
 
+/** Ollama is documented to return tool-call arguments as an object, but some
+ *  model templates emit a JSON string — normalize both to an object. */
+function asArgs(raw: unknown): Record<string, unknown> {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  return (raw ?? {}) as Record<string, unknown>;
+}
+
 export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
   const numCtx = opts.numCtx ?? 4096;
   const maxIters = opts.maxIters ?? 5;
@@ -110,29 +123,29 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     finalAnswer: '',
   };
 
+  const messages: any[] = [{ role: 'user', content: opts.prompt }];
+
   try {
     await client.connect(transport);
     const listed = await client.listTools();
     traj.toolNames = listed.tools.map((t) => t.name);
     const tools = mcpToOllamaTools(listed.tools);
 
-    const messages: any[] = [{ role: 'user', content: opts.prompt }];
-
     for (let i = 0; i < maxIters; i++) {
       const raw = await chat(opts.host, opts.model, messages, tools, numCtx);
 
+      if (!raw || typeof raw !== 'object') {
+        throw new Error('ollama /api/chat: no/invalid response');
+      }
       // Ollama returns {error: "...does not support tools"} when the model's
       // template can't do tool calling — a clean capability verdict, not a crash.
-      if (raw?.error) {
-        if (/does not support tools/i.test(String(raw.error))) {
-          traj.supported = false;
-          traj.error = String(raw.error);
-          return traj;
-        }
-        throw new Error(`ollama /api/chat: ${raw.error}`);
+      if (raw.error) {
+        if (/does not support tools/i.test(String(raw.error))) traj.supported = false;
+        traj.error = String(raw.error);
+        return traj;
       }
 
-      const msg = raw?.message;
+      const msg = raw.message;
       const toolCalls: any[] = msg?.tool_calls ?? [];
 
       if (toolCalls.length === 0) {
@@ -140,23 +153,37 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
         return traj;
       }
 
-      // Echo the assistant's tool-call turn, then run each call for real.
-      messages.push(msg);
+      // Echo the assistant's tool-call turn (normalized), then run each call.
+      messages.push({ role: 'assistant', content: msg?.content ?? '', tool_calls: toolCalls });
       for (const tc of toolCalls) {
         const name = tc.function?.name ?? '';
-        const args = (tc.function?.arguments ?? {}) as Record<string, unknown>;
+        const args = asArgs(tc.function?.arguments);
         traj.toolCalls.push({ name, arguments: args });
 
-        const result: any = await client.callTool({ name, arguments: args });
-        const content = resultText(result?.content);
-        traj.toolResults.push({ name, content, isError: Boolean(result?.isError) });
-
+        // A bad tool name / args throws — but "the model picked wrong" is exactly
+        // the verdict under test, so capture it and feed it back, don't crash.
+        let content: string;
+        let isError: boolean;
+        try {
+          const result: any = await client.callTool({ name, arguments: args });
+          content = resultText(result?.content);
+          isError = Boolean(result?.isError);
+        } catch (e) {
+          content = `tool call failed: ${e instanceof Error ? e.message : String(e)}`;
+          isError = true;
+        }
+        traj.toolResults.push({ name, content, isError });
         messages.push({ role: 'tool', content, tool_name: name });
       }
     }
 
     // Ran out of iterations still calling tools — report what we have.
     traj.error = `no final answer within ${maxIters} tool rounds`;
+    return traj;
+  } catch (e) {
+    // Connect/list/transport failure or an Ollama HTTP/JSON failure: return a
+    // trajectory carrying the error rather than throwing (mirrors perf/fa.ts).
+    traj.error = e instanceof Error ? e.message : String(e);
     return traj;
   } finally {
     await client.close().catch(() => {});

--- a/docs/stories/STORY-004.md
+++ b/docs/stories/STORY-004.md
@@ -1,0 +1,51 @@
+# STORY-004: Validate that Ollama models can perform MCP tool calls
+
+## User Story
+
+As a maintainer of the K80 Ollama fork,
+I want to test whether a given model can correctly drive a real MCP server's tools,
+So that I know which models are usable for tool-calling / agent workloads — not just chat.
+
+## The Need
+
+The test framework (`cicd/tests/`) proves a model can **chat** over HTTP. It never proves a
+model can **drive tools** — given a menu of functions, pick the right one with valid
+arguments, run it, and use the result. That is a different, increasingly important capability,
+and it **varies by model**: this repo already recorded that `gemma3` has no tool support while
+`llama3.2` does. Without a dedicated test we can't answer a basic question like *"can `gemma4`
+actually call `list_projects` on `testlink-mcp` and use the answer?"* — we'd be guessing.
+
+The check must be **real and end-to-end** (no mocks): the model decides the tool call, a real
+MCP server executes it against real data, and the model's final answer is graded on whether it
+used that result. It must **not** disturb the existing HTTP chat tests, which work well.
+
+## Success Looks Like
+
+- A maintainer can run a single on-demand check and get a per-model verdict on tool-calling
+  capability against a **real** MCP server.
+- For a tool-capable model (e.g. `gemma4`/`llama3.2`): the report shows the model called the
+  right tool with valid arguments, the real server returned real data, and the final answer
+  was graded correct.
+- For a model with no tool support (e.g. `gemma3`): the report says so cleanly — a clear
+  "no tool support" verdict, not a crash.
+- The check works against **any** real MCP server, not just the default — switching servers
+  needs no code change.
+- The existing chat tests are unchanged and still pass.
+
+## Open Questions
+
+The technical approach has been discussed and will be carried by the plan issue (`/dw-plan`),
+where the *how* is decided and recorded. Genuinely unresolved details to settle there / on the
+task issues:
+
+- How the default MCP server is launched and how its credentials are supplied (locally vs in
+  CI) without hardcoding secrets.
+- What exactly counts as a correct tool call for the verdict, and how a "no tool support"
+  outcome is classified as a clean result rather than a failure.
+- Whether a manual on-demand CI entry point is worth adding now or deferred.
+
+## Status
+
+- Created: 2026-06-15
+- Plan: #248
+- Issues: #249, #250, #251, #252


### PR DESCRIPTION
## Summary
- New `cicd/tests/src/mcp/host.ts` — a server-agnostic MCP host that lets an Ollama model drive a **real** stdio MCP server end-to-end: `Client`/`StdioClientTransport` (config-driven spawn) → `listTools` → translate to Ollama `/api/chat` `tools[]` → tool loop (`chat → callTool → role:'tool' feedback → answer`) with a `maxIters` guard.
- A model whose template can't do tools is reported `supported:false` — a clean verdict, not a crash. The host never throws: connect/transport/HTTP errors and bad tool calls return a trajectory carrying the error (mirrors `perf/fa.ts`).
- Adds `@modelcontextprotocol/sdk` (^1.29.0). Also lands the STORY-004 doc.

Fixes #249
Part of STORY-004

## Test plan
- [x] `npm run build` (strict tsc) passes.
- [x] Real stdio MCP server round-trip verified (`@modelcontextprotocol/server-everything`): 13 tools listed, translation produces correct Ollama tool schema, `callTool('echo')` returns real data; bad-tool-name path handled.
- [ ] Live model round-trip (Ollama emitting `tool_calls`) — covered by the validation task #251.

Generated with [Claude Code](https://claude.com/claude-code)