### PR TITLE
Wire --verify-live into test-mcp (#280)

### DIFF
--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -306,7 +306,7 @@ program
   .option('--mcp-args <args>', 'Args for the MCP server (space-separated; no spaces within a single arg)', CONFIG.mcp.args.join(' '))
   .option('--mcp-env <names>', 'Comma-separated env var names to forward to the server as creds (overrides MCP_ENV)', '')
   .option('--verify-live', 'Verify the answer against LIVE truth: the judge calls the server\'s read-only tools itself (supersedes --judge)', false)
-  .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (default: read-only list_/read_/get_)', '')
+  .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (fail-closed: empty verifies nothing)', '')
   .option('--verify-server-name <name>', 'mcp__<name>__<tool> label the verifier registers the server under', 'mcp')
   .option('-o, --output <file>', 'Write the JSON report to this file')
   .action(async (models: string[], options) => {

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -305,6 +305,9 @@ program
   .option('--mcp-command <cmd>', 'Command to launch the stdio MCP server', CONFIG.mcp.command)
   .option('--mcp-args <args>', 'Args for the MCP server (space-separated; no spaces within a single arg)', CONFIG.mcp.args.join(' '))
   .option('--mcp-env <names>', 'Comma-separated env var names to forward to the server as creds (overrides MCP_ENV)', '')
+  .option('--verify-live', 'Verify the answer against LIVE truth: the judge calls the server\'s read-only tools itself (supersedes --judge)', false)
+  .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (default: read-only list_/read_/get_)', '')
+  .option('--verify-server-name <name>', 'mcp__<name>__<tool> label the verifier registers the server under', 'mcp')
   .option('-o, --output <file>', 'Write the JSON report to this file')
   .action(async (models: string[], options) => {
     const code = await runMcpTest({
@@ -312,6 +315,9 @@ program
       prompt: options.prompt,
       numCtx: Number(options.numCtx),
       judge: options.judge,
+      verifyLive: options.verifyLive,
+      verifyAllow: options.verifyAllow ? String(options.verifyAllow).split(',').map((s: string) => s.trim()).filter(Boolean) : undefined,
+      verifyServerName: options.verifyServerName,
       host: options.host,
       server: {
         command: options.mcpCommand,

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -31,8 +31,8 @@ export interface McpTestOptions {
   /** Opt in the live verifier: the judge calls the server's read-only tools itself
    *  to check the answer against live ground truth (supersedes --judge). */
   verifyLive?: boolean;
-  /** Exact tool names the verifier may call. Empty ⇒ derive read-only (list_/read_/get_)
-   *  from the server's tools — review that heuristic per server. */
+  /** Exact tool names the verifier may call. Fail-closed: if empty/unset, the verifier
+   *  verifies nothing — pass an explicit allow-list (no prefix heuristic across servers). */
   verifyAllow?: string[];
   /** mcp__<name>__<tool> label the verifier registers the server under. */
   verifyServerName?: string;
@@ -142,11 +142,11 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
 
   if (eligible.length > 0 && opts.verifyLive) {
     // Full server tool list (same server for every model) → the verifier's allow/deny.
+    // Fail-closed: only an explicit --verify-allow opens tools. No prefix heuristic —
+    // it can't tell a read-only `get_x` from a destructive `get_and_purge` on an
+    // arbitrary server, and the verifier's contract is exact-name allow-listing.
     const allToolNames = Array.from(new Set(eligible.flatMap((r) => r.tool_names)));
-    const allowTools =
-      opts.verifyAllow && opts.verifyAllow.length > 0
-        ? opts.verifyAllow
-        : allToolNames.filter((t) => (/^(list_|read_|get_)/).test(t));
+    const allowTools = opts.verifyAllow ?? [];
     const verifier = new VerifierJudge(
       { server: opts.server, serverName: opts.verifyServerName ?? 'mcp', toolNames: allToolNames, allowTools },
       '',

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -13,7 +13,7 @@
  */
 import { writeFileSync } from 'node:fs';
 import { runMcpHost, type McpServerConfig, type McpTrajectory } from './host.js';
-import { AgentJudge } from '../judge/index.js';
+import { AgentJudge, VerifierJudge } from '../judge/index.js';
 import { TestResult, Judgment } from '../types.js';
 
 const JUDGE_CRITERIA =
@@ -28,6 +28,14 @@ export interface McpTestOptions {
   host: string;
   numCtx: number;
   judge: boolean;
+  /** Opt in the live verifier: the judge calls the server's read-only tools itself
+   *  to check the answer against live ground truth (supersedes --judge). */
+  verifyLive?: boolean;
+  /** Exact tool names the verifier may call. Empty ⇒ derive read-only (list_/read_/get_)
+   *  from the server's tools — review that heuristic per server. */
+  verifyAllow?: string[];
+  /** mcp__<name>__<tool> label the verifier registers the server under. */
+  verifyServerName?: string;
   output?: string;
 }
 
@@ -116,25 +124,47 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
     process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass}\n`);
   }
 
-  // Agent judge (dual mode): one batch over a single reused session, only for
-  // models that passed the structural check (no point grading a non-call).
-  if (opts.judge) {
-    const eligible = results.filter((r) => r.check.simple.pass);
-    if (eligible.length > 0) {
-      const agentJudge = new AgentJudge();
-      if (await agentJudge.isAvailable()) {
-        const byModel = new Map(results.map((r) => [r.model, r]));
-        const verdicts = await agentJudge.judgeResults(eligible.map((r) => toTestResult(trajByModel.get(r.model)!, opts.prompt)));
-        for (const v of verdicts) {
-          const r = byModel.get(v.testId);
-          if (r) {
-            r.check.agent = v;
-            r.check.overall_pass = r.check.simple.pass && v.pass;
-          }
-        }
-      } else {
-        process.stderr.write('[WARN] agent judge not available — simple check only\n');
+  // Agent-level check, only for models that passed the structural check. Two modes:
+  //  --verify-live : the verifier calls the server's read-only tools itself to check
+  //                  the answer against LIVE truth (the stronger check; supersedes --judge).
+  //  --judge       : the sandboxed agent judge grades groundedness over the captured trajectory.
+  const eligible = results.filter((r) => r.check.simple.pass);
+  const byModel = new Map(results.map((r) => [r.model, r]));
+  const applyVerdicts = (verdicts: Judgment[]) => {
+    for (const v of verdicts) {
+      const r = byModel.get(v.testId);
+      if (r) {
+        r.check.agent = v;
+        r.check.overall_pass = r.check.simple.pass && v.pass;
       }
+    }
+  };
+
+  if (eligible.length > 0 && opts.verifyLive) {
+    // Full server tool list (same server for every model) → the verifier's allow/deny.
+    const allToolNames = Array.from(new Set(eligible.flatMap((r) => r.tool_names)));
+    const allowTools =
+      opts.verifyAllow && opts.verifyAllow.length > 0
+        ? opts.verifyAllow
+        : allToolNames.filter((t) => (/^(list_|read_|get_)/).test(t));
+    const verifier = new VerifierJudge(
+      { server: opts.server, serverName: opts.verifyServerName ?? 'mcp', toolNames: allToolNames, allowTools },
+      '',
+      opts.server.cwd ?? process.cwd(),
+    );
+    if (await verifier.isAvailable()) {
+      applyVerdicts(
+        await verifier.verify(eligible.map((r) => ({ testId: r.model, prompt: opts.prompt, answer: trajByModel.get(r.model)!.finalAnswer }))),
+      );
+    } else {
+      process.stderr.write('[WARN] verifier agent not available — simple check only\n');
+    }
+  } else if (eligible.length > 0 && opts.judge) {
+    const agentJudge = new AgentJudge();
+    if (await agentJudge.isAvailable()) {
+      applyVerdicts(await agentJudge.judgeResults(eligible.map((r) => toTestResult(trajByModel.get(r.model)!, opts.prompt))));
+    } else {
+      process.stderr.write('[WARN] agent judge not available — simple check only\n');
     }
   }
 
@@ -147,7 +177,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
     writeFileSync(
       opts.output,
       JSON.stringify(
-        { timestamp: new Date().toISOString(), server: { command: opts.server.command, args: opts.server.args }, prompt: opts.prompt, judge: opts.judge ? 'dual' : 'simple', results: full },
+        { timestamp: new Date().toISOString(), server: { command: opts.server.command, args: opts.server.args }, prompt: opts.prompt, judge: opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple', results: full },
         null,
         2
       )
@@ -163,7 +193,7 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   const out: string[] = [];
   out.push('## MCP tool-call test');
   out.push('');
-  out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\` · **Prompt:** ${opts.prompt} · **Judge:** ${opts.judge ? 'dual' : 'simple'}`);
+  out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\` · **Prompt:** ${opts.prompt} · **Judge:** ${opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple'}`);
   out.push('');
   out.push('| Model | Verdict | Tool calls | Answer | Reason |');
   out.push('|---|---|---|---|---|');


### PR DESCRIPTION
## Summary

Wires the `VerifierJudge` (#279) into the `test-mcp` subcommand as an opt-in, so the MCP tool-call test can verify a model's answer against **live** ground truth instead of only the captured trajectory. Default behavior is unchanged.

Part of STORY-008 · plan #272 · builds on #279.

## What changed

- **`cli.ts`** — three new `test-mcp` options: `--verify-live` (opt-in, default off), `--verify-allow <names>` (exact tool names the verifier may call), `--verify-server-name <name>`.
- **`test-mcp.ts`** — when `--verify-live` is set, eligible (simple-pass) models route through the `VerifierJudge`, which calls the server's read-only tools itself and grades the answer against live truth; otherwise the existing sandboxed `AgentJudge` path runs unchanged. Shared `applyVerdicts`/`byModel` keep both paths consistent. Report/summary label reflects `verify-live` / `dual` / `simple`.

## Safety: fail-closed allow-list

The verifier's allow-list is **fail-closed** — an empty/unset `--verify-allow` verifies nothing. Tools open only via an explicit allow-list. (A `list_/read_/get_` prefix default was dropped after code-review: it can't tell a read-only `get_x` from a destructive `get_and_purge` on an arbitrary server, which contradicts `VerifierJudge`'s exact-name, deny-by-default contract.)

## Verification

- Without `--verify-live`: default path byte-for-byte unchanged (verified against server-everything routing).
- `npm run build` (`tsc`) passes; `test-mcp --help` shows the flags.
- Live spike (run before this PR) confirmed the verifier autonomously calls `mcp__testlink__list_projects` against live TestLink and grounds its verdict.

Fixes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
