### PR TITLE
Add TS-06-throughput + TS-07-fa test docs

### DIFF
--- a/docs/tests/TS-06-throughput.md
+++ b/docs/tests/TS-06-throughput.md
@@ -1,0 +1,29 @@
+---
+id: TS-06
+title: Throughput — per-model generation speed + output coherence on K80
+namespace: ollama37
+story: STORY-005
+story_hash: 8dc577f7876df4962321b6b7aff6e5ccd37e0f12d1c2590b08062eae9342b523
+status: green
+---
+
+## Why this scenario exists
+
+A model is only usable on K80 if it generates at a workable speed **and** the output is coherent
+— fast garbage is worthless. This scenario measures per-model throughput (tok/s) and gates it on
+a content check, so a "pass" means *fast and meaningful*. It is the usable-performance facet of
+[STORY-005](../stories/STORY-005.md). Bound to the `cli.ts bench-throughput` subcommand (no YAML).
+
+### TC-01: per-model throughput is measured and the output is coherent
+
+- **Objective:** each model generates at a measured tok/s and produces coherent output.
+- **Script:** `cli.ts bench-throughput <models...> [--judge]`
+- **Preconditions:** Ollama up on K80.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Ensure each model is available | pulled if missing |
+| 2 | Warmup, then a deterministic benchmark generate (temp 0, seed 42) | tokens generated; tok/s + durations captured |
+| 3 | Capture GPU offload % and VRAM | per-GPU VRAM + offload % recorded |
+| 4 | Check the output (simple non-empty; agent judge with `--judge`) | response is coherent — not empty or garbled |
+| 5 | Report | per-model table (tok/s, GPU%, VRAM) + JSON artifact; PASS only if coherent |

--- a/docs/tests/TS-07-fa.md
+++ b/docs/tests/TS-07-fa.md
@@ -1,0 +1,39 @@
+---
+id: TS-07
+title: Flash-attention — K80 FA regression + benchmark
+namespace: ollama37
+story: STORY-005
+story_hash: 8dc577f7876df4962321b6b7aff6e5ccd37e0f12d1c2590b08062eae9342b523
+status: green
+---
+
+## Why this scenario exists
+
+Flash-attention on K80 can silently corrupt output — non-empty but garbled — while the call
+still "succeeds". This scenario benchmarks FA configurations and judges their coherence, and
+verifies that enabling FA doesn't change the output vs an FA-off baseline — guarding the K80
+build's correctness from [STORY-005](../stories/STORY-005.md). Bound to the `cli.ts test-fa`
+subcommand (no YAML).
+
+### TC-01: the FA benchmark sweep stays coherent
+
+- **Objective:** every flash-attention configuration produces coherent output.
+- **Script:** `cli.ts test-fa --benchmark`
+- **Preconditions:** exclusive use of port 11434 (the workflow stops production ollama around it).
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Boot a fresh container per config (off-f16, on-f16, on-q8_0) | each container comes up |
+| 2 | Run a deterministic inference per config | tok/s, VRAM, and KV-cache size captured |
+| 3 | Judge each config's output (simple + agent judge) | coherent — no FA-induced garble; no `CUBLAS_STATUS` / `CUDA error` |
+| 4 | Report | benchmark + judge tables + JSON; PASS only if every config is coherent |
+
+### TC-02: enabling FA does not change the output
+
+- **Objective:** FA-on output matches the FA-off baseline (FA is numerically safe on K80).
+- **Script:** `cli.ts test-fa --baseline-compare`
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Run an FA-off baseline, then the same deterministic prompt with FA on | both produce a response |
+| 2 | Compare the two outputs | exact match (FA identical to the baseline), or the difference is surfaced |


### PR DESCRIPTION
## Summary
Second task of STORY-007 — document the throughput and flash-attention capability tools as test docs tracing to STORY-005 (usable performance + FA correctness on K80), bound to their `cli.ts` subcommands via the format note from #276:
- `docs/tests/TS-06-throughput.md` — per-model tok/s + output coherence (`cli.ts bench-throughput`).
- `docs/tests/TS-07-fa.md` — FA benchmark-sweep coherence + FA-vs-baseline output match (`cli.ts test-fa`).

`story_hash` matches STORY-005; `qw-review-cases STORY-005` passes across all six STORY-005 docs (the 4 suites + these 2).

Fixes #274
Part of STORY-007

## Test plan
- [x] `story_hash` == `sha256sum docs/stories/STORY-005.md`; links resolve.
- [x] subcommand-bound (no row-count invariant), per the format note.
- [x] `qw-review-cases STORY-005` passes.

Generated with [Claude Code](https://claude.com/claude-code)