### PR TITLE
[STORY-010] Verdict explains itself: empty evidence says why

### DIFF
--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -446,7 +446,7 @@ export class VerifierJudge {
         process.stderr.write(`  [verify] ${t.testId}: ${judgment.pass ? 'PASS' : 'FAIL'} — ${judgment.reason}\n`);
       } catch (error) {
         process.stderr.write(`  [verify] Failed to verify ${t.testId}: ${error}\n`);
-        out.push({ testId: t.testId, pass: false, reason: 'Verifier failed: ' + String(error) });
+        out.push({ testId: t.testId, pass: false, reason: 'Verifier failed: ' + String(error), evidenceStatus: 'verifier-unavailable' });
       } finally {
         // Fresh session per target — tear down so the next target re-spawns clean.
         this.kill();

--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -83,6 +83,8 @@ export class VerifierJudge {
    *  only ever shows ground truth from a tool we permit (not a denied/built-in call). Correlated by
    *  id because a `tool_call_update` carries the id but not the tool title. */
   private allowedCallIds = new Set<string>();
+  /** Whether the gate denied any tool this turn — lets an empty evidence cell explain itself. */
+  private sawDeniedCall = false;
 
   private readonly cfg: VerifierConfig;
   private readonly allow: Set<string>;
@@ -103,6 +105,14 @@ export class VerifierJudge {
   private bareName(name: string): string {
     const parts = name.split('__');
     return parts.length >= 3 ? parts.slice(2).join('__') : name;
+  }
+
+  /** Why this turn's evidence is what it is — so an empty cell explains itself (STORY-010). */
+  private currentEvidenceStatus(): NonNullable<Judgment['evidenceStatus']> {
+    if (this.toolEvidence) return 'captured';
+    if (this.sawDeniedCall) return 'denied';
+    if (this.allowedCallIds.size === 0) return 'not-called';
+    return 'no-data';
   }
 
   /** Pull the actual result text out of a `tool_call_update.content` envelope
@@ -209,6 +219,7 @@ export class VerifierJudge {
       params.options.find((o) => o.kind?.startsWith('reject'));
     // The security boundary — always log every decision (allow and reject), not just DEBUG.
     process.stderr.write(`  [verify] ${allowed ? 'ALLOWED' : 'DENIED'} tool permission: "${String(raw).slice(0, 80)}"\n`);
+    if (!allowed) this.sawDeniedCall = true;
     return opt
       ? { outcome: { outcome: 'selected', optionId: opt.optionId } }
       : { outcome: { outcome: 'cancelled' } };
@@ -380,6 +391,7 @@ export class VerifierJudge {
     this.turnText = '';
     this.toolEvidence = '';
     this.allowedCallIds.clear();
+    this.sawDeniedCall = false;
     try {
       await this.withTimeout(
         this.conn!.prompt({ sessionId: this.sessionId!, prompt: [{ type: 'text', text: prompt }] }),
@@ -394,12 +406,13 @@ export class VerifierJudge {
 
   private async verifyOne(t: VerifyTarget): Promise<Judgment> {
     const responseText = await this.promptAgent(this.buildPrompt(t));
+    const evidenceStatus = this.currentEvidenceStatus();
     if (!responseText) {
-      return { testId: t.testId, pass: false, reason: 'Verifier returned empty response' };
+      return { testId: t.testId, pass: false, reason: 'Verifier returned empty response', evidenceStatus };
     }
     const json = this.extractJson(responseText);
     if (!json) {
-      return { testId: t.testId, pass: false, reason: `No JSON in verifier response: ${responseText.substring(0, 200)}` };
+      return { testId: t.testId, pass: false, reason: `No JSON in verifier response: ${responseText.substring(0, 200)}`, evidenceStatus };
     }
     try {
       const judgment = JSON.parse(json) as Judgment;
@@ -408,14 +421,15 @@ export class VerifierJudge {
         judgment.pass = (judgment.pass as unknown as string).toLowerCase() === 'true';
       }
       if (typeof judgment.pass !== 'boolean') {
-        return { testId: t.testId, pass: false, reason: `Verifier response missing "pass": ${responseText.substring(0, 200)}` };
+        return { testId: t.testId, pass: false, reason: `Verifier response missing "pass": ${responseText.substring(0, 200)}`, evidenceStatus };
       }
       if (!judgment.reason) judgment.reason = judgment.pass ? 'Verified (no reason provided)' : 'Failed (no reason provided)';
       // Prefer the raw tool result we captured ourselves over the agent's self-reported evidence.
       if (this.toolEvidence) judgment.evidence = this.toolEvidence;
+      judgment.evidenceStatus = evidenceStatus;
       return judgment;
     } catch {
-      return { testId: t.testId, pass: false, reason: `Failed to parse verifier response: ${responseText.substring(0, 200)}` };
+      return { testId: t.testId, pass: false, reason: `Failed to parse verifier response: ${responseText.substring(0, 200)}`, evidenceStatus };
     }
   }
 

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -163,6 +163,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
         testId: r.model,
         pass: false,
         reason: 'verify-live could not run: verifier agent unavailable (auth/availability)',
+        evidenceStatus: 'verifier-unavailable' as const,
       })));
     }
   } else if (eligible.length > 0 && opts.judge) {
@@ -195,6 +196,17 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
   return failed > 0 ? 1 : 0;
 }
 
+/** Turn an empty evidence cell into a one-glance reason instead of a bare "—" (STORY-010). */
+function evidenceWhy(status: Judgment['evidenceStatus']): string {
+  switch (status) {
+    case 'denied': return '— (tool denied)';
+    case 'not-called': return '— (no tool called)';
+    case 'no-data': return '— (tool returned no data)';
+    case 'verifier-unavailable': return '— (verifier did not run)';
+    default: return '—';
+  }
+}
+
 function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   const out: string[] = [];
   out.push('## MCP tool-call test');
@@ -209,7 +221,9 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
     const answer = r.final_answer_preview.trim() ? 'yes' : 'no';
     const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').replace(/[\n|]/g, ' ').slice(0, 200);
     // The raw tool result the verifier captured (verify-live only); full result is in the JSON output.
-    const evidence = (r.check.agent?.evidence ?? '').replace(/[\n|]/g, ' ').slice(0, 200) || '—';
+    // When there's no captured data, say WHY rather than a bare "—" (STORY-010).
+    const evidence = (r.check.agent?.evidence ?? '').replace(/[\n|]/g, ' ').slice(0, 200)
+      || evidenceWhy(r.check.agent?.evidenceStatus);
     out.push(`| ${r.model} | ${verdict} | ${calls} | ${answer} | ${reason} | ${evidence} |`);
   }
   process.stdout.write(out.join('\n') + '\n');

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -137,7 +137,8 @@ export interface Judgment {
   evidence?: string;
   /** Why the evidence is what it is — so an empty cell explains itself instead of a bare "—":
    *  'captured' (live data), 'denied' (a tool was refused), 'not-called' (no tool was called),
-   *  'no-data' (called but returned nothing), 'verifier-unavailable' (the verifier never ran). */
+   *  'no-data' (called but returned nothing), 'verifier-unavailable' (the verifier produced no
+   *  verdict — couldn't start, or errored/timed out mid-run). */
   evidenceStatus?: 'captured' | 'denied' | 'not-called' | 'no-data' | 'verifier-unavailable';
 }
 

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -135,6 +135,10 @@ export interface Judgment {
   reason: string;
   /** Evidence log line (required when pass=false) */
   evidence?: string;
+  /** Why the evidence is what it is — so an empty cell explains itself instead of a bare "—":
+   *  'captured' (live data), 'denied' (a tool was refused), 'not-called' (no tool was called),
+   *  'no-data' (called but returned nothing), 'verifier-unavailable' (the verifier never ran). */
+  evidenceStatus?: 'captured' | 'denied' | 'not-called' | 'no-data' | 'verifier-unavailable';
 }
 
 // ============================================

--- a/docs/stories/STORY-010.md
+++ b/docs/stories/STORY-010.md
@@ -40,4 +40,4 @@ and why — not reverse-engineer it.
 
 - Created: 2026-06-18
 - Plan: #297
-- Issues: none
+- Issues: #300, #301, #302, #303


### PR DESCRIPTION
Fixes #300.

## What & why
A verify-live evidence cell was a bare `—` whether the tool was **denied**, **never called**, **returned nothing**, or the **verifier never ran** — you couldn't tell which without `VERIFY_DEBUG`. This is the first task of [STORY-010](../docs/stories/STORY-010.md) (plan #297): make the verdict explain itself in normal output.

## Changes
- `Judgment` gains `evidenceStatus`: `captured | denied | not-called | no-data | verifier-unavailable` (`types.ts`).
- `verifier-judge.ts` tracks denied calls (`sawDeniedCall`) alongside the existing allowed-call/evidence state, computes the status per turn, and sets it on every `verifyOne` return **and** the `verify()` crash/timeout catch.
- `test-mcp.ts`: the fail-closed branch sets `verifier-unavailable`; `printSummary` renders an empty cell as `— (tool denied / no tool called / tool returned no data / verifier did not run)`; the JSON output carries `evidenceStatus`.

## Verification (keyless)
- Deny path → `— (no tool called)`, `evidenceStatus: not-called`, **exit 1**.
- PASS path → captured live data, `evidenceStatus: captured`, **exit 0** (no regression).
- Verifier-unavailable label verified by inspection (the fail-closed branch itself was proven earlier via a real 401; a clean live re-trigger needs a 300s auth-hang).

## Also
- Lands STORY-010 Status (tasks #300–#303).
- code-review (medium): 1 finding (crash-path label), fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)