### PR TITLE
Add STORY-010 + STORY-011 (test-framework stories)

### DIFF
--- a/docs/stories/STORY-010.md
+++ b/docs/stories/STORY-010.md
@@ -1,0 +1,43 @@
+# STORY-010: A test verdict explains itself without a debugging session
+
+## User Story
+
+As a maintainer (or agent) running ollama37's capability tests,
+I want each verdict to carry the facts that decided it,
+So that I can tell why a PASS / FAIL / no-evidence happened without re-running under a debug flag.
+
+## The Need
+
+When a capability test reports a result, the result hides what determined it. A run can report
+PASS when the deeper check never actually ran; an empty or "—" result could mean the tool was
+denied, never called, returned nothing, or the checker itself failed to start — the report can't
+tell you which. The only way to find out today is to re-run under a debug flag and read a firehose
+of low-level events, or to add temporary instrumentation by hand. We did exactly that several
+times this week. A maintainer should be able to read a verdict and immediately know what happened
+and why — not reverse-engineer it.
+
+## Success Looks Like
+
+- Every verdict states the decisive facts behind it: whether the capability under test actually
+  exercised the thing it measures (for the MCP test: the tool surfaced, was permitted, was called,
+  returned data; for a perf test: the run executed and produced a real measurement) and whether the
+  deeper check truly ran or silently fell back.
+- A missing or empty result says *why* it's missing, in one glance — not an ambiguous dash.
+- A maintainer can diagnose a failed or surprising run from the normal output, without turning on
+  a debug flag or editing code.
+- There's a sensible middle ground between the terse default and the full debug firehose.
+- The capability tools report this consistently, so what you learn from one carries to the others.
+
+## Open Questions
+
+- Where the decisive facts belong — the human-facing report, the machine-readable output, the log,
+  or some of each — settled when the work is planned.
+- How log verbosity should be structured (levels; what's on by default).
+- How far to standardize the "explain yourself" shape across the capability tools vs doing it
+  per-tool first.
+
+## Status
+
+- Created: 2026-06-18
+- Plan: #297
+- Issues: none

--- a/docs/stories/STORY-011.md
+++ b/docs/stories/STORY-011.md
@@ -1,0 +1,54 @@
+# STORY-011: A verifier PASS means the claim was checked against ground truth, not just believed
+
+## User Story
+
+As a maintainer relying on the live verifier's verdict,
+I want a PASS to be backed by a fact the harness checked itself,
+So that the verdict reflects the real data — not the verifying model's say-so or its tidied-up retelling.
+
+## The Need
+
+The live verifier retrieves real data and an independent model judges the answer against it. But
+the trust currently rests on that model's prose: it decides PASS/FAIL and reports the evidence in
+its own words. We saw it return evidence that looked clean and correct but was a paraphrase the
+model reconstructed — plausible, partly inferred, not what the tool actually returned. For an exact
+match that's harmless; for a subtle case (a near-miss id, a renamed item, partial data) a model
+that will tidy up evidence may also be too quick to call PASS. The harness already captures the
+real data, so the verdict should be anchored to that captured fact, with the model's opinion as a
+second check rather than the sole authority.
+
+## Success Looks Like
+
+- A PASS is gated on a check the harness performs itself against the data it captured — the facts
+  the answer claims must actually be present in the real result before a PASS stands.
+- The verdict judges the model's **whole attempt against a clear guideline**, not just whether the
+  final text matched. The guideline grades the three stages where tool use fails:
+  - **Tool selection** — did the model make the right call(s) for the question (the necessary ones,
+    no wrong or wasteful extras)? — not assuming exactly one call.
+  - **Query** — did it invoke the tool with correct arguments (right filters, no invented params)?
+  - **Interpretation** — is the final content both **correct/complete** *and* **grounded**: every
+    fact it states actually came from the tool result, nothing plausibly invented.
+- The verifying model's role is a second opinion over a verified fact, not the only judge.
+- The verdict's evidence is the real captured data; the harness no longer relies on the model to
+  report (and possibly invent) what it saw.
+- The model's answer and the ground truth are kept clearly distinct, so the verifier isn't anchored
+  to the very claim it's meant to test.
+- A contradicted, incomplete, or invented answer is caught even when the verifying model would have
+  waved it through.
+
+## Open Questions
+
+- The verifier currently sees only the model's *final answer* — to judge tool selection and query
+  it needs the model's actual **tool calls** (the trajectory). What to pass, and how much.
+- How strict the harness-side check should be (exact presence vs normalized/fuzzy matching) and how
+  it behaves for tools whose answer isn't a simple set of facts.
+- Whether the three-stage guideline yields one PASS/FAIL or a per-stage breakdown, and whether all
+  three must pass or some are advisory.
+- Whether the model opinion stays a required second gate or becomes advisory.
+- How to keep this general across different servers/tools rather than tailored to one.
+
+## Status
+
+- Created: 2026-06-18
+- Plan: #298
+- Issues: none


### PR DESCRIPTION
Two goal-doc stories surfaced by the keyless live-MCP verifier work (#293), both reviewed via dw-review-story and planned:

- **STORY-010** — *a test verdict explains itself without a debugging session* (observability). Plan: #297.
- **STORY-011** — *a verifier PASS means the claim was checked against ground truth, not just believed* (trustworthiness; three-stage tool/query/content guideline). Plan: #298.

Pure documentation. Plans are open for human review before `/dw-tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)