### PR TITLE
Derive TS-01..03 test docs from existing build/runtime/inference YAML

### DIFF
--- a/docs/tests/TS-01-build.md
+++ b/docs/tests/TS-01-build.md
@@ -1,0 +1,49 @@
+---
+id: TS-01
+title: Build — toolchain image and runtime binary
+namespace: ollama37
+story: STORY-005
+story_hash: 0598aff09de9ddd319d9c168f10a059e16496ea8a26a0d7dcfd1f39f12d9e0f3
+status: green
+---
+
+## Why this scenario exists
+
+ollama37 must *build* before it can run on K80: the cached builder image has to carry the exact
+sm_37 toolchain (CUDA 11.4, GCC 10, Go), the runtime image has to compile from clean source
+without errors, and both images have to stay within sane size bounds. This scenario is the
+build half of [STORY-005](../stories/STORY-005.md).
+
+### TC-01: Builder image verification
+
+- **Objective:** the builder Docker image contains the required build tools (CUDA 11.4, GCC 10, Go).
+- **Script:** cicd/tests/testcases/build/TC-BUILD-001.yml
+- **Preconditions:** the `ollama37-builder:latest` image has been built.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Check the builder image exists | `ollama37-builder:latest` is present |
+| 2 | Verify the CUDA toolkit | reports `Cuda compilation tools`, release `11.4` |
+| 3 | Verify the GCC version | reports `gcc` version 10 |
+| 4 | Verify the Go version | reports `go1.2x` |
+
+### TC-02: Runtime image build
+
+- **Objective:** the ollama37 runtime image builds from local source without errors.
+- **Script:** cicd/tests/testcases/build/TC-BUILD-002.yml
+- **Preconditions:** the builder image exists; local source is checked out.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Build the runtime image | prints `Runtime image built successfully`, no `error:` / `Error:` |
+| 2 | Verify the runtime image exists | `ollama37:latest` is present |
+
+### TC-03: Image size validation
+
+- **Objective:** the builder and runtime image sizes are within expected ranges.
+- **Script:** cicd/tests/testcases/build/TC-BUILD-003.yml
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Check the builder image size | within range (`SIZE_OK`) |
+| 2 | Check the runtime image size | within range (`SIZE_OK`) |

--- a/docs/tests/TS-02-runtime.md
+++ b/docs/tests/TS-02-runtime.md
@@ -1,0 +1,69 @@
+---
+id: TS-02
+title: Runtime — container, GPU detection, health, metrics on K80
+namespace: ollama37
+story: STORY-005
+story_hash: 0598aff09de9ddd319d9c168f10a059e16496ea8a26a0d7dcfd1f39f12d9e0f3
+status: green
+---
+
+## Why this scenario exists
+
+A built image is worthless if the runtime doesn't actually come up on K80: the container must
+start healthy, the Tesla K80 must be detected by both `nvidia-smi` and Ollama's CUDA runtime
+(not fall back to CPU), the health/API must respond, and the `/api/metrics` endpoint must
+report a well-formed schema. This scenario is the runtime half of
+[STORY-005](../stories/STORY-005.md).
+
+### TC-01: Container starts with GPU passthrough and reports healthy
+
+- **Objective:** the ollama37 container starts with GPU passthrough and reaches healthy status.
+- **Script:** cicd/tests/testcases/runtime/TC-RUNTIME-001.yml
+- **Preconditions:** the `ollama37:latest` image is built; the host has a Tesla K80 + driver.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Clean up any old container | prior container removed (idempotent; no failure if absent) |
+| 2 | Start the container | comes up with no `error` / `Error` in the logs |
+| 3 | Wait for container health | reports `Container is healthy` within the timeout |
+| 4 | Check container status | shows `ollama37` `Up` |
+
+### TC-02: Tesla K80 detected by nvidia-smi and the CUDA runtime
+
+- **Objective:** the K80 is detected by `nvidia-smi` and by Ollama's CUDA runtime — no CPU fallback.
+- **Script:** cicd/tests/testcases/runtime/TC-RUNTIME-002.yml
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Check `nvidia-smi` inside the container | lists `Tesla K80` on driver `470.`; no "NVIDIA-SMI has failed" / "No devices were found" |
+| 2 | Check the CUDA libraries | `cuda` libraries present |
+| 3 | Ensure the UVM device exists | `nvidia-uvm` device present |
+| 4 | Check Ollama GPU detection in the logs | `library=CUDA`, `compute=3.7`; never `library=cpu` |
+
+### TC-03: Health check and API responsiveness
+
+- **Objective:** the server reports healthy and the API responds.
+- **Script:** cicd/tests/testcases/runtime/TC-RUNTIME-003.yml
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Check container health status | `healthy` |
+| 2 | Test the API endpoint | returns a `models` payload |
+| 3 | Check the Ollama version | reports `ollama` |
+
+### TC-04: /api/metrics returns a well-formed schema
+
+- **Objective:** `GET /api/metrics` returns HTTP 200 and JSON conforming to the documented schema.
+- **Script:** cicd/tests/testcases/runtime/TC-RUNTIME-004.yml
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Request the endpoint | `HTTP_CODE:200` (not 4xx/5xx) |
+| 2 | Check the top-level schema (gpus, models, errors, totals) | `schema OK` |
+| 3 | Check GPU shape (≥1 GPU with id, name, vram_total) | `gpu shape OK` |
+| 4 | Check error counters present | `error counters OK` |
+| 5 | Check totals shape (gpu_count ≥1, loaded_models ≥0) | `totals OK` |
+| 6 | Check `gpus[]` length matches `totals.gpu_count` | `gpus length consistent OK` |
+| 7 | Check `gpu_count` matches the `nvidia-smi` count | `gpu_count match OK` |
+| 8 | Check `gpus[].name` is the marketing name, not the runtime label | `gpu name OK` |
+| 9 | Dump the full response for inspection | full JSON printed |

--- a/docs/tests/TS-03-inference.md
+++ b/docs/tests/TS-03-inference.md
@@ -1,0 +1,37 @@
+---
+id: TS-03
+title: Inference — model pull and GPU inference smoke on K80
+namespace: ollama37
+story: STORY-005
+story_hash: 0598aff09de9ddd319d9c168f10a059e16496ea8a26a0d7dcfd1f39f12d9e0f3
+status: green
+---
+
+## Why this scenario exists
+
+The point of the build is to *infer* on K80. This scenario proves a model pulls into the
+container and the REST API generates a real response using GPU memory — without a CUBLAS/CUDA
+error and without silently falling back to CPU. It is the inference half of
+[STORY-005](../stories/STORY-005.md).
+
+### TC-01: Pull the test model
+
+- **Objective:** the `gemma3:4b` test model pulls into the container.
+- **Script:** cicd/tests/testcases/inference/TC-INFERENCE-001.yml
+- **Preconditions:** the runtime container is up and healthy.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Pull the test model | reports `success` / `already exists` / `pulling`; no `error pulling` / `Error:` |
+| 2 | Verify the model is available | `gemma3:4b` listed |
+
+### TC-02: API inference allocates GPU memory
+
+- **Objective:** the generate endpoint returns a response using GPU memory, with no CUDA/CUBLAS error.
+- **Script:** cicd/tests/testcases/inference/TC-INFERENCE-002.yml
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Call the generate endpoint | returns a `response`; no `error` / `CUBLAS_STATUS` / `CUDA error` |
+| 2 | Check GPU memory usage | reports non-zero `MiB` in use |
+| 3 | Unload the model after the test | `Model unload requested` |


### PR DESCRIPTION
## Summary
Backfill readable test docs for the pipeline suites, derived from each `TC-*.yml`'s `intent.user_story` + `steps` (no invented coverage):
- `docs/tests/TS-01-build.md` (TC-BUILD-001..003)
- `docs/tests/TS-02-runtime.md` (TC-RUNTIME-001..004)
- `docs/tests/TS-03-inference.md` (TC-INFERENCE-001..002)

Each `### TC-NN` binds to its YAML via `Script:`; the Steps-table row count equals that YAML's `steps:` count (the binding invariant — **verified for all 9 cases**). `story_hash` anchors STORY-005; `plan:` omitted (no Test Plan issue in the revert path). `qw-review-cases STORY-005` passes.

Phase 1 of the revert-path qa adoption. The models doc (#260) and the Phase-2 misfit reconcile follow separately.

Fixes #259
Part of STORY-005

## Test plan
- [x] Binding invariant verified (doc Steps rows == YAML `steps:`) for all 9 cases.
- [x] `qw-review-cases STORY-005` passes (front-matter resolvable, steps observable, format-conformant, traces both ways).
- [x] Every `Script:`/`story:` link resolves.

Generated with [Claude Code](https://claude.com/claude-code)