### PR TITLE
Keyless live-MCP verifier: client-calls-tool against live ground truth

### DIFF
--- a/cicd/docs/CICD.md
+++ b/cicd/docs/CICD.md
@@ -258,6 +258,8 @@ Current perf workflows: `test-throughput.yml` (tok/s benchmark) and `test-fa-k80
 
 `cli.ts test-mcp` is a **capability** probe rather than a perf metric: it drives a **real** stdio MCP server (server-agnostic — default `testlink-mcp`, override via `--mcp-command`/`--mcp-args`), lists and translates its tools to Ollama's `/api/chat` `tools[]`, runs the model's tool loop against the live server, and reuses the one agent judge to grade whether the final answer is grounded in the tool result. It reports a per-model verdict (PASS / FAIL / NO TOOL SUPPORT) and runs via the manual `test-mcp.yml` workflow (`workflow_dispatch`; testlink-mcp creds supplied as `cicd-1` secrets and forwarded with `--mcp-env`). See [`docs/traces/mcp-tool-call-validation.md`](../../docs/traces/mcp-tool-call-validation.md) for an end-to-end validation run.
 
+Add `--verify-live --verify-allow <read-only-tool>` for a stronger check: instead of trusting the result the model captured, the verifier makes its **own** read-only call to the live MCP server and the sandboxed agent judge grades the model's answer against that **fresh** ground truth — so a confidently-wrong (or stale-captured) answer FAILs where consistency-only would pass. Read-only is by exact allow-list (empty ⇒ fail-closed), and it stays keyless (the grading agent is never exposed to the tool). Background on why the verifier calls the tool itself rather than the agent: keyless ACP adapters either don't surface a client-injected stdio server or flood the agent with account connectors disableable only via `ANTHROPIC_API_KEY`.
+
 ## Quick Start
 
 ```bash

--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -1,47 +1,27 @@
 /**
- * Verifier Judge — independently verifies a model's MCP answer against LIVE ground truth.
+ * Verifier Judge — checks a model's MCP answer against INDEPENDENT live ground truth.
  *
- * Unlike the sandboxed AgentJudge (which opens its session with `mcpServers: []` and
- * rejects every tool call), the verifier spawns the same ACP agent WITH the test's MCP
- * server attached and lets it call the tools itself to check the answer. Tool access is
- * restricted to a per-case **exact allow-list** of tool names (read-only by intent),
- * enforced two ways:
+ * Rather than trust the tool result the model captured (which could be stale or mis-captured),
+ * the verifier makes its OWN read-only call to the live MCP server and grades the model's answer
+ * against THAT fresh result. Grading is done by the sandboxed, keyless `AgentJudge`
+ * (`mcpServers: []`, rejects every tool call) — the grading agent only reads text, it is never
+ * exposed to the live tool, so there is no account-connector flood and no write path.
  *
- *   1. `requestPermission` backstop — the gate. For an MCP tool the permission request's
- *      `toolCall.title` IS the `mcp__<server>__<tool>` id (the bundled claude-agent-acp
- *      sets it there; `_meta.claudeCode.toolName` is NOT populated on permission requests).
- *      We strip it to the bare name and ALLOW only if it's in the exact allow-list, else
- *      REJECT. Built-in tools (Bash/Edit/Write/…) carry a prose title that is never in the
- *      allow-list, so they are rejected too; an empty/unknown name also rejects (fail-closed).
- *   2. Claude SDK `disallowedTools` (via newSession `_meta.claudeCode.options`) — defence in
- *      depth: every server tool NOT in the allow-list is also denied by the agent's own SDK
- *      before it reaches permission.
+ * Read-only is enforced by an exact allow-list of tool names: only those are ever called, and a
+ * name not on the server's menu is skipped. Empty allow-list ⇒ verifies nothing (fail-closed).
  *
- * Read-only is therefore by *exact allow-list*, never a name prefix (a prefix would let a
- * `get_and_purge` through). This file does NOT touch `agent-judge.ts` — the generic judge
- * stays sandboxed.
- *
- * NOTE: that the SDK actually hard-denies, and that the agent does call the tools, is proven
- * live by the forced-write-refusal test in the validation task (#281) before this is trusted
- * against a real backend.
+ * Why not have the *agent* call the tool? The Claude ACP adapters either don't surface a
+ * client-injected stdio MCP server (claude-agent-acp) or flood the agent with the operator's
+ * claude.ai connectors that can only be disabled with an API key (claude-code-acp). Both keyless
+ * paths are exhausted (see #285). Calling the tool ourselves keeps the independent-live-check
+ * property — a fresh second call to truth, not the model's captured result — with none of that.
  */
-
-import { spawn, type ChildProcess, type StdioOptions } from 'node:child_process';
-import { Readable, Writable } from 'node:stream';
-import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
-import {
-  ClientSideConnection,
-  ndJsonStream,
-  PROTOCOL_VERSION,
-  type Client,
-  type SessionNotification,
-  type RequestPermissionRequest,
-  type RequestPermissionResponse,
-} from '@agentclientprotocol/sdk';
-import type { McpServerConfig } from '../mcp/host.js';
-import type { Judgment } from '../types.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { AgentJudge } from './agent-judge.js';
 import { CONFIG } from '../config.js';
+import type { McpServerConfig } from '../mcp/host.js';
+import type { Judgment, TestResult } from '../types.js';
 
 /** One model's answer to verify against the live server. */
 export interface VerifyTarget {
@@ -53,274 +33,125 @@ export interface VerifyTarget {
 export interface VerifierConfig {
   /** The stdio MCP server the host used (same command/args/env). */
   server: McpServerConfig;
-  /** Rule prefix: the server's tools are `mcp__<serverName>__<tool>`. */
+  /** Rule prefix the host reported tools under (kept for report symmetry). */
   serverName: string;
-  /** Every tool the server exposes — used to derive the SDK deny-list (deny-by-default). */
+  /** Every tool the server exposes (informational). */
   toolNames: string[];
-  /** EXACT bare tool names the verifier may call (read-only by intent). Anything not here is
-   *  rejected. Empty ⇒ the verifier can call nothing (fail-closed). */
+  /** EXACT read-only tool names the verifier may call. Empty ⇒ verifies nothing (fail-closed). */
   allowTools: string[];
 }
 
-export class VerifierJudge {
-  private agentCmd: string;
-  private cwd: string;
-  private child?: ChildProcess;
-  private conn?: ClientSideConnection;
-  private sessionId?: string;
-  private turnText = '';
+interface GroundTruth {
+  tool: string;
+  result: string;
+  isError: boolean;
+}
 
+/** Join an MCP CallToolResult's content blocks into one text payload (mirrors host.ts). */
+function resultText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : JSON.stringify(c)))
+    .join('\n');
+}
+
+const VERIFY_CRITERIA =
+  'You are given the user PROMPT, the model ANSWER to verify, and LIVE GROUND TRUTH independently ' +
+  'fetched from the real tool. PASS only if the answer is consistent with the ground truth. FAIL ' +
+  'if the answer states facts the ground truth contradicts or does not contain (wrong or invented ' +
+  'names, ids, counts, or data), or if the answer is empty.';
+
+export class VerifierJudge {
   private readonly cfg: VerifierConfig;
-  private readonly allow: Set<string>;
-  /** `mcp__<server>__<tool>` rules for every tool NOT in the allow-list (SDK hard-deny). */
-  private readonly disallowedTools: string[];
+  private readonly allow: string[];
+  private readonly judge: AgentJudge;
 
   constructor(cfg: VerifierConfig, agentCmd: string = CONFIG.judge.agent, cwd: string = process.cwd()) {
     this.cfg = cfg;
-    this.agentCmd = agentCmd;
-    this.cwd = cwd;
-    this.allow = new Set(cfg.allowTools);
-    this.disallowedTools = cfg.toolNames
-      .filter((t) => !this.allow.has(t))
-      .map((t) => `mcp__${cfg.serverName}__${t}`);
-    process.once('exit', () => this.kill());
+    this.allow = [...new Set(cfg.allowTools.filter(Boolean))];
+    // The verdict is graded by the sandboxed agent judge (text-only, keyless).
+    this.judge = new AgentJudge(agentCmd, cwd);
   }
 
-  /** `mcp__server__tool` (or a bare name) → the bare tool name. */
-  private bareName(name: string): string {
-    const parts = name.split('__');
-    return parts.length >= 3 ? parts.slice(2).join('__') : name;
-  }
-
-  private async withTimeout<T>(p: Promise<T>, label: string): Promise<T> {
-    let timer: NodeJS.Timeout;
-    const timeout = new Promise<never>((_, rej) => {
-      timer = setTimeout(() => rej(new Error(`${label} exceeded ${CONFIG.judge.timeout}ms`)), CONFIG.judge.timeout);
-    });
-    try {
-      return await Promise.race([p, timeout]);
-    } finally {
-      clearTimeout(timer!);
-    }
-  }
-
-  /** Spawn the configured ACP agent as a stdio child (same logic as AgentJudge). */
-  private spawnAgent(): ChildProcess {
-    const env = { ...process.env };
-    delete env.CLAUDECODE;
-    delete env.CLAUDE_CODE_ENTRYPOINT;
-    delete env.CLAUDE_CODE_SSE_PORT;
-    const stdio: StdioOptions = ['pipe', 'pipe', 'inherit'];
-
-    if (this.agentCmd) {
-      return spawn(this.agentCmd, { cwd: this.cwd, stdio, env, shell: true });
-    }
-    const require = createRequire(import.meta.url);
-    const pkg = require.resolve('@agentclientprotocol/claude-agent-acp/package.json');
-    const entry = resolve(dirname(pkg), 'dist/index.js');
-    return spawn(process.execPath, [entry], { cwd: this.cwd, stdio, env });
-  }
-
-  /** The read-only gate: allow only exact-allow-listed tools, else reject (fail-closed). */
-  private decide(params: RequestPermissionRequest): RequestPermissionResponse {
-    const tc = params.toolCall as { _meta?: { claudeCode?: { toolName?: string } }; title?: string };
-    // For MCP tools `title` is the `mcp__server__tool` id; `_meta.claudeCode.toolName` is not
-    // set on permission requests, so prefer title and treat both as best-effort.
-    const raw = tc?.title ?? tc?._meta?.claudeCode?.toolName ?? '';
-    const allowed = this.allow.has(this.bareName(String(raw)));
-    const want = allowed ? 'allow' : 'reject';
-    const opt =
-      params.options.find((o) => o.kind?.startsWith(want)) ??
-      params.options.find((o) => o.kind?.startsWith('reject'));
-    if (!allowed) process.stderr.write(`  [verify] DENIED tool permission: "${String(raw).slice(0, 80)}"\n`);
-    return opt
-      ? { outcome: { outcome: 'selected', optionId: opt.optionId } }
-      : { outcome: { outcome: 'cancelled' } };
-  }
-
-  private async ensureStarted(): Promise<void> {
-    if (this.sessionId) return;
-
-    const child = this.spawnAgent();
-    this.child = child;
-
-    const stream = ndJsonStream(
-      Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
-      Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
-    );
-
-    const client: Client = {
-      sessionUpdate: async (params: SessionNotification): Promise<void> => {
-        const u = params.update;
-        if (u.sessionUpdate === 'agent_message_chunk' && u.content.type === 'text') {
-          this.turnText += u.content.text;
-        }
-      },
-      requestPermission: async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> =>
-        this.decide(params),
-      readTextFile: async () => { throw new Error('filesystem access disabled for the verifier'); },
-      writeTextFile: async () => { throw new Error('filesystem access disabled for the verifier'); },
-    };
-
-    this.conn = new ClientSideConnection(() => client, stream);
-    try {
-      await this.withTimeout(this.conn.initialize({
-        protocolVersion: PROTOCOL_VERSION,
-        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
-        clientInfo: { name: `${CONFIG.projectName}-verifier`, version: '1.0.0' },
-      }), 'verifier initialize');
-
-      const env = Object.entries(this.cfg.server.env ?? {}).map(([name, value]) => ({ name, value }));
-      const session = await this.withTimeout(
-        this.conn.newSession({
-          cwd: this.cwd,
-          // Populate the server (the generic judge keeps this empty); hard-deny every
-          // non-allow-listed server tool via the agent's own SDK config (defence in depth).
-          mcpServers: [{ name: this.cfg.serverName, command: this.cfg.server.command, args: this.cfg.server.args, env }],
-          _meta: { claudeCode: { options: { disallowedTools: this.disallowedTools } } },
-        }),
-        'verifier session/new',
-      );
-      this.sessionId = session.sessionId;
-    } catch (e) {
-      this.kill();
-      throw e;
-    }
-  }
-
-  private kill(): void {
-    try { this.child?.kill('SIGKILL'); } catch { /* already gone */ }
-    this.child = undefined;
-    this.conn = undefined;
-    this.sessionId = undefined;
-  }
-
-  /** Probe agent reachability — without the MCP server, so it tests the agent, not the backend. */
+  /** Available iff the (keyless, sandboxed) grading agent is reachable. */
   async isAvailable(): Promise<boolean> {
-    let child: ChildProcess | undefined;
+    return this.judge.isAvailable();
+  }
+
+  /** One independent read-only call per allow-listed tool against the LIVE server. */
+  private async fetchGroundTruth(): Promise<GroundTruth[]> {
+    if (this.allow.length === 0) return [];
+    const transport = new StdioClientTransport({
+      command: this.cfg.server.command,
+      args: this.cfg.server.args,
+      cwd: this.cfg.server.cwd,
+      env: { ...getDefaultEnvironment(), ...(this.cfg.server.env ?? {}) },
+    });
+    const client = new Client({ name: 'ollama37-verifier', version: '1.0.0' });
+    const out: GroundTruth[] = [];
     try {
-      child = this.spawnAgent();
-      const stream = ndJsonStream(
-        Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
-        Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
-      );
-      let text = '';
-      const client: Client = {
-        sessionUpdate: async (p: SessionNotification) => {
-          const u = p.update;
-          if (u.sessionUpdate === 'agent_message_chunk' && u.content.type === 'text') text += u.content.text;
-        },
-        requestPermission: async () => ({ outcome: { outcome: 'cancelled' } } as RequestPermissionResponse),
-        readTextFile: async () => { throw new Error('disabled'); },
-        writeTextFile: async () => { throw new Error('disabled'); },
-      };
-      const conn = new ClientSideConnection(() => client, stream);
-      await this.withTimeout(conn.initialize({
-        protocolVersion: PROTOCOL_VERSION,
-        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
-        clientInfo: { name: `${CONFIG.projectName}-verifier`, version: '1.0.0' },
-      }), 'verifier probe initialize');
-      const s = await this.withTimeout(conn.newSession({ cwd: this.cwd, mcpServers: [] }), 'verifier probe session');
-      await this.withTimeout(conn.prompt({ sessionId: s.sessionId, prompt: [{ type: 'text', text: 'Reply with exactly: ok' }] }), 'verifier probe turn');
-      if (!text.trim()) throw new Error('verifier agent produced no output on probe turn');
-      return true;
-    } catch (error) {
-      process.stderr.write(`  [verify] Agent not reachable: ${error}\n`);
-      return false;
+      await client.connect(transport);
+      const onMenu = new Set((await client.listTools()).tools.map((t) => t.name));
+      for (const tool of this.allow) {
+        if (!onMenu.has(tool)) continue; // never call a tool the server doesn't expose
+        try {
+          const r: any = await client.callTool({ name: tool, arguments: {} });
+          out.push({ tool, result: resultText(r?.content), isError: Boolean(r?.isError) });
+        } catch (e) {
+          out.push({ tool, result: `tool call failed: ${e instanceof Error ? e.message : String(e)}`, isError: true });
+        }
+      }
     } finally {
-      try { child?.kill('SIGKILL'); } catch { /* gone */ }
-    }
-  }
-
-  private buildPrompt(t: VerifyTarget): string {
-    return JSON.stringify({
-      role: `You independently verify another model's answer for ${CONFIG.projectName}. You have access to the ${this.cfg.serverName} MCP tools.`,
-      task: 'You MUST call the available tools yourself to retrieve the real data, then judge whether the model\'s answer is correct and grounded in that real data. Do NOT trust the answer — check it. If you cannot call any tool, set pass=false and say so.',
-      allowed_tools: [...this.allow],
-      user_prompt: t.prompt,
-      model_answer: t.answer,
-      rules: [
-        'Call the allowed tools to retrieve the ground truth before deciding.',
-        'pass=true only if the answer matches the real data you retrieved.',
-        'If the answer states facts the tools contradict or do not contain, pass=false.',
-      ],
-      respond: {
-        format: 'Respond with a single JSON object and nothing else',
-        fields: {
-          testId: t.testId,
-          pass: 'true if the answer matches the live tool data, false otherwise',
-          reason: 'Brief explanation, naming the tool(s) you called',
-          evidence: 'The tool result you verified against',
-        },
-      },
-    }, null, 2);
-  }
-
-  private extractJson(text: string): string | null {
-    const start = text.indexOf('{');
-    const end = text.lastIndexOf('}');
-    if (start === -1 || end === -1 || end < start) return null;
-    return text.substring(start, end + 1);
-  }
-
-  private async promptAgent(prompt: string): Promise<string> {
-    this.turnText = '';
-    try {
-      await this.withTimeout(
-        this.conn!.prompt({ sessionId: this.sessionId!, prompt: [{ type: 'text', text: prompt }] }),
-        'verifier turn',
-      );
-    } catch (e) {
-      this.kill();
-      throw e;
-    }
-    return this.turnText;
-  }
-
-  private async verifyOne(t: VerifyTarget): Promise<Judgment> {
-    const responseText = await this.promptAgent(this.buildPrompt(t));
-    if (!responseText) {
-      return { testId: t.testId, pass: false, reason: 'Verifier returned empty response' };
-    }
-    const json = this.extractJson(responseText);
-    if (!json) {
-      return { testId: t.testId, pass: false, reason: `No JSON in verifier response: ${responseText.substring(0, 200)}` };
-    }
-    try {
-      const judgment = JSON.parse(json) as Judgment;
-      judgment.testId = t.testId;
-      if (typeof judgment.pass === 'string') {
-        judgment.pass = (judgment.pass as unknown as string).toLowerCase() === 'true';
-      }
-      if (typeof judgment.pass !== 'boolean') {
-        return { testId: t.testId, pass: false, reason: `Verifier response missing "pass": ${responseText.substring(0, 200)}` };
-      }
-      if (!judgment.reason) judgment.reason = judgment.pass ? 'Verified (no reason provided)' : 'Failed (no reason provided)';
-      return judgment;
-    } catch {
-      return { testId: t.testId, pass: false, reason: `Failed to parse verifier response: ${responseText.substring(0, 200)}` };
-    }
-  }
-
-  /** Verify each target in its OWN fresh session (no cross-target context bleed). */
-  async verify(targets: VerifyTarget[]): Promise<Judgment[]> {
-    const out: Judgment[] = [];
-    for (let i = 0; i < targets.length; i++) {
-      const t = targets[i];
-      process.stderr.write(`  [verify] Verifying ${i + 1}/${targets.length}: ${t.testId} (allow ${this.allow.size} tools, deny ${this.disallowedTools.length})...\n`);
-      try {
-        await this.ensureStarted();
-        const judgment = await this.verifyOne(t);
-        out.push(judgment);
-        process.stderr.write(`  [verify] ${t.testId}: ${judgment.pass ? 'PASS' : 'FAIL'} — ${judgment.reason}\n`);
-      } catch (error) {
-        process.stderr.write(`  [verify] Failed to verify ${t.testId}: ${error}\n`);
-        out.push({ testId: t.testId, pass: false, reason: 'Verifier failed: ' + String(error) });
-      } finally {
-        // Fresh session per target — tear down so the next target re-spawns clean.
-        this.kill();
-      }
+      await client.close().catch(() => {});
     }
     return out;
+  }
+
+  /** Synthetic TestResult so the sandboxed judge grades the answer vs the live ground truth. */
+  private toTestResult(t: VerifyTarget, truth: GroundTruth[]): TestResult {
+    const gt = truth.map((x) => `${x.tool} ->\n${x.result.slice(0, 1000)}`).join('\n\n');
+    const stdout =
+      `PROMPT: ${t.prompt}\n\nMODEL ANSWER (verify this): ${t.answer}\n\n` +
+      `LIVE GROUND TRUTH (independently fetched from the real tool):\n${gt}`;
+    return {
+      testCase: {
+        id: t.testId,
+        name: `verify:${t.testId}`,
+        suite: 'inference',
+        priority: 1,
+        timeout: 60000,
+        dependencies: [],
+        goal: 'Decide whether the model answer matches the live ground truth',
+        steps: [{ name: 'verify', command: '(independent live tool call)' }],
+        criteria: VERIFY_CRITERIA,
+      },
+      steps: [{ name: 'verify', command: '(independent live tool call)', stdout, stderr: '', exitCode: 0, duration: 0 }],
+      totalDuration: 0,
+      logs: '',
+      logFile: '',
+    };
+  }
+
+  /** Verify every target against ONE independent fetch of live ground truth. */
+  async verify(targets: VerifyTarget[]): Promise<Judgment[]> {
+    let truth: GroundTruth[];
+    try {
+      truth = await this.fetchGroundTruth();
+    } catch (e) {
+      const reason = 'verifier could not reach the live server: ' + (e instanceof Error ? e.message : String(e));
+      return targets.map((t) => ({ testId: t.testId, pass: false, reason }));
+    }
+    const usable = truth.filter((x) => !x.isError && x.result.trim());
+    if (usable.length === 0) {
+      const reason =
+        this.allow.length === 0
+          ? 'verifier allow-list empty — verified nothing (fail-closed)'
+          : 'verifier got no usable result from any allowed read-only tool (fail-closed)';
+      return targets.map((t) => ({ testId: t.testId, pass: false, reason }));
+    }
+    process.stderr.write(`  [verify] live ground truth from: ${usable.map((x) => x.tool).join(', ')}\n`);
+    const verdicts = await this.judge.judgeResults(targets.map((t) => this.toTestResult(t, usable)));
+    const evidence = usable.map((x) => `${x.tool}: ${x.result.replace(/\s+/g, ' ').slice(0, 300)}`).join(' | ');
+    return verdicts.map((v) => ({ ...v, evidence: v.evidence ?? evidence }));
   }
 }

--- a/docs/tests/TS-05-mcp.md
+++ b/docs/tests/TS-05-mcp.md
@@ -49,3 +49,21 @@ logical flow.
 |---|--------|-----------------|
 | 1 | Point the host at a second real stdio MCP server (e.g. an echo server) via the flags | the host lists + drives that server's tools, no testlink involved |
 | 2 | The model calls one of its tools and uses the result | tool executed against the real server; grounded answer → PASS |
+
+### TC-04: verify the answer against live ground truth (`--verify-live`)
+
+- **Objective:** the verdict reflects an **independent** check of the live tool, not just the
+  model's own captured trajectory — a confidently-wrong answer is caught.
+- **Script:** `cli.ts test-mcp <tool-capable-model> --verify-live --verify-allow <read-only-tool>`
+  (e.g. `--verify-allow list_projects`)
+- **How:** the verifier makes its OWN read-only call to the live MCP server (via the MCP SDK,
+  not the model's captured result), then the sandboxed keyless agent judge grades the model's
+  answer against that fresh ground truth. Read-only is by **exact allow-list** — only the named
+  tools are ever called; an empty allow-list verifies nothing (fail-closed). Keyless.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | The verifier independently calls the allow-listed read-only tool against the live server | fresh live result captured (e.g. the real project list) |
+| 2 | The judge compares the model's answer to that fresh result | answer consistent with live truth → **PASS** |
+| 3 | A model answer that **contradicts** live truth (invented names/ids) | caught → **FAIL**, with the live result as evidence |
+| 4 | A mutating tool is not on the allow-list | never called — read-only is structural, no agent to steer |


### PR DESCRIPTION
## Summary
Makes `--verify-live` actually work — **keyless**. The verifier now independently checks a model's MCP answer against **live** ground truth, the capability STORY-009 / #285 set out to deliver.

## What changed
`VerifierJudge` is rewritten from "spawn an ACP agent and have it call the tool" to **client-calls-tool**:
- It connects to the MCP server itself via `@modelcontextprotocol/sdk` (mirroring `host.ts`), calls each **allow-listed read-only** tool, and captures the **fresh** live result.
- It grades the model's answer against that fresh result with the existing **sandboxed, keyless `AgentJudge`** (`mcpServers: []`, text-only) — the grading agent is never exposed to the tool.

Net −149 lines (drops the entire ACP-agent spawn/permission/capture path).

## Why not have the agent call the tool
Both keyless ACP paths are exhausted (full RCA on #285): `claude-agent-acp` doesn't surface a client-injected **stdio** server (it advertises only http/sse), and `claude-code-acp` floods the agent with the operator's claude.ai connectors that are only disableable via `ANTHROPIC_API_KEY` (a remote Statsig flag otherwise). Calling the tool ourselves keeps the **independent-live-check** property — a second fresh call to truth, not the model's captured result — with none of that.

## Read-only guarantee
Structural: only **exact-allow-listed** tool names are ever called; a name not on the server's menu is skipped; an empty allow-list verifies nothing (fail-closed). There is no agent that could be steered into a write.

## Verified (keyless, live)
- **Read-path PASS** — verifier fetched live `list_projects`; the judge confirmed the model's answer matched (`ollama37` ID 1 …).
- **Contradiction → FAIL** — a doctored answer ("Acme Rockets, ID 999") was caught with the live result as evidence.
- `npm run build` passes; the generic `AgentJudge` (run/throughput/fa `--judge`) is reused unchanged.

## Docs
`docs/tests/TS-05-mcp.md` gains TC-04 (live-verify); `cicd/docs/CICD.md` documents the mode.

## Note on the plan
This supersedes the phased #286/#287/#288 (closed) — Plan B's design folds verdict-from-live-result + docs into one simpler change and makes the shared-ACP-client module (#286) unnecessary.

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
