### PR TITLE
Reconcile qa-workflow rule with qw-* command scope

### DIFF
--- a/.claude/commands/qa-workflow/qw-bind.md
+++ b/.claude/commands/qa-workflow/qw-bind.md
@@ -16,7 +16,7 @@ link still holds.
 Fits in the qa-workflow:
 
     qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → dw-merge
-    (qw-run = `npm test` — the cicd runner; a phase, not a slash command)
+    (qw-run = `npm --prefix cicd/tests test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -24,10 +24,10 @@ Fits in the qa-workflow:
 
 ### A. Forward — bind an existing test doc
 
-    /qw-bind docs/tests/TS-01-stack-lifecycle.md
+    /qw-bind docs/tests/TS-02-runtime.md
         │
         ├─► For each `### TC-NN:` case, set a `Script:` line to the cicd YAML that
-        │   runs it (e.g. cicd/tests/testcases/integration/TC-INTEGRATION-001.yml).
+        │   runs it (e.g. cicd/tests/testcases/runtime/TC-RUNTIME-001.yml).
         ├─► Keep the case's Steps table aligned 1:1 with the YAML's steps — the
         │   audit treats a step-count mismatch as `unbound`.
         └─► Run `/qw-review-bind` to confirm the binding.
@@ -36,19 +36,21 @@ Fits in the qa-workflow:
 
     /qw-bind cicd/tests/testcases/build/TC-BUILD-001.yml
         │
-        ├─► Generate a scaffold from the YAML:
-        │     npm --prefix cicd/tests run port-yaml -- <yaml> > docs/tests/TS-NN-<slug>.md
-        │   The scaffold carries the steps and the `Script:` binding; objective,
-        │   expected results, story link, and namespace are TODOs.
-        ├─► Fill the TODOs: `namespace`, `story` (+ `story_hash`), each TC's
-        │   objective and Expected Result column. (The format contract is docs/tests/README.md.)
-        └─► Run `/qw-review-bind` to confirm the binding, then `/qw-cases`-style review.
+        ├─► Scaffold a TS doc from the YAML by hand: one `### TC-NN` per case, a
+        │   `Script:` to the YAML, and a Steps row per YAML `step` (row count == the
+        │   YAML's `steps:`). The STORY-005 TS docs are worked examples; the format
+        │   contract is docs/tests/README.md.
+        ├─► Fill the rest: `namespace`, `story` (+ `story_hash`), each TC's objective
+        │   and Expected Result column.
+        └─► Run `/qw-review-bind` to confirm the binding.
+        (An automated `port-yaml` scaffolder is a deferred port — STORY-006/Phase 2.)
 
 ---
 
 ## API Notes
 
-- `port-yaml` is a scaffolder, not a translator — a human/agent fills meaning.
+- Scaffolding is by hand today; an automated `port-yaml` is a deferred port
+  (STORY-006/Phase 2). Either way it carries structure, not meaning — a human/agent fills that.
 - `story_hash` = `sha256sum docs/stories/STORY-XXX.md` (the drift anchor).
 - Producer paired with `/qw-review-bind` (the audit).
 ```

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -1,8 +1,8 @@
 # Write the Test Docs
 
 ```
-Turn a reviewed test plan into readable test docs in docs/tests/ — reusing vetted
-steps from the store instead of re-inventing them.
+Turn a reviewed test plan into readable test docs in docs/tests/ — reusing existing
+steps instead of re-inventing them.
 
 Target: the scenarios approved by /qw-review-plan for a STORY-XXX.
 
@@ -16,7 +16,7 @@ Action / Expected Result rows.
 Fits in the qa-workflow:
 
     qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    (qw-run = `npm --prefix cicd/tests test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -30,15 +30,13 @@ Fits in the qa-workflow:
         │       issue, status: green
         │   - (Format and field meanings: docs/tests/README.md.)
         │
-        ├─► Step 2: Write each case (TC) — reuse before re-inventing (dogfood the store)
-        │   - For each step you are about to write, ask the store first:
-        │       make query Q="<the action you mean>"
-        │     If a vetted step comes back close, phrase yours to match it — same
-        │     meaning, same good expected result — instead of coining a new one.
+        ├─► Step 2: Write each case (TC) — reuse before re-inventing
+        │   - Before writing a step, skim the existing docs/tests/ for one that
+        │     already means the same thing; phrase yours to match it — same meaning,
+        │     same good expected result — instead of coining a new one.
         │   - Fill the Steps table: each row one Action + its Expected Result.
         │
-        ├─► Step 3: Index + bind
-        │   - Load the new docs into the store:  npm --prefix step-store run load-tests
+        ├─► Step 3: Bind
         │   - Bind each case to its executable:  /qw-bind  (then /qw-review-bind)
         │
         └─► Step 4: Hand off
@@ -48,8 +46,9 @@ Fits in the qa-workflow:
 
 ## API Notes
 
-- Reuse is the point of the store: `search_step` (via `make query`) makes a vetted
-  step findable so coverage converges instead of duplicating.
+- Reuse keeps coverage converging instead of duplicating: skim the existing
+  docs/tests/ for a matching step before coining a new one. (A searchable step
+  store is a deferred enhancement — STORY-006/Phase 2.)
 - `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
 - Producer paired with `/qw-review-cases`.
 ```

--- a/.claude/commands/qa-workflow/qw-drift.md
+++ b/.claude/commands/qa-workflow/qw-drift.md
@@ -4,7 +4,7 @@
 Surface every test that no longer matches what it verifies — before a stale
 test passes quietly and a green build lies.
 
-Target: every test doc under docs/tests/ (runs in CI and on demand).
+Target: every test doc under docs/tests/ (on demand today; a CI gate once the drift port lands).
 
 ## PURPOSE
 
@@ -14,7 +14,7 @@ this looks, deterministically, every run.
 
 Fits in the qa-workflow:
 
-    … → qw-run → [human] → dw-merge   (qw-run = `npm test` — the cicd runner, not a slash command)
+    … → qw-run → [human] → dw-merge   (qw-run = `npm --prefix cicd/tests test` — the cicd runner, not a slash command)
                     └──────────────► qw-drift ──► back to qw-cases when stale
 
 ---
@@ -23,13 +23,13 @@ Fits in the qa-workflow:
 
     /qw-drift
         │
-        ├─► Run the gate:  npm --prefix cicd/tests run drift
-        │   Two deterministic signals, per case/scenario:
-        │     - STALE   — the linked story's sha256 no longer matches the doc's
-        │                 `story_hash` (the story moved since the test was synced).
-        │     - UNBOUND — the doc and its bound executable diverged (reuses the
-        │                 binding audit).
-        │   Exits non-zero if anything is stale or unbound (so CI fails on drift).
+        ├─► Run the checks (by hand for now), per case/scenario:
+        │     - STALE   — `sha256sum docs/stories/STORY-XXX.md` no longer matches the
+        │                 doc's `story_hash` (the story moved since the test was synced).
+        │     - UNBOUND — the doc's Steps row count no longer matches the bound YAML's
+        │                 `steps:` count (the binding diverged).
+        │   (An automated `npm --prefix cicd/tests run drift` doing both and exiting
+        │   non-zero so CI fails on drift is a deferred port — STORY-006/Phase 2.)
         │
         └─► On a finding:
             - STALE: re-read the test against the changed story. If it still holds,
@@ -41,9 +41,10 @@ Fits in the qa-workflow:
 
 ## API Notes
 
-- Hash-first is deterministic and needs no stack; it runs in CI and on demand.
-- A semantic, embedding-based signal (softer "drifted in meaning", via the store)
-  is a planned advisory add — hash is the build-failing gate.
+- Hash-first is deterministic and needs no stack; it's a by-hand check today, and a
+  build-failing CI gate once the `drift` port lands (STORY-006/Phase 2).
+- A semantic, embedding-based signal (softer "drifted in meaning") is a further
+  planned advisory add — the hash + row-count checks are the structural gate.
 - `status` in a test doc (green | stale | unbound) reflects this gate's verdict.
 - No paired producer — `qw-drift` *is* a review (the qa-workflow pairing rule).
 ```

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -15,7 +15,7 @@ that together cover the need, so `qw-cases` has a scoped plan to write against.
 Fits in the qa-workflow:
 
     qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    (qw-run = `npm --prefix cicd/tests test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -27,12 +27,11 @@ Fits in the qa-workflow:
         │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
         │   - If an on-request target: restate what behaviour is to be verified.
         │
-        ├─► Step 2: Check what already exists (dogfood the store)
-        │   - Search the step-store for steps/cases already covering this:
-        │       make query Q="<the behaviour>"
-        │     so the plan reuses vetted coverage instead of duplicating it.
-        │   - List the docs/tests/ scenarios already linked to this story:
+        ├─► Step 2: Check what already exists
+        │   - List the docs/tests/ scenarios already linked to this story and skim
+        │     them, so the plan reuses existing coverage instead of duplicating it:
         │       grep -l 'story: STORY-XXX' docs/tests/
+        │     (A searchable step-store is a deferred enhancement — STORY-006/Phase 2.)
         │
         ├─► Step 3: Propose scenarios
         │   - Break the need into scenarios (TS-to-be), each:

--- a/.claude/commands/qa-workflow/qw-review-bind.md
+++ b/.claude/commands/qa-workflow/qw-review-bind.md
@@ -9,13 +9,13 @@ Target: the docs/tests/ scenarios (all, or one named file).
 ## PURPOSE
 
 The paired review for `/qw-bind`. Binding is audit-not-codegen, so something has to
-*check* that the markdown and the YAML haven't drifted apart. This runs the
-deterministic audit and adds a human/agent pass for meaning.
+*check* that the markdown and the YAML haven't drifted apart. This runs the structural
+audit (by hand today) and adds a human/agent pass for meaning.
 
 Fits in the qa-workflow:
 
     qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → dw-merge
-    (qw-run = `npm test` — the cicd runner; a phase, not a slash command)
+    (qw-run = `npm --prefix cicd/tests test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -23,13 +23,13 @@ Fits in the qa-workflow:
 
     /qw-review-bind
         │
-        ├─► Step 1: Run the deterministic audit
-        │     npm --prefix cicd/tests run audit-bind
-        │   For each case it checks:
+        ├─► Step 1: Run the structural audit (by hand)
+        │   For each case, check:
         │     - the `Script:` path resolves to a file, and
-        │     - the doc's step count matches the YAML's step count.
-        │   A failure prints `UNBOUND` with the reason; the command exits non-zero
-        │   (so CI and the drift gate, #27, can gate on it).
+        │     - the doc's Steps row count matches the bound YAML's `steps:` count.
+        │   Either mismatch = `UNBOUND`.
+        │   (An automated `audit-bind` that does this and exits non-zero for CI to
+        │   gate on is a deferred port — STORY-006/Phase 2.)
         │
         ├─► Step 2: Read the meaning the audit can't
         │   For each `bound` case, skim that the doc's Actions/Expected Results
@@ -45,8 +45,9 @@ Fits in the qa-workflow:
 
 ## API Notes
 
-- The audit (`audit-bind`) is structural + deterministic; it is the runnable check
-  CI and `/qw-drift` reuse. Semantic agreement is the reviewer's job.
+- The structural audit (the `Script:` path resolves + the row counts match) is done
+  by hand today; an automated `audit-bind` that CI and `/qw-drift` reuse is a deferred
+  port (STORY-006/Phase 2). Semantic agreement is the reviewer's job.
 - `unbound` is one of the test doc's `status` values (docs/tests/README.md).
 - Review paired with the producer `/qw-bind`.
 ```

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -14,7 +14,7 @@ gates the written docs for quality and traceability.
 Fits in the qa-workflow:
 
     qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    (qw-run = `npm --prefix cicd/tests test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -35,7 +35,7 @@ Fits in the qa-workflow:
         │
         └─► Step 3: Decision
             - PASS: docs do their job and trace back → proceed to `/qw-bind` (if not
-              yet bound), then run it (`make up` + the cicd runner).
+              yet bound), then run it (`npm --prefix cicd/tests test`).
             - REVISE: fix the named doc — smallest change first — and re-check.
 
 ---

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -15,7 +15,7 @@ so coverage gaps are caught cheaply.
 Fits in the qa-workflow:
 
     qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    (qw-run = `npm --prefix cicd/tests test` — the cicd runner; a phase, not a slash command)
 
 ---
 

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -45,6 +45,9 @@ No producer ships without a review covering its output.
 - **Owns:** the authoring flow + the `docs/tests/` test-doc format (the contract). Self-contained
   — markdown + GitHub only.
 - **Hands off:** binding each case to an executable and running it is the **project's binding +
-  run layer**. Reusing vetted steps (a search index) is an **optional** project enhancement.
+  run layer** (`qw-bind` / `qw-review-bind` / `qw-drift`). In ollama37 that layer is **manual
+  today** — set the `Script:` link, keep the row-count invariant (a doc's Steps rows == the
+  bound YAML's `steps:`), run `npm --prefix cicd/tests test`. The automation (`audit-bind` /
+  `drift` / `port-yaml`) and a searchable step-store are **deferred ports** (STORY-006/Phase 2).
 
 The format a test doc must follow is `docs/tests/README.md`.


### PR DESCRIPTION
## Summary
Phase 2 (qa-workflow misfit reconcile), final task of 3 — make the `qa-workflow.md` rule and the `qw-*` commands agree, and stop the commands instructing steps that can't be followed here.

- **`qa-workflow.md`** — the binding/run layer is **manual today** (set the `Script:` link, keep the row-count invariant — a doc's Steps rows == the bound YAML's `steps:` — and run `npm --prefix cicd/tests test`); the automation (`audit-bind`/`drift`/`port-yaml`) and a searchable step-store are **deferred ports**.
- **`qw-plan`/`qw-cases`** — dropped the step-store `make query` reuse; reuse = skim existing `docs/tests`.
- **`qw-bind`** — real suite in the example (was the nonexistent `integration`); manual scaffold; `port-yaml` noted deferred.
- **`qw-review-bind`/`qw-drift`** — structural audit + freshness checks by hand (`Script:` resolves + Steps-rows == YAML `steps:`; `story_hash` == sha256 of the story); `audit-bind`/`drift` noted deferred.
- Standardized the `qw-run` note to `npm --prefix cicd/tests test` across all commands.

`reviewing-artifacts`: all 8 PASS (2 Q4 wording fixes); producer→review pairings intact. grep confirms no `make up`/`make query`/`integration` instruction remains — only honest "deferred port" notes.

This completes STORY-006 (the Phase-2 misfit reconcile).

Fixes #267
Part of STORY-006

## Test plan
- [x] grep: no unbuilt-infra step instructed as runnable; remaining mentions are deferred-port notes.
- [x] `reviewing-artifacts` run on the rule + all 7 commands.
- [x] rule and commands describe the same (lighter) scope.

Generated with [Claude Code](https://claude.com/claude-code)