### PR TITLE
Fix test-mcp.yml masking the runner exit code (| tee)

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -91,6 +91,9 @@ jobs:
           TESTLINK_URL: ${{ secrets.TESTLINK_URL }}
           TESTLINK_API_KEY: ${{ secrets.TESTLINK_API_KEY }}
         run: |
+          # pipefail so the test runner's exit code survives the `| tee` below — without it a
+          # FAIL/fail-closed verdict is masked by tee's 0 and the job goes green dishonestly.
+          set -o pipefail
           cd cicd/tests
           JUDGE_FLAG=""
           case "${{ inputs.judge_mode || 'simple' }}" in


### PR DESCRIPTION
## Problem
The `Run MCP tool-call test` step pipes the runner into `tee -a "$GITHUB_STEP_SUMMARY"`. With pipefail off (the self-hosted runner's default), the pipeline exit code is tee's `0`, so a **FAIL / fail-closed verdict is masked and the job goes green**.

Confirmed both ways:
- On the runner: a verify-live run whose Docker MCP server couldn't connect printed `FAIL` in the summary, yet the job succeeded.
- Locally: `node … test-mcp …` exits **1**; `… | tee` exits **0**; `set -o pipefail; … | tee` exits **1**.

## Fix
`set -o pipefail` at the top of the run step, so the runner's exit code survives the pipe — restoring the "Exit code gates the job" contract the inline comment already claims.

## Note (out of scope)
`test-throughput.yml` and `test-fa-k80.yml` have the identical `| tee` pattern and the same latent bug. Left untouched here; can fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)