### PR TITLE
Add docs/tests/ format contract + STORY-005 (qa-workflow foundation)

### DIFF
--- a/docs/stories/STORY-005.md
+++ b/docs/stories/STORY-005.md
@@ -1,0 +1,42 @@
+# STORY-005: ollama37 builds and runs correctly on Tesla K80
+
+## User Story
+
+As a maintainer of the K80 Ollama fork,
+I want confidence that the sm_37 build produces a working runtime that loads models and infers on Tesla K80,
+So that every release is known to actually run on the target hardware — not just compile.
+
+## The Need
+
+ollama37 exists to run on Tesla K80 (CUDA compute 3.7), hardware mainstream Ollama no longer
+supports. Compiling is not the goal — *running* is. A build can succeed yet fail silently on
+K80: a CUBLAS fallback that errors, a model that loads to CPU instead of the GPU, garbled
+output that still "passes" an exit-code check. The fork already has a regression suite that
+guards against exactly this (build → runtime → inference → per-model), but that suite traces
+back to **no story** — there's no single statement of the need it serves. This story is that
+backfill: the foundational goal the existing K80 validation tests exist to verify.
+
+## Success Looks Like
+
+- The **build** is confirmed to produce the K80 toolchain image and runtime binary.
+- The **runtime** comes up healthy: container starts, the K80 GPU(s) are detected, health and
+  the metrics endpoint report correctly.
+- **Inference** works on the GPU: a model pulls and generates a real response using the K80,
+  not a silent CPU fallback.
+- Each supported **model** passes its per-model regression on K80 — coherent output, no
+  `CUBLAS_STATUS_*` / `CUDA error` / `cudaMalloc failed` and no `library=cpu` fallback.
+- The existing regression tests trace back to this need, so anyone can see *why* each test
+  exists.
+
+## Open Questions
+
+- Whether this stays one foundational story or later splits (e.g. the build/runtime/inference
+  pipeline vs the per-model regression) — settled when the test docs are derived.
+- How freshness between this story and its tests is enforced over time (the qa-workflow's drift
+  gate) — that automation is a separate follow-up, not part of capturing the need.
+
+## Status
+
+- Created: 2026-06-15
+- Plan: #257
+- Issues: #258, #259, #260

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,88 @@
+# `docs/tests/` — the test-doc format
+
+Each test is a **readable markdown document** that lives here, close to the story it verifies.
+The markdown owns **why / what** (intent); the bound `cicd/tests/` YAML owns **how it runs**
+(execution). `qw-cases` authors these docs, `qw-review-cases` gates them, and (when the binding
+tooling is wired — see "Binding & drift" below) `qw-bind`/`qw-drift` keep the doc and its
+executable in sync.
+
+## One file = one scenario (TS), many cases (TC)
+
+A **scenario** groups related **cases**, each case a sequence of **steps**.
+
+```
+docs/tests/
+  TS-01-<slug>.md     # a scenario: TC-01, TC-02, … each with a Steps table
+  TS-02-….md
+```
+
+- **TS** (scenario) — the file. Holds the front-matter and a `## Why this scenario exists`.
+- **TC** (case) — a `### TC-NN:` section. Has an objective, a **`Script:`** line (the bound
+  `cicd/tests/` YAML), and a **Steps** table.
+- **Step** — one row of a case's Steps table: an **Action** and its **Expected Result**. The
+  binding check compares the doc's step count against the bound YAML's `steps:` count.
+
+## Front-matter (scenario level)
+
+```yaml
+---
+id: TS-02                       # scenario id, unique within the namespace
+title: Runtime comes up healthy on K80
+namespace: ollama37             # which repo this test belongs to
+story: STORY-005                # the need this scenario verifies (→ docs/stories/STORY-005.md)
+story_hash: 7474d8b6…           # sha256 of the linked story file at last sync (drift anchor)
+plan: 257                       # the [STORY-XXX] Test Plan issue it was authored from (optional)
+status: green                   # green | stale | unbound
+---
+```
+
+- `story` + `story_hash` are the **drift anchor**: when the story changes, its hash no longer
+  matches and the scenario is `stale`. Set it with `sha256sum docs/stories/STORY-XXX.md`.
+- The **`Script:` binding is per-TC, not in front-matter** — a scenario's cases can map to
+  different executables.
+
+## Case (TC) structure
+
+```markdown
+### TC-01: Container starts with GPU passthrough and reports healthy
+
+- **Objective:** the runtime container comes up and the K80 GPU is detected.
+- **Script:** cicd/tests/testcases/runtime/TC-RUNTIME-001.yml
+- **Preconditions:** the ollama37 image is built; the host has a Tesla K80 + driver.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Start the container (`docker compose up -d`) | comes up with no `error` in the logs |
+| 2 | Wait for container health | reports `healthy` within the timeout |
+```
+
+The Steps table is **machine-extractable** on purpose: one row = one `Action → Expected Result`,
+and the row count is what the binding check compares to the YAML's `steps:`.
+
+## Suites (the `cicd/tests/testcases/` layout)
+
+Scenarios map to ollama37's four executable suites (see [`cicd/README.md`](../../cicd/README.md)):
+
+| Suite | Verifies | YAML |
+|-------|----------|------|
+| `build` | toolchain image + runtime binary | `cicd/tests/testcases/build/TC-BUILD-*.yml` |
+| `runtime` | container, GPU detection, health, metrics | `cicd/tests/testcases/runtime/TC-RUNTIME-*.yml` |
+| `inference` | model pull + GPU inference smoke | `cicd/tests/testcases/inference/TC-INFERENCE-*.yml` |
+| `models` | per-model regression on K80 | `cicd/tests/testcases/models/TC-MODELS-*.yml` |
+
+## Binding & drift
+
+- **Bind:** each TC's `Script:` points at the `cicd/tests/testcases/**/*.yml` that runs it.
+- **Run:** `npm --prefix cicd/tests test` (the runner — `cli.ts run`; filter with `-- --suite <suite>`).
+- **Audit / drift:** the automated `audit-bind` / `drift` scripts are **not yet ported** to
+  ollama37 (a planned follow-up). Until they are, the binding invariant — each TC's Steps-table
+  **row count equals its bound YAML's `steps:` count** — and `qw-review-cases` are checked by
+  hand. When the scripts land, `status` (green | stale | unbound) becomes their verdict.
+
+## Traceability
+
+- **story → tests:** `grep -l 'story: STORY-XXX' docs/tests/`
+- **test → story / script:** the front-matter `story:` and each case's `Script:` line.
+- **script → test:** the `Script:` path points at the YAML.
+
+No hand-maintained index — the links live in the files and resolve by `grep`/path.


### PR DESCRIPTION
## Summary
- Add **`docs/tests/README.md`** — the test-doc format contract the synced qa-workflow (`qw-cases`/`qw-review-cases`) validates against, adapted from the upstream `test-framework-template`: `namespace: ollama37`, the `build/runtime/inference/models` suites, correct `cicd/tests` paths, the TS/TC/Steps shape + per-TC `Script:` binding + the row-count invariant.
- Honest about scope: the automated `audit-bind`/`drift` scripts aren't ported yet (Phase-2 follow-up); binding/freshness is the manual row-count invariant + `qw-review-cases` for now.
- Land **STORY-005** (the foundational "ollama37 builds and runs on K80" story) so the regression suites have a need to trace back to.

This is **Phase 1** of the revert-path qa adoption (issue #258). The actual test docs derived from the existing YAMLs (#259 build/runtime/inference, #260 models) follow; the qa-workflow **misfit reconcile** is a separate Phase-2 PR.

Fixes #258
Part of STORY-005

## Test plan
- [x] `docs/tests/README.md` documents the fields/shape the synced `qw-*` commands reference (no invented fields).
- [x] Cross-link `../../cicd/README.md` resolves.
- [ ] `qw-review-cases STORY-005` — runs once the TS docs exist (#259/#260).

Generated with [Claude Code](https://claude.com/claude-code)