### PR TITLE
Self-contained test creds + fix broken test-mcp default (Docker)

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -29,12 +29,12 @@ on:
       mcp_command:
         description: "Command to launch the stdio MCP server"
         required: false
-        default: "npx"
+        default: "docker"
         type: string
       mcp_args:
         description: "Args for the MCP server (space-separated)"
         required: false
-        default: "-y testlink-mcp"
+        default: "run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest"
         type: string
 
 env:
@@ -92,8 +92,8 @@ jobs:
           npx tsx src/cli.ts test-mcp $MODELS \
             --prompt "${{ inputs.prompt || 'List the projects.' }}" \
             --num-ctx "${{ inputs.num_ctx || '4096' }}" \
-            --mcp-command "${{ inputs.mcp_command || 'npx' }}" \
-            --mcp-args "${{ inputs.mcp_args || '-y testlink-mcp' }}" \
+            --mcp-command "${{ inputs.mcp_command || 'docker' }}" \
+            --mcp-args "${{ inputs.mcp_args || 'run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest' }}" \
             --mcp-env "TESTLINK_URL,TESTLINK_API_KEY" \
             --output /tmp/mcp-results.json \
             $JUDGE_FLAG | tee -a "$GITHUB_STEP_SUMMARY"

--- a/cicd/tests/.env.example
+++ b/cicd/tests/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env (gitignored) and fill in. These map 1:1 to the GitHub Actions
+# secret names the test-mcp.yml workflow feeds in CI — same names locally and in CI.
+TESTLINK_URL=
+TESTLINK_API_KEY=
+# Keyless agent-judge auth (--judge / --verify-live). Optional: falls back to ~/.claude.
+CLAUDE_CODE_OAUTH_TOKEN=

--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
+        "dotenv": "^16.4.0",
         "glob": "^10.3.10",
         "js-yaml": "^4.1.0"
       },
@@ -1074,6 +1075,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -19,6 +19,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "dotenv": "^16.4.0",
     "glob": "^10.3.10",
     "js-yaml": "^4.1.0"
   },

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -7,6 +7,7 @@
  *   npx tsx src/cli.ts list [options]
  */
 
+import 'dotenv/config'; // load cicd/tests/.env into process.env before config.ts reads it
 import { Command } from 'commander';
 import path from 'path';
 import { mkdirSync, existsSync } from 'fs';

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -39,8 +39,8 @@ export const CONFIG = {
   // model's tool-calling can be checked end-to-end. testlink-mcp is only the
   // default target — point --mcp-command / --mcp-args at any stdio MCP server.
   mcp: {
-    command: process.env.MCP_COMMAND || 'npx',
-    args: (process.env.MCP_ARGS || '-y testlink-mcp').split(' ').filter(Boolean),
+    command: process.env.MCP_COMMAND || 'docker',
+    args: (process.env.MCP_ARGS || 'run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest').split(' ').filter(Boolean),
     cwd: process.env.MCP_CWD || undefined,
     prompt: process.env.MCP_PROMPT || 'List the projects.',
     // Env var names to forward to the spawned server (its creds). Values come

--- a/docs/tests/TS-05-mcp.md
+++ b/docs/tests/TS-05-mcp.md
@@ -20,7 +20,7 @@ logical flow.
 
 - **Objective:** the model calls the right tool against the live server and produces a grounded answer.
 - **Script:** `cli.ts test-mcp <tool-capable-model> --judge` (default server: testlink-mcp)
-- **Preconditions:** Ollama up with the model pulled; testlink-mcp reachable with `TESTLINK_URL` / `TESTLINK_API_KEY`.
+- **Preconditions:** Ollama up with the model pulled; testlink-mcp reachable with `TESTLINK_URL` / `TESTLINK_API_KEY`. Locally these are read from `cicd/tests/.env` (copy `cicd/tests/.env.example`); in CI they come from the matching GitHub secrets.
 
 | # | Action | Expected Result |
 |---|--------|-----------------|


### PR DESCRIPTION
## Summary
The salvageable, keyless, working result from the MCP-verifier investigation: **self-contained test creds** + a **fix for a genuinely broken default**.

This is independent of the live-verifier rewrite (STORY-009), which is blocked keyless — see #285. These two changes stand on their own and should land.

## What's in it
1. **Fix the broken `test-mcp` default (the important one).** The default MCP server was `npx -y testlink-mcp`, which **404s** — never published to npm, and the name doesn't even match its package (`testlink-mcp-server`). So the default could never run. Replaced with the self-contained Docker invocation from testlink-mcp's README (`docker run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest`) in `config.ts` + `test-mcp.yml`. **Verified:** `test-mcp gemma4:e4b` with no overrides drives `list_projects` against live TestLink and PASSes.
2. **Self-contained local creds.** `cicd/tests/.env` (gitignored) → `dotenv` → `--mcp-env`, mapped 1:1 to the CI secret names; `.env.example` documents them. Makes `test-mcp` runnable locally without exporting vars by hand.

## Verify
- `npm run build` passes.
- `test-mcp gemma4:e4b --prompt "List the projects."` (no server overrides) → Docker server → real TestLink data.
- `.env` is gitignored; `.env.example` is the committed contract.

## Not included / context
- The `--verify-live` rewrite (have the agent independently call the tool) is **blocked keyless** — the agent's toolset is flooded by account claude.ai connectors that can only be disabled with `ANTHROPIC_API_KEY` (ruled out here). Full RCA on #285; capability is proven, productionizing is not keyless-possible. This PR deliberately does **not** touch the verifier.

Does not close #281 (that's the verifier-validation task, still blocked).
