### PR TITLE
Add test-mcp: drive a real MCP server's tools to probe model tool-calling

### DIFF
--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -18,6 +18,7 @@ import { RunConfig } from './types.js';
 import { CONFIG } from './config.js';
 import { runThroughput } from './perf/throughput.js';
 import { runFa } from './perf/fa.js';
+import { runMcpTest } from './mcp/test-mcp.js';
 
 const program = new Command();
 
@@ -279,6 +280,44 @@ program
       benchmark: options.benchmark,
       kvCacheType: options.kvCacheType,
       baselineCompare: options.baselineCompare,
+      output: options.output,
+    });
+    await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));
+    process.exit(code);
+  });
+
+/**
+ * test-mcp — can a model drive a REAL MCP server's tools end-to-end?
+ *
+ * Connects to a stdio MCP server (default testlink-mcp; override with
+ * --mcp-command/--mcp-args), lists + translates its tools, and runs the model
+ * through the tool loop. Reports a per-model verdict: structural check always,
+ * plus the keyless agent judge with --judge. Server-agnostic — no mock.
+ */
+program
+  .command('test-mcp')
+  .description("Test whether models can drive a real MCP server's tools")
+  .argument('<models...>', 'One or more model names to test')
+  .option('--prompt <text>', 'Prompt that should trigger a tool call', CONFIG.mcp.prompt)
+  .option('-c, --num-ctx <n>', 'Context window size', '4096')
+  .option('--judge', 'Also run the agent judge on the final answer (dual mode)', false)
+  .option('-H, --host <url>', 'Ollama host', process.env.OLLAMA_HOST || 'http://localhost:11434')
+  .option('--mcp-command <cmd>', 'Command to launch the stdio MCP server', CONFIG.mcp.command)
+  .option('--mcp-args <args>', 'Args for the MCP server (space-separated)', CONFIG.mcp.args.join(' '))
+  .option('-o, --output <file>', 'Write the JSON report to this file')
+  .action(async (models: string[], options) => {
+    const code = await runMcpTest({
+      models,
+      prompt: options.prompt,
+      numCtx: Number(options.numCtx),
+      judge: options.judge,
+      host: options.host,
+      server: {
+        command: options.mcpCommand,
+        args: String(options.mcpArgs).split(' ').filter(Boolean),
+        cwd: CONFIG.mcp.cwd,
+        env: CONFIG.mcp.env,
+      },
       output: options.output,
     });
     await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -15,7 +15,7 @@ import { TestExecutor } from './executor.js';
 import { SimpleJudge, AgentJudge } from './judge/index.js';
 import { JsonReporter, ConsoleReporter } from './reporter/index.js';
 import { RunConfig } from './types.js';
-import { CONFIG } from './config.js';
+import { CONFIG, pickEnv } from './config.js';
 import { runThroughput } from './perf/throughput.js';
 import { runFa } from './perf/fa.js';
 import { runMcpTest } from './mcp/test-mcp.js';
@@ -303,7 +303,8 @@ program
   .option('--judge', 'Also run the agent judge on the final answer (dual mode)', false)
   .option('-H, --host <url>', 'Ollama host', process.env.OLLAMA_HOST || 'http://localhost:11434')
   .option('--mcp-command <cmd>', 'Command to launch the stdio MCP server', CONFIG.mcp.command)
-  .option('--mcp-args <args>', 'Args for the MCP server (space-separated)', CONFIG.mcp.args.join(' '))
+  .option('--mcp-args <args>', 'Args for the MCP server (space-separated; no spaces within a single arg)', CONFIG.mcp.args.join(' '))
+  .option('--mcp-env <names>', 'Comma-separated env var names to forward to the server as creds (overrides MCP_ENV)', '')
   .option('-o, --output <file>', 'Write the JSON report to this file')
   .action(async (models: string[], options) => {
     const code = await runMcpTest({
@@ -316,7 +317,7 @@ program
         command: options.mcpCommand,
         args: String(options.mcpArgs).split(' ').filter(Boolean),
         cwd: CONFIG.mcp.cwd,
-        env: CONFIG.mcp.env,
+        env: options.mcpEnv ? pickEnv(options.mcpEnv) : CONFIG.mcp.env,
       },
       output: options.output,
     });

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -7,7 +7,7 @@
 
 /** Forward only the named env vars (comma-separated) from the parent process —
  *  the spawned MCP server's creds come from the environment, never hardcoded. */
-function pickEnv(names: string): Record<string, string> {
+export function pickEnv(names: string): Record<string, string> {
   const out: Record<string, string> = {};
   for (const k of names.split(',').map((s) => s.trim()).filter(Boolean)) {
     const v = process.env[k];

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -4,6 +4,18 @@
  * ollama37 keeps its run config in types.ts (DEFAULT_CONFIG); this file provides
  * the CONFIG block the ported ACP agent judge (judge/agent-judge.ts) reads.
  */
+
+/** Forward only the named env vars (comma-separated) from the parent process —
+ *  the spawned MCP server's creds come from the environment, never hardcoded. */
+function pickEnv(names: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const k of names.split(',').map((s) => s.trim()).filter(Boolean)) {
+    const v = process.env[k];
+    if (v) out[k] = v;
+  }
+  return out;
+}
+
 export const CONFIG = {
   projectName: 'ollama37',
 
@@ -21,5 +33,18 @@ export const CONFIG = {
     stdoutLimit: 1000,
     stderrLimit: 500,
     logsLimit: 3000,
+  },
+
+  // MCP tool-call test (cli.ts test-mcp). Drives a REAL stdio MCP server so a
+  // model's tool-calling can be checked end-to-end. testlink-mcp is only the
+  // default target — point --mcp-command / --mcp-args at any stdio MCP server.
+  mcp: {
+    command: process.env.MCP_COMMAND || 'npx',
+    args: (process.env.MCP_ARGS || '-y testlink-mcp').split(' ').filter(Boolean),
+    cwd: process.env.MCP_CWD || undefined,
+    prompt: process.env.MCP_PROMPT || 'List the projects.',
+    // Env var names to forward to the spawned server (its creds). Values come
+    // from the environment (.env locally / secret in CI). Default = testlink's.
+    env: pickEnv(process.env.MCP_ENV || 'TESTLINK_URL,TESTLINK_API_KEY'),
   },
 };

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -54,6 +54,8 @@ export interface McpTrajectory {
   supported: boolean;
   /** Tool names the MCP server exposed. */
   toolNames: string[];
+  /** Required arg names per tool, from each tool's inputSchema.required. */
+  toolRequired: Record<string, string[]>;
   toolCalls: ToolCallRecord[];
   toolResults: ToolResultRecord[];
   finalAnswer: string;
@@ -118,6 +120,7 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     model: opts.model,
     supported: true,
     toolNames: [],
+    toolRequired: {},
     toolCalls: [],
     toolResults: [],
     finalAnswer: '',
@@ -129,6 +132,10 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     await client.connect(transport);
     const listed = await client.listTools();
     traj.toolNames = listed.tools.map((t) => t.name);
+    for (const t of listed.tools) {
+      const req = (t.inputSchema as any)?.required;
+      traj.toolRequired[t.name] = Array.isArray(req) ? req : [];
+    }
     const tools = mcpToOllamaTools(listed.tools);
 
     for (let i = 0; i < maxIters; i++) {

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -55,6 +55,11 @@ function simpleMcpCheck(t: McpTrajectory): McpSimpleVerdict {
   if (t.toolCalls.length === 0) return { pass: false, reason: 'model produced no tool call' };
   const unknown = t.toolCalls.find((c) => !t.toolNames.includes(c.name));
   if (unknown) return { pass: false, reason: `called unknown tool "${unknown.name}"` };
+  // Args vs schema: every required arg of the called tool must be present.
+  for (const c of t.toolCalls) {
+    const missing = (t.toolRequired[c.name] ?? []).filter((k) => !(k in c.arguments));
+    if (missing.length) return { pass: false, reason: `tool "${c.name}" called without required arg(s): ${missing.join(', ')}` };
+  }
   const errored = t.toolResults.find((r) => r.isError);
   if (errored) return { pass: false, reason: `tool "${errored.name}" call failed (bad args or server error)` };
   if (!t.finalAnswer.trim()) return { pass: false, reason: 'empty final answer' };
@@ -130,7 +135,9 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
     }
   }
 
-  const failed = results.filter((r) => !r.check.overall_pass).length;
+  // "No tool support" is an informational capability verdict, not a harness
+  // failure — only a supported model that failed its check drives a non-zero exit.
+  const failed = results.filter((r) => r.supported && !r.check.overall_pass).length;
 
   if (opts.output) {
     const full = results.map((r) => ({ ...r, trajectory: trajByModel.get(r.model) }));
@@ -160,7 +167,7 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   for (const r of results) {
     const verdict = r.check.overall_pass ? 'PASS' : r.supported ? 'FAIL' : 'NO TOOL SUPPORT';
     const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
-    const answer = r.final_answer_preview ? 'yes' : 'no';
+    const answer = r.final_answer_preview.trim() ? 'yes' : 'no';
     const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').replace(/[\n|]/g, ' ').slice(0, 200);
     out.push(`| ${r.model} | ${verdict} | ${calls} | ${answer} | ${reason} |`);
   }

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -1,0 +1,168 @@
+/**
+ * Per-model MCP tool-call test (the cli.ts test-mcp subcommand).
+ *
+ * For each model: drive a REAL stdio MCP server through the host (host.ts) and
+ * grade the trajectory. The simple check is structural (did the model call a
+ * real tool, did the call succeed, did it produce a final answer?); with
+ * --judge the keyless AgentJudge adds the semantic check (did the final answer
+ * correctly use the tool result?). A model whose template can't do tools is
+ * reported "no tool support" — a clean verdict, not a failure of the harness.
+ *
+ * Mirrors perf/throughput.ts: markdown summary on stdout (CI step summary) and,
+ * with --output, a JSON report. Exit code is non-zero if any model fails.
+ */
+import { writeFileSync } from 'node:fs';
+import { runMcpHost, type McpServerConfig, type McpTrajectory } from './host.js';
+import { AgentJudge } from '../judge/index.js';
+import { TestResult, Judgment } from '../types.js';
+
+const JUDGE_CRITERIA =
+  'Given the user prompt and the tool result(s) the model received, the final answer must ' +
+  'correctly use the tool result to answer the prompt. Reject empty answers, answers that ' +
+  'ignore or contradict the tool result, or data the tool result does not contain.';
+
+export interface McpTestOptions {
+  models: string[];
+  prompt: string;
+  server: McpServerConfig;
+  host: string;
+  numCtx: number;
+  judge: boolean;
+  output?: string;
+}
+
+interface McpSimpleVerdict {
+  pass: boolean;
+  reason: string;
+}
+
+interface McpModelResult {
+  model: string;
+  supported: boolean;
+  tool_names: string[];
+  tool_calls: { name: string; arguments: Record<string, unknown> }[];
+  tool_results: { name: string; isError: boolean }[];
+  final_answer_preview: string;
+  error?: string;
+  check: { overall_pass: boolean; simple: McpSimpleVerdict; agent: Judgment | null };
+}
+
+/** Structural check: the model must have called a real tool, the call must have
+ *  succeeded, and it must have produced a non-empty final answer. */
+function simpleMcpCheck(t: McpTrajectory): McpSimpleVerdict {
+  if (!t.supported) return { pass: false, reason: 'model template does not support tools' };
+  if (t.error) return { pass: false, reason: t.error };
+  if (t.toolCalls.length === 0) return { pass: false, reason: 'model produced no tool call' };
+  const unknown = t.toolCalls.find((c) => !t.toolNames.includes(c.name));
+  if (unknown) return { pass: false, reason: `called unknown tool "${unknown.name}"` };
+  const errored = t.toolResults.find((r) => r.isError);
+  if (errored) return { pass: false, reason: `tool "${errored.name}" call failed (bad args or server error)` };
+  if (!t.finalAnswer.trim()) return { pass: false, reason: 'empty final answer' };
+  return { pass: true, reason: `called ${t.toolCalls.map((c) => c.name).join(', ')} and produced a final answer` };
+}
+
+/** Build a synthetic TestResult so the AgentJudge can grade groundedness. */
+function toTestResult(t: McpTrajectory, prompt: string): TestResult {
+  const toolLog = t.toolCalls
+    .map((c, i) => `TOOL CALL: ${c.name}(${JSON.stringify(c.arguments)})\nTOOL RESULT: ${t.toolResults[i]?.content ?? ''}`)
+    .join('\n\n');
+  const stdout = `PROMPT: ${prompt}\n\n${toolLog}\n\nFINAL ANSWER: ${t.finalAnswer}`;
+  return {
+    testCase: {
+      id: t.model,
+      name: `mcp:${t.model}`,
+      suite: 'inference',
+      priority: 1,
+      timeout: 60000,
+      dependencies: [],
+      goal: 'Use the MCP tool result to answer the prompt',
+      steps: [{ name: 'tool-call', command: '(captured MCP trajectory)' }],
+      criteria: JUDGE_CRITERIA,
+    },
+    steps: [{ name: 'tool-call', command: '(captured MCP trajectory)', stdout, stderr: '', exitCode: 0, duration: 0 }],
+    totalDuration: 0,
+    logs: '',
+    logFile: '',
+  };
+}
+
+export async function runMcpTest(opts: McpTestOptions): Promise<number> {
+  const results: McpModelResult[] = [];
+  const trajByModel = new Map<string, McpTrajectory>();
+
+  for (const model of opts.models) {
+    process.stderr.write(`--- ${model} ---\n`);
+    const traj = await runMcpHost({ host: opts.host, model, prompt: opts.prompt, server: opts.server, numCtx: opts.numCtx });
+    trajByModel.set(model, traj);
+    const simple = simpleMcpCheck(traj);
+    results.push({
+      model,
+      supported: traj.supported,
+      tool_names: traj.toolNames,
+      tool_calls: traj.toolCalls,
+      tool_results: traj.toolResults.map((r) => ({ name: r.name, isError: r.isError })),
+      final_answer_preview: traj.finalAnswer.slice(0, 200),
+      error: traj.error,
+      check: { overall_pass: simple.pass, simple, agent: null },
+    });
+    process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass}\n`);
+  }
+
+  // Agent judge (dual mode): one batch over a single reused session, only for
+  // models that passed the structural check (no point grading a non-call).
+  if (opts.judge) {
+    const eligible = results.filter((r) => r.check.simple.pass);
+    if (eligible.length > 0) {
+      const agentJudge = new AgentJudge();
+      if (await agentJudge.isAvailable()) {
+        const byModel = new Map(results.map((r) => [r.model, r]));
+        const verdicts = await agentJudge.judgeResults(eligible.map((r) => toTestResult(trajByModel.get(r.model)!, opts.prompt)));
+        for (const v of verdicts) {
+          const r = byModel.get(v.testId);
+          if (r) {
+            r.check.agent = v;
+            r.check.overall_pass = r.check.simple.pass && v.pass;
+          }
+        }
+      } else {
+        process.stderr.write('[WARN] agent judge not available — simple check only\n');
+      }
+    }
+  }
+
+  const failed = results.filter((r) => !r.check.overall_pass).length;
+
+  if (opts.output) {
+    const full = results.map((r) => ({ ...r, trajectory: trajByModel.get(r.model) }));
+    writeFileSync(
+      opts.output,
+      JSON.stringify(
+        { timestamp: new Date().toISOString(), server: { command: opts.server.command, args: opts.server.args }, prompt: opts.prompt, judge: opts.judge ? 'dual' : 'simple', results: full },
+        null,
+        2
+      )
+    );
+    process.stderr.write(`Results written to ${opts.output}\n`);
+  }
+
+  printSummary(opts, results);
+  return failed > 0 ? 1 : 0;
+}
+
+function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
+  const out: string[] = [];
+  out.push('## MCP tool-call test');
+  out.push('');
+  out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\` · **Prompt:** ${opts.prompt} · **Judge:** ${opts.judge ? 'dual' : 'simple'}`);
+  out.push('');
+  out.push('| Model | Verdict | Tool calls | Answer | Reason |');
+  out.push('|---|---|---|---|---|');
+  for (const r of results) {
+    const verdict = r.check.overall_pass ? 'PASS' : r.supported ? 'FAIL' : 'NO TOOL SUPPORT';
+    const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
+    const answer = r.final_answer_preview ? 'yes' : 'no';
+    const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').replace(/[\n|]/g, ' ').slice(0, 200);
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${answer} | ${reason} |`);
+  }
+  process.stdout.write(out.join('\n') + '\n');
+}


### PR DESCRIPTION
## Summary
- New `cli.ts test-mcp <models...>` subcommand: drives a **real** stdio MCP server (default testlink-mcp; override via `--mcp-command`/`--mcp-args`/`--mcp-env`) and reports a per-model verdict — structural check always, keyless `AgentJudge` with `--judge`. Mirrors `perf/throughput.ts`.
- `src/mcp/test-mcp.ts` runner + generic `mcp` config block (`pickEnv` forwards only named cred vars). Server-agnostic — no testlink coupling in code.
- Structural check: real tool called, **required args present (vs schema)**, call succeeded, non-empty answer. NO-TOOL-SUPPORT is an informational verdict (doesn't redden the exit code); only a supported-but-failing model exits 1.

Fixes #250
Part of STORY-004

## Test plan
- [x] `npm run build` (strict tsc) passes.
- [x] End-to-end against `@modelcontextprotocol/server-everything` (real server, no mock): `gemma3:4b` → NO TOOL SUPPORT (clean), `qwen3:4b` → PASS (called `echo`, got the real result, grounded answer), exit 0.
- [ ] Real testlink-mcp + `--judge` end-to-end — task #251.

Generated with [Claude Code](https://claude.com/claude-code)