### PR TITLE
[STORY-010] Perf tools say when the judge fell back to simple (#303)

### DIFF
--- a/cicd/tests/src/perf/fa.ts
+++ b/cicd/tests/src/perf/fa.ts
@@ -210,6 +210,7 @@ export async function runFa(opts: FaOptions): Promise<number> {
     m.check.pass = m.check.simple.pass; // updated by the agent below
   }
   const eligible = judgeable.filter((m) => m.check!.simple.pass);
+  let judgeFellBack = false;
   if (eligible.length > 0) {
     const agentJudge = new AgentJudge();
     if (await agentJudge.isAvailable()) {
@@ -225,6 +226,7 @@ export async function runFa(opts: FaOptions): Promise<number> {
         }
       }
     } else {
+      judgeFellBack = true;
       process.stderr.write('[WARN] agent judge not available — simple check only\n');
     }
   }
@@ -254,11 +256,11 @@ export async function runFa(opts: FaOptions): Promise<number> {
     );
   }
 
-  printTables(opts, metrics, comparison);
+  printTables(opts, metrics, comparison, judgeFellBack);
   return failed > 0 ? 1 : 0;
 }
 
-function printTables(opts: FaOptions, metrics: ConfigMetrics[], comparison?: { match: boolean }): void {
+function printTables(opts: FaOptions, metrics: ConfigMetrics[], comparison: { match: boolean } | undefined, judgeFellBack: boolean): void {
   const out: string[] = [];
   if (opts.benchmark) {
     out.push('## K80 FA benchmark');
@@ -274,6 +276,11 @@ function printTables(opts: FaOptions, metrics: ConfigMetrics[], comparison?: { m
   }
   out.push('## K80 FA judge verdicts');
   out.push('');
+  // Don't pass off a simple-only result as a judged one — say the judge didn't run (STORY-010).
+  if (judgeFellBack) {
+    out.push('_Agent judge unavailable — verdicts below are the simple content check only._');
+    out.push('');
+  }
   out.push('| Config | Verdict | Reason |');
   out.push('|---|---|---|');
   for (const m of metrics) {

--- a/cicd/tests/src/perf/throughput.ts
+++ b/cicd/tests/src/perf/throughput.ts
@@ -142,6 +142,7 @@ export async function runThroughput(opts: ThroughputOptions): Promise<number> {
 
   // Agent judge (dual mode): one batch over a single reused session, only for
   // models that passed the simple check (an empty output is already a fail).
+  let judgeFellBack = false;
   if (judge) {
     const eligible = results.filter((r) => r.check.simple.pass);
     if (eligible.length > 0) {
@@ -161,6 +162,7 @@ export async function runThroughput(opts: ThroughputOptions): Promise<number> {
           }
         }
       } else {
+        judgeFellBack = true;
         process.stderr.write('[WARN] agent judge not available — simple check only\n');
       }
     }
@@ -182,8 +184,10 @@ export async function runThroughput(opts: ThroughputOptions): Promise<number> {
     process.stderr.write(`Results written to ${opts.output}\n`);
   }
 
-  // Markdown summary on stdout (CI appends this to the step summary)
-  printSummary(sha, gpuBefore, numCtx, judge ? 'dual' : 'simple', results);
+  // Markdown summary on stdout (CI appends this to the step summary). When dual was asked for but
+  // the judge couldn't run, say so — don't claim "dual" for a simple-only result (STORY-010).
+  const judgeMode = judge ? (judgeFellBack ? 'dual → simple (judge unavailable)' : 'dual') : 'simple';
+  printSummary(sha, gpuBefore, numCtx, judgeMode, results);
   return failed > 0 ? 1 : 0;
 }
 


### PR DESCRIPTION
Fixes #303. The "generalize self-explaining verdicts to throughput + fa" task (plan #297).

## The gap (investigated)
`throughput.ts` and `fa.ts` had the **same silent-fallback** as test-mcp before #293: a `dual` run whose agent judge is unavailable silently becomes simple (a stderr `[WARN]`), while the report still claims **"dual"** — so a reader can't tell the deeper check was skipped. Lower severity than verify-live (the judge is an opt-in *extra* here, not the primary verdict), but still misleading.

## Fix
- **throughput.ts**: track `judgeFellBack`; the summary's `Judge:` field reads `dual → simple (judge unavailable)` instead of `dual`.
- **fa.ts**: track `judgeFellBack` (threaded into `printTables`); the judge-verdicts section gets a note that those verdicts are the simple content check only.

The rest of STORY-010's cross-tool criterion was *already* met (both perf tools log `tok/s` + `simple=` and the agent judge logs its raw response) — this closes the one real gap.

## Validation
Build clean. Happy path is **byte-identical** when the judge runs (`judgeFellBack` stays false). These are GPU perf tools, so runtime validation is via the perf CI workflows; the fell-back path itself needs judge-unavailable, which can't be forced cleanly in CI (same limitation as test-mcp's `verifier-unavailable` label). Pure observability — no verdict/behavior change on the happy path. (Per CLAUDE.md §5, `dw-review-implement` run; full `code-review` skipped for a no-logic change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)