### PR TITLE
Trim workflow-patterns/ci-run/ci-testcase to ollama37's real CI + runner

### DIFF
--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -5,51 +5,55 @@ paths:
 
 # CI Workflow Patterns
 
-## Per-Feature Workflow Pattern
+ollama37's CI is organized by **test suite**, with a pipeline workflow that chains the suites,
+plus separate perf/experiment workflows. All run on the self-hosted Tesla K80 runner.
 
-Split CI into composable, independently triggerable workflows:
-
-```
-.github/workflows/
-├── build.yml                # Standalone build step
-├── test-run.yml             # Reusable test runner (called by feature workflows)
-├── test-<feature>.yml       # One per feature (~25 lines, thin delegator)
-└── ci.yml                   # Full pipeline: build -> all features in parallel
-```
-
-**Adding a new feature test:**
-1. Tag test cases: `tags: [my-feature]`
-2. Copy `test-feature-example.yml` -> `test-my-feature.yml`
-3. Change the `tag` input value to `my-feature`
-4. Add the new workflow as a job in `ci.yml`
-
-### Suite-Based Alternative
-
-For projects organized by test suite rather than feature:
+## Suite workflows + the pipeline
 
 ```
 .github/workflows/
-├── build.yml
-├── test-run.yml             # Same reusable runner
-├── test-build.yml           # Uses --suite build
-├── test-integration.yml     # Uses --suite integration
-└── ci.yml                   # Orchestrates all suites
+├── test-build.yml        # build suite     (toolchain image, runtime image, image sizes)
+├── test-runtime.yml      # runtime suite   (container, GPU detection, health, /api/metrics)
+├── test-inference.yml    # inference suite (model pull + GPU inference smoke)
+├── test-models.yml       # models suite    (per-model regression on K80)
+└── test-pipeline.yml     # full pipeline: build → runtime → inference → models (via needs:)
 ```
 
-Both patterns use `test-run.yml` as the single reusable job.
+Each suite workflow runs the TypeScript runner (`cli.ts run`) filtered by `--suite`. The
+pipeline chains the suites with job `needs:` dependencies; the inference/models suites are the
+ones that exercise the agent judge.
+
+**Adding a suite test:** add a `TC-<SUITE>-NNN.yml` under `cicd/tests/testcases/<suite>/` (via
+`ci-testcase`) — no workflow change needed; the suite workflow picks it up by `--suite`.
+
+## Perf / experiment workflows
+
+Performance and capability experiments run via the runner's perf subcommands, separate from the
+suite workflows:
+
+```
+├── test-throughput.yml   # cli.ts bench-throughput — per-model tok/s + output check
+└── test-fa-k80.yml       # cli.ts test-fa — flash-attention regression + benchmark
+```
+
+(`cli.ts test-mcp` — MCP tool-call capability — is a subcommand with no workflow yet.)
+`release-docker.yml` builds and publishes the image on a release.
 
 ## Key Design Decisions
 
-**Dual triggers:** Each workflow supports both `workflow_dispatch` (manual, with dropdowns) and `workflow_call` (callable from pipeline). This lets you run features independently or as part of the full CI.
+**Dual triggers:** workflows support `workflow_dispatch` (manual) and, where they compose,
+`workflow_call` (the pipeline calls the suites). Run a suite alone or as part of the pipeline.
 
-**Judge mode dropdown:** Each workflow offers `simple` (default — fast, deterministic, no model) or `dual` (simple + the opt-in agent judge). The workflow sets `JUDGE_MODE` from this input; the runner is simple-only unless it reads `dual`.
+**Judge mode:** the inference/models workflows offer `simple` (default — fast, deterministic, no
+model) or `dual` (simple + the opt-in agent judge), set via `JUDGE_MODE`. The runner is
+simple-only unless it reads `dual`.
 
 ## Environment Variables
 
-The agent judge is an Agent Client Protocol client: it drives an ACP agent that
-authenticates itself, so the judge runs keyless — no Console API key. Swapping the
-model or vendor means pointing `JUDGE_AGENT` at a different ACP agent, not changing
-code. Set these via GitHub repository variables/secrets (`Settings > Variables/Secrets > Actions`):
+The agent judge is an Agent Client Protocol client: it drives an ACP agent that authenticates
+itself, so the judge runs keyless — no Console API key. Swapping the model or vendor means
+pointing `JUDGE_AGENT` at a different ACP agent, not changing code. Set these via GitHub
+repository variables/secrets (`Settings > Variables/Secrets > Actions`):
 
 | Variable | Purpose | Example |
 |----------|---------|---------|
@@ -58,7 +62,3 @@ code. Set these via GitHub repository variables/secrets (`Settings > Variables/S
 | `CLAUDE_CODE_OAUTH_TOKEN` | Secret that authenticates the bundled Claude agent on a GitHub-hosted runner; unneeded on a self-hosted runner logged into Claude Code | `sk-ant-oat...` |
 
 **Two auth paths for `dual`:** on a GitHub-hosted runner, add the `CLAUDE_CODE_OAUTH_TOKEN` secret. On a self-hosted runner already logged into Claude Code, the agent uses `~/.claude` and no secret is needed — point the workflow's `runs-on` at that runner. Either way, an unauthenticated agent degrades cleanly to the simple judge.
-
-## Legacy Workflows
-
-`test-pipeline.yml` and `test-suite.yml` are the original suite-based workflows. They still work but the per-feature pattern (`ci.yml` + `test-run.yml`) is recommended for projects with many test cases.

--- a/.claude/skills/ci-run/SKILL.md
+++ b/.claude/skills/ci-run/SKILL.md
@@ -24,9 +24,8 @@ Run YAML test cases by executing commands and evaluating results against pattern
 ### Step 1: Load Test Cases
 
 Input can be:
-- A test ID (e.g., `TC-INT-001`) — run that specific test
-- A suite name (e.g., `integration`) — run all tests in that suite
-- A tag name (e.g., `auth`) — run all tests with that tag
+- A test ID (e.g., `TC-RUNTIME-001`) — run that specific test
+- A suite name (`build`, `runtime`, `inference`, or `models`) — run all tests in that suite
 - Empty — run all tests
 
 Read YAML test case files from `cicd/tests/testcases/`.
@@ -68,12 +67,12 @@ Output a summary table:
 ```
 Test Results
 ============
-TC-INT-001  Query resources            PASS  (1.2s)
-TC-INT-002  Create and verify          FAIL  (step 2: expected pattern "active" not found)
-TC-E2E-001  Full lifecycle             PASS  (5.8s)
+TC-RUNTIME-001   Container Startup     PASS  (12.4s)
+TC-RUNTIME-002   GPU Detection         FAIL  (step 4: expected "library=CUDA" not found)
+TC-INFERENCE-002 API Inference Test    PASS  (8.1s)
 
 Summary: 2/3 passed
-Duration: 8.2s
+Duration: 28.6s
 ```
 
 If any test failed, show:
@@ -87,12 +86,11 @@ Instead of agent-based execution, use the built-in CLI:
 
 ```bash
 cd cicd/tests
-npm test                        # All tests (simple judge — fast, no model)
-npm test -- --suite integration # Specific suite
-npm test -- --id TC-INT-001     # Specific test
-npm test -- --tag auth          # Tests tagged 'auth'
-npm test -- --dry-run           # Preview only
-JUDGE_MODE=dual npm test        # Opt in the agent judge (env, not a flag)
+npm test                         # All tests (simple judge — fast, no model)
+npm test -- --suite runtime      # Specific suite (build|runtime|inference|models)
+npm test -- --id TC-RUNTIME-001  # Specific test
+npm test -- --dry-run            # Preview only
+JUDGE_MODE=dual npm test         # Opt in the agent judge (env, not a flag)
 ```
 
 **Environment variables for CI:**

--- a/.claude/skills/ci-testcase/SKILL.md
+++ b/.claude/skills/ci-testcase/SKILL.md
@@ -46,16 +46,23 @@ Create test case file(s) in `cicd/tests/testcases/<suite>/` using this format:
 ```yaml
 id: TC-[SUITE]-[NUMBER]
 name: Descriptive test name
-suite: build|integration|e2e
-goal: One-line test objective for agent judge
+suite: build|runtime|inference|models
 priority: 1-10 (lower = runs first)
 timeout: 30000
 dependencies: []
 tags: [feature-name]
 
+intent:                    # the design authority — why this test exists
+  user_story: |
+    What value this test delivers
+  acceptance:              # optional — observable criteria
+    - "..."
+  notes: |                 # optional — prerequisites, gotchas, acceptable warnings
+    ...
+
 steps:
   - name: Step description
-    command: <shell command or mcp-client.ts call>
+    command: <shell command>
     timeout: 5000              # Optional
     expectPatterns:
       - "regex pattern"
@@ -69,18 +76,14 @@ criteria: |
 ```
 
 **Suite guidelines:**
-- `build` — compilation, dependency checks, environment validation
-- `integration` — single tool/API calls, verify output format and correctness
-- `e2e` — multi-step workflows, verify end-to-end state
+- `build` — toolchain image, runtime image build, image sizes
+- `runtime` — container startup, GPU detection, health, `/api/metrics`
+- `inference` — model pull + GPU inference smoke
+- `models` — per-model regression on K80
 
-**ID format:** `TC-BUILD-XXX`, `TC-INT-XXX`, `TC-E2E-XXX`
+**ID format:** `TC-BUILD-XXX`, `TC-RUNTIME-XXX`, `TC-INFERENCE-XXX`, `TC-MODELS-XXX`
 
-**Tags:** Use feature names or capability areas (e.g., `auth`, `api`, `build`). Tags enable per-feature CI workflows via `--tag`.
-
-**For MCP tool testing:**
-```yaml
-command: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '{"arg":"value"}'
-```
+**Tags:** the `tags:` field is optional metadata; the runner selects by `--suite`/`--id` (there is no `--tag` filter).
 
 **For shell command testing:**
 ```yaml

--- a/docs/stories/STORY-006.md
+++ b/docs/stories/STORY-006.md
@@ -1,0 +1,51 @@
+# STORY-006: The synced qa-workflow tooling fits ollama37 and is trustworthy
+
+## User Story
+
+As a maintainer (or agent) using ollama37's `.claude` tooling,
+I want the synced qa-workflow and CI skills/commands to match how this repo actually works,
+So that I can trust and run them without hitting dangling references, contradictions, or steps that assume infrastructure that isn't here.
+
+## The Need
+
+ollama37 recently synced its qa-workflow and test-framework tooling from an upstream template.
+The sync brought the agent-facing commands, rules, and skills, but several of them describe a
+setup ollama37 doesn't have or a testing model it doesn't use — so following them leads to dead
+ends. Concretely, the tooling currently: points at files and scripts that don't exist here;
+describes a CI structure and a runner flag the repo doesn't use; carries a design skill written
+for a different kind of test suite than ollama37's; and contains a command set that contradicts
+its own rule about how big the workflow is. A maintainer or agent who trusts these as-is wastes
+time discovering, one failure at a time, that the instructions don't apply. The tooling should
+either fit this repo or honestly say what isn't wired yet — nothing should silently mislead.
+
+Phase 1 (STORY-005) already made the authoring half real (the format contract + the test docs);
+this is the cleanup that makes the rest of the synced tooling coherent.
+
+## Success Looks Like
+
+- Every synced command, rule, and skill either applies to ollama37 as written, or is trimmed/
+  removed/marked so it no longer claims something untrue.
+- No dangling references: anything a synced file points to (a file, a script, a workflow, a
+  command flag) exists, or the reference is dropped.
+- No internal contradiction: the qa-workflow rule and its commands agree on the same scope.
+- A design skill that doesn't match ollama37's testing model is adapted to it or set aside, not
+  left as a misleading rule.
+- Where capability genuinely isn't built yet (e.g. automated binding/freshness checks), the
+  tooling says so plainly rather than implying it works.
+- A maintainer/agent can read any piece of the synced tooling and act on it without hitting a
+  step that can't be followed.
+
+## Open Questions
+
+- Whether to *port* the missing automation (the binding/freshness scripts) or just *document*
+  that it isn't wired yet — settled per item when the work is planned; porting may be its own
+  separate effort.
+- Whether the contradictory command set should be reconciled toward the lighter or the heavier
+  shape — decided against how ollama37 actually intends to use it.
+- Which synced pieces are worth keeping at all versus removing as not-applicable.
+
+## Status
+
+- Created: 2026-06-16
+- Plan: #264
+- Issues: #265, #266, #267


### PR DESCRIPTION
## Summary
Phase 2 (qa-workflow misfit reconcile), task 1 of 3 — make the synced CI skills/rule describe what ollama37 actually has:
- **`workflow-patterns.md`** — rewritten to the real suite-based workflows (`test-build/runtime/inference/models.yml` + `test-pipeline.yml`) and the perf workflows; dropped the nonexistent per-feature `ci.yml`/`test-run.yml`/`test-feature-example.yml`/`--tag` pattern (all referenced workflows verified to exist).
- **`ci-run`** — examples use real IDs/suites; dropped `--tag` and the `integration` suite (the runner has only `--suite`/`--id`; suites are build/runtime/inference/models).
- **`ci-testcase`** — real suite names + ID formats; removed the absent `mcp-client.ts` example and the `--tag` claim; the generated YAML now leads with the `intent:` block (the design authority) matching the existing test cases.

`reviewing-artifacts`: workflow-patterns + ci-run PASS; ci-testcase had one Q4 fit finding (goal→intent), fixed. grep confirms no remaining dangling file/flag references.

Fixes #265
Part of STORY-006

## Test plan
- [x] grep sweep across the three files: no reference to a file/flag that doesn't exist.
- [x] All workflows named in `workflow-patterns.md` exist in `.github/workflows/`.
- [x] `reviewing-artifacts` run on the changed rule + skills.

Generated with [Claude Code](https://claude.com/claude-code)