### PR TITLE
[STORY-010] Verifier raw-response logging + mid verbosity level (#301, #302)

### DIFF
--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -48,6 +48,10 @@ import { CONFIG } from '../config.js';
 /** VERIFY_DEBUG=1 → reveal every ACP event (sessionUpdate kinds, tool calls, permission/trust
  *  requests) so nothing the adapter emits is swallowed silently. */
 const DEBUG = !!process.env.VERIFY_DEBUG;
+/** VERIFY_VERBOSE=1 → a middle level between the terse default and the DEBUG firehose: the
+ *  decisive per-step trace (config isolation, tool calls/results) without every event or the
+ *  warm-up turn. DEBUG implies VERBOSE. */
+const VERBOSE = DEBUG || !!process.env.VERIFY_VERBOSE;
 
 /** One model's answer to verify against the live server. */
 export interface VerifyTarget {
@@ -178,7 +182,7 @@ export class VerifierJudge {
     }));
     const settings = join(cfgDir, 'settings.json');
     if (!existsSync(settings)) writeFileSync(settings, '{}');
-    if (DEBUG) process.stderr.write(`  [verify:isolate] CLAUDE_CONFIG_DIR=${cfgDir} cwd=${work}\n`);
+    if (VERBOSE) process.stderr.write(`  [verify:isolate] CLAUDE_CONFIG_DIR=${cfgDir} cwd=${work}\n`);
     this.isolatedCfgDir = cfgDir;
     this.isolatedCwd = work;
     return { cfgDir, cwd: work };
@@ -240,11 +244,12 @@ export class VerifierJudge {
       sessionUpdate: async (params: SessionNotification): Promise<void> => {
         const u = params.update;
         const x = u as Record<string, unknown>;
-        if (DEBUG) {
-          const extra =
-            u.sessionUpdate === 'tool_call' || u.sessionUpdate === 'tool_call_update'
-              ? ` id=${JSON.stringify(x.toolCallId)} title=${JSON.stringify(x.title)} status=${String(x.status)}`
-              : '';
+        // VERBOSE shows the decisive tool-call steps; DEBUG adds every other event (the firehose).
+        const isToolEvent = u.sessionUpdate === 'tool_call' || u.sessionUpdate === 'tool_call_update';
+        if (DEBUG || (VERBOSE && isToolEvent)) {
+          const extra = isToolEvent
+            ? ` id=${JSON.stringify(x.toolCallId)} title=${JSON.stringify(x.title)} status=${String(x.status)}`
+            : '';
           process.stderr.write(`  [verify:event] ${u.sessionUpdate}${extra}\n`);
         }
         if (u.sessionUpdate === 'agent_message_chunk' && u.content.type === 'text') {
@@ -406,6 +411,9 @@ export class VerifierJudge {
 
   private async verifyOne(t: VerifyTarget): Promise<Judgment> {
     const responseText = await this.promptAgent(this.buildPrompt(t));
+    // Parity with AgentJudge — log the raw response at the normal level so a surprising verdict
+    // (or a parse failure) is diagnosable without VERIFY_DEBUG.
+    process.stderr.write(`  [verify] Raw response for ${t.testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
     const evidenceStatus = this.currentEvidenceStatus();
     if (!responseText) {
       return { testId: t.testId, pass: false, reason: 'Verifier returned empty response', evidenceStatus };


### PR DESCRIPTION
Fixes #301. Fixes #302. Two tightly-coupled STORY-010 observability tasks (plan #297).

## #301 — verifier logs its raw response (parity with AgentJudge)
`AgentJudge` logs `[judge] Raw response for … (N chars): …` unconditionally; the verifier didn't (we hand-instrumented it this session). Now `[verify] Raw response for … ` logs at the normal level, **before** the parse — so a parse failure is diagnosable too.

## #302 — a mid `VERIFY_VERBOSE` level
Between the terse default and the `VERIFY_DEBUG` firehose. Shows the decisive per-step trace (config isolation + tool calls/results) without every ACP event, the permission dumps, or the warm-up turn. `VERIFY_DEBUG` implies `VERIFY_VERBOSE`.

## Verification (keyless)
At `VERIFY_VERBOSE=1`: 7 decisive lines (isolate, tool_call/update, ALLOWED, raw response, verdict), **0** firehose lines; PASS, exit 0. Default stays terse by construction (both gates off; the raw-response line is intentionally unconditional, like AgentJudge); `VERIFY_DEBUG` unchanged.

Pure observability — no logic/verdict change. (Per CLAUDE.md §5, `dw-review-implement` run; full `code-review` skipped for a no-logic logging change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)