### PR TITLE
Fix | tee exit-code masking in test-throughput.yml + test-fa-k80.yml

### DIFF
--- a/.github/workflows/test-fa-k80.yml
+++ b/.github/workflows/test-fa-k80.yml
@@ -137,6 +137,8 @@ jobs:
           # ~/.claude if the secret is unset.
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
+          # pipefail so the runner's exit code survives the `| tee` below (else a FAIL is masked green).
+          set -o pipefail
           cd cicd/tests
           ARGS=(
             --model "$MODEL"

--- a/.github/workflows/test-throughput.yml
+++ b/.github/workflows/test-throughput.yml
@@ -65,6 +65,8 @@ jobs:
           # ambient ~/.claude if the secret is unset.
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
+          # pipefail so the runner's exit code survives the `| tee` below (else a FAIL is masked green).
+          set -o pipefail
           cd cicd/tests
           JUDGE_FLAG=""
           if [ "${{ inputs.judge_mode || 'simple' }}" = "dual" ]; then


### PR DESCRIPTION
Applies the same fix as #295 to the two remaining workflows that pipe the test runner into `tee -a "$GITHUB_STEP_SUMMARY"`. Without `set -o pipefail` the pipeline's exit code is tee's `0`, so a FAIL verdict is masked and the job goes green.

Verified locally for the pattern: `node … | tee` exits 0; `set -o pipefail; node … | tee` exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)