### PR TITLE
docs/tests format note (subcommand binding) + TS-05-mcp.md

### DIFF
--- a/docs/stories/STORY-007.md
+++ b/docs/stories/STORY-007.md
@@ -1,0 +1,44 @@
+# STORY-007: Capability test tools are documented and CI-runnable
+
+## User Story
+
+As a maintainer of the K80 fork,
+I want each capability/performance test tool to have a readable test doc and be runnable on demand from CI,
+So that anyone can see what a tool verifies and trigger it without reading the source.
+
+## The Need
+
+The fork has three on-demand capability tools — a throughput benchmark, a flash-attention
+regression, and an MCP tool-call probe. They already work and report the same way (a per-model
+result table plus a JSON artifact), but they're only half-wired into how the project tracks
+tests: none has a readable test doc, two of the three don't trace back to the need they verify,
+and the MCP tool-call probe can't be triggered from CI at all — it only runs by hand on a
+developer's machine. So a maintainer can't discover what each tool checks, or run the MCP probe
+through CI, without going into the code. The structured suites (build/runtime/inference/models)
+already have this — these tools should match.
+
+This is a **backfill**: document what already exists and wire the missing CI trigger. It does
+not change how any tool verifies a result.
+
+## Success Looks Like
+
+- Each of the three capability tools has a readable test doc that states what it verifies and
+  traces to the need it serves.
+- The MCP tool-call probe can be triggered on demand from CI — the same way the throughput and
+  flash-attention tools already can — with its credentials supplied securely.
+- The test-doc review gate passes over the new docs.
+- No change to how the tools judge results — they're documented and wired, not re-designed.
+
+## Open Questions
+
+- How a test doc records its binding to a tool that is a **command/workflow rather than a YAML
+  test case** — settled when the work is planned (a small format convention).
+- Stronger MCP verification (having the judge independently re-run the tool to check the answer
+  against live data) and the broader MCP capability ladder are **separate, later stories**, not
+  part of this backfill.
+
+## Status
+
+- Created: 2026-06-16
+- Plan: #271
+- Issues: #273, #274, #275

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -73,6 +73,11 @@ Scenarios map to ollama37's four executable suites (see [`cicd/README.md`](../..
 ## Binding & drift
 
 - **Bind:** each TC's `Script:` points at the `cicd/tests/testcases/**/*.yml` that runs it.
+- **Subcommand / workflow binding:** when a tool has no YAML test case — e.g. a `cli.ts`
+  perf/capability subcommand (`bench-throughput`, `test-fa`, `test-mcp`) — a TC's `Script:` may
+  point at the **subcommand** (`cli.ts test-mcp …`) or its **workflow** instead. The row-count
+  invariant below applies **only to YAML-bound cases**; a subcommand-bound case's Steps describe
+  the subcommand's logical flow, not YAML `steps:`.
 - **Run:** `npm --prefix cicd/tests test` (the runner — `cli.ts run`; filter with `-- --suite <suite>`).
 - **Audit / drift:** the automated `audit-bind` / `drift` scripts are **not yet ported** to
   ollama37 (a planned follow-up). Until they are, the binding invariant — each TC's Steps-table

--- a/docs/tests/TS-05-mcp.md
+++ b/docs/tests/TS-05-mcp.md
@@ -1,0 +1,51 @@
+---
+id: TS-05
+title: MCP tool-call capability — can a model drive a real MCP server's tools
+namespace: ollama37
+story: STORY-004
+story_hash: 4e602782b1a4a6813fc9cf3bf0ef58ec85929e78553d68eba81351171282582d
+status: green
+---
+
+## Why this scenario exists
+
+Chatting is not the same as *driving tools*. This scenario proves whether a given model can take
+a real MCP server's tool menu, pick the right tool with valid arguments, run it against the live
+backend, and use the result in its answer — and that the harness reports a model that *can't* do
+tools cleanly rather than crashing. It is the capability [STORY-004](../stories/STORY-004.md)
+delivers. Bound to the `cli.ts test-mcp` subcommand (no YAML), so the Steps below describe its
+logical flow.
+
+### TC-01: a tool-capable model drives `list_projects` on the real testlink-mcp
+
+- **Objective:** the model calls the right tool against the live server and produces a grounded answer.
+- **Script:** `cli.ts test-mcp <tool-capable-model> --judge` (default server: testlink-mcp)
+- **Preconditions:** Ollama up with the model pulled; testlink-mcp reachable with `TESTLINK_URL` / `TESTLINK_API_KEY`.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Run the host against the real testlink-mcp | the server is spawned and its tools are listed + translated to Ollama tools |
+| 2 | The model receives the menu + the prompt ("List the projects") | it emits a `list_projects` tool call with valid args (a real tool, required args present) |
+| 3 | The host executes the call against live TestLink | a real project list comes back (e.g. ollama37, testlink-mcp), `isError=false` |
+| 4 | The model produces a final answer from the result | a non-empty answer that names the real projects |
+| 5 | Judge the trajectory | simple check **and** the agent judge both PASS |
+
+### TC-02: a model with no tool support is reported cleanly
+
+- **Objective:** a model whose template can't do tools yields a clean verdict, not a crash.
+- **Script:** `cli.ts test-mcp <no-tool-model>` (e.g. gemma3:4b)
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Run the host with a no-tool model | Ollama responds "does not support tools" |
+| 2 | Report the verdict | **NO TOOL SUPPORT** — a clean per-model verdict, not a crash, and it does not redden the exit code on its own |
+
+### TC-03: server-agnostic — the same host drives a different MCP server
+
+- **Objective:** the host works against any stdio MCP server — no testlink coupling.
+- **Script:** `cli.ts test-mcp <tool-capable-model> --mcp-command <cmd> --mcp-args <args>`
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Point the host at a second real stdio MCP server (e.g. an echo server) via the flags | the host lists + drives that server's tools, no testlink involved |
+| 2 | The model calls one of its tools and uses the result | tool executed against the real server; grounded answer → PASS |


### PR DESCRIPTION
## Summary
First task of STORY-007 (capability tools documented + CI-runnable):
- `docs/tests/README.md` — a TC's `Script:` may bind to a **subcommand/workflow** when there's no YAML executable; the row-count invariant applies only to YAML-bound cases. (Enables docs for the perf/capability subcommands.)
- `docs/tests/TS-05-mcp.md` — the MCP tool-call capability test doc (`story: STORY-004`), 3 cases bound to `cli.ts test-mcp`: a tool-capable model drives `list_projects` on the **real** testlink-mcp → grounded answer; a no-tool model → clean **NO TOOL SUPPORT**; server-agnostic (2nd server, no coupling).
- Lands the parent **STORY-007** doc.

`qw-review-cases STORY-004` passes (hash matches, front-matter resolvable, steps observable, traces both ways).

Fixes #273
Part of STORY-007

## Test plan
- [x] `story_hash` == `sha256sum docs/stories/STORY-004.md`; `story:`/`Script:` links resolve.
- [x] subcommand-bound (no row-count invariant); format note documents this.
- [x] `qw-review-cases STORY-004` passes.

Generated with [Claude Code](https://claude.com/claude-code)