### PR TITLE
Document test-mcp in cicd README + CICD perf family

### DIFF
--- a/cicd/README.md
+++ b/cicd/README.md
@@ -75,12 +75,13 @@ These workflows execute the YAML test suites via the TypeScript runner with the 
 
 ### Perf / experiment workflows (the unified test-workflow pattern)
 
-These run via the TypeScript runner's perf subcommands (`cli.ts bench-throughput`, `cli.ts test-fa`), which capture metrics and judge output coherence through the same agent judge, emitting a JSON report plus a markdown summary. Full bullet list in [`docs/CICD.md`](docs/CICD.md) → "Perf / experiment workflows".
+These run via the TypeScript runner's perf subcommands (`cli.ts bench-throughput`, `cli.ts test-fa`, `cli.ts test-mcp`), which capture metrics or a capability verdict and judge output through the same agent judge, emitting a JSON report plus a markdown summary. Full bullet list in [`docs/CICD.md`](docs/CICD.md) → "Perf / experiment workflows".
 
 | Workflow | Script | Description |
 |----------|--------|-------------|
 | `test-throughput.yml` | `cli.ts bench-throughput` | Per-model tok/s benchmark with simple + optional agent-judge output check |
 | `test-fa-k80.yml` | `cli.ts test-fa` | K80 flash-attention regression + benchmark (FA off/on × KV cache type) |
+| _(subcommand only)_ | `cli.ts test-mcp` | Probe whether a model can drive a real MCP server's tools — server-agnostic (default `testlink-mcp`, override via `--mcp-command`/`--mcp-args`); structural check + optional agent judge; per-model verdict (PASS / FAIL / NO TOOL SUPPORT) |
 
 ### Release workflow
 

--- a/cicd/docs/CICD.md
+++ b/cicd/docs/CICD.md
@@ -249,12 +249,14 @@ Runs all test suites in sequence: build → runtime → inference → models. Th
 
 The TC framework above handles **correctness validation** — "did this model load and produce coherent output?". Performance benchmarks and experiments live alongside under a separate, simpler contract:
 
-- A TypeScript subcommand per workflow (`cli.ts bench-throughput`, `cli.ts test-fa`)
+- A TypeScript subcommand per workflow (`cli.ts bench-throughput`, `cli.ts test-fa`, `cli.ts test-mcp`)
 - Metrics + coherence judging reuse the framework's perf helpers and the one agent judge
 - A JSON report (`--output`) plus a markdown summary on stdout
 - Workflow manages container lifecycle (stop production → run → restart production → upload artifacts)
 
 Current perf workflows: `test-throughput.yml` (tok/s benchmark) and `test-fa-k80.yml` (FA regression + benchmark). The agent judge is invoked here too but only ever to answer "is this response meaningful for its prompt?" — never for static / log / exit-code checks.
+
+`cli.ts test-mcp` is a **capability** probe rather than a perf metric: it drives a **real** stdio MCP server (server-agnostic — default `testlink-mcp`, override via `--mcp-command`/`--mcp-args`), lists and translates its tools to Ollama's `/api/chat` `tools[]`, runs the model's tool loop against the live server, and reuses the one agent judge to grade whether the final answer is grounded in the tool result. It reports a per-model verdict (PASS / FAIL / NO TOOL SUPPORT) and is subcommand-only today (a manual `workflow_dispatch` workflow is a future follow-up). See [`docs/traces/mcp-tool-call-validation.md`](../../docs/traces/mcp-tool-call-validation.md) for an end-to-end validation run.
 
 ## Quick Start
 

--- a/cicd/docs/CICD.md
+++ b/cicd/docs/CICD.md
@@ -249,7 +249,7 @@ Runs all test suites in sequence: build → runtime → inference → models. Th
 
 The TC framework above handles **correctness validation** — "did this model load and produce coherent output?". Performance benchmarks and experiments live alongside under a separate, simpler contract:
 
-- A TypeScript subcommand per workflow (`cli.ts bench-throughput`, `cli.ts test-fa`, `cli.ts test-mcp`)
+- A TypeScript subcommand per workflow or experiment (`cli.ts bench-throughput`, `cli.ts test-fa`, `cli.ts test-mcp`)
 - Metrics + coherence judging reuse the framework's perf helpers and the one agent judge
 - A JSON report (`--output`) plus a markdown summary on stdout
 - Workflow manages container lifecycle (stop production → run → restart production → upload artifacts)


### PR DESCRIPTION
## Summary
- `cicd/README.md`: add `test-mcp` to the perf-subcommand intro and a table row, shown as **subcommand-only** (no `.yml` workflow yet) with its server-agnostic flags and the PASS / FAIL / NO TOOL SUPPORT verdict.
- `cicd/docs/CICD.md`: add it to the subcommand bullet + a paragraph framing it as a **capability** probe (drives a real MCP server, reuses the one agent judge), linking the end-to-end validation trace.

Fixes #252
Part of STORY-004

## Test plan
- [x] Both cross-references resolve to existing files (`docs/CICD.md`, `docs/traces/mcp-tool-call-validation.md`).
- [x] No nonexistent `test-mcp.yml` workflow referenced.
- [x] Flags (`--mcp-command`/`--mcp-args`) + verdict match the shipped `cli.ts test-mcp`.

Generated with [Claude Code](https://claude.com/claude-code)