### PR TITLE
Readable verify-live report + judge stages + secret redaction (#314)

### DIFF
--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -57,6 +57,16 @@ const VERBOSE = DEBUG || !!process.env.VERIFY_VERBOSE;
  *  every record (the report still shows only the first ~200 chars). */
 const EVIDENCE_CAP = 20000;
 
+/** Redact secret-like JSON field values (api_key, token, password, …) from a captured tool result
+ *  before it becomes evidence — so credentials a server returns never reach the report, the JSON
+ *  artifact, or the CI log. Matches the field NAME; leaves everything else intact. */
+export function redactSecrets(s: string): string {
+  return s.replace(
+    /("(?:[\w-]*(?:api[_-]?key|key|token|secret|password|passwd|credential)[\w-]*)"\s*:\s*)"[^"]*"/gi,
+    '$1"[redacted]"',
+  );
+}
+
 /** Deterministic cross-check (STORY-011): the distinctive identifiers a model's answer claims —
  *  multi-digit ids and identifier-like names (those containing a digit or hyphen) — must appear in
  *  the captured live result. Returns the claims that DON'T, i.e. the likely inventions. Conservative
@@ -291,7 +301,7 @@ export class VerifierJudge {
         if (u.sessionUpdate === 'tool_call_update' && typeof x.toolCallId === 'string' &&
             this.allowedCallIds.has(x.toolCallId) && String(x.status) === 'completed') {
           const text = this.toolResultText(x.content);
-          if (text) this.toolEvidence = (this.toolEvidence + text).slice(0, EVIDENCE_CAP);
+          if (text) this.toolEvidence = (this.toolEvidence + redactSecrets(text)).slice(0, EVIDENCE_CAP);
         }
       },
       requestPermission: async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
@@ -461,6 +471,12 @@ export class VerifierJudge {
     try {
       const judgment = JSON.parse(json) as Judgment;
       judgment.testId = t.testId;
+      // Capture the verifier's per-stage rubric flags (it grades these; surface them as judge info).
+      const raw = judgment as unknown as Record<string, unknown>;
+      const toBool = (v: unknown) => v === true || String(v).toLowerCase() === 'true';
+      if ('tool_selection_ok' in raw || 'query_ok' in raw || 'interpretation_ok' in raw) {
+        judgment.stages = { tool: toBool(raw.tool_selection_ok), query: toBool(raw.query_ok), content: toBool(raw.interpretation_ok) };
+      }
       if (typeof judgment.pass === 'string') {
         judgment.pass = (judgment.pass as unknown as string).toLowerCase() === 'true';
       }
@@ -471,9 +487,10 @@ export class VerifierJudge {
       // Deterministic cross-check: the verifying model's PASS only stands if the answer's claimed
       // facts actually appear in the live result we captured. The LLM is a second opinion, never the
       // sole judge — it cannot wave through an answer the ground truth doesn't support.
-      if (judgment.pass && this.toolEvidence) {
+      if (this.toolEvidence) {
         const unsupported = unsupportedClaims(t.answer, this.toolEvidence);
-        if (unsupported.length) {
+        judgment.crossCheckUnsupported = unsupported;        // record the result for the report (judge info)
+        if (judgment.pass && unsupported.length) {
           judgment.pass = false;
           judgment.reason = `Deterministic cross-check FAILED: answer claims not present in live data: ${unsupported.join(', ')}. (verifier had said: ${judgment.reason})`;
           process.stderr.write(`  [verify] cross-check overrode PASS→FAIL — unsupported: ${unsupported.join(', ')}\n`);

--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -61,8 +61,10 @@ const EVIDENCE_CAP = 20000;
  *  before it becomes evidence — so credentials a server returns never reach the report, the JSON
  *  artifact, or the CI log. Matches the field NAME; leaves everything else intact. */
 export function redactSecrets(s: string): string {
+  // Field name contains a secret-ish word → replace its value (string-with-escapes, array, object,
+  // or bare number/bool/null) with [redacted]. Over-redacts (safe direction) rather than miss one.
   return s.replace(
-    /("(?:[\w-]*(?:api[_-]?key|key|token|secret|password|passwd|credential)[\w-]*)"\s*:\s*)"[^"]*"/gi,
+    /("(?:[\w-]*(?:api[_-]?key|key|token|secret|password|passwd|credential|authorization|auth|bearer|session|cookie|signature|access|private)[\w-]*)"\s*:\s*)(?:"(?:\\.|[^"\\])*"|\[[^\]]*\]|\{[^}]*\}|[^,}\]\s][^,}\]]*)/gi,
     '$1"[redacted]"',
   );
 }

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -207,24 +207,54 @@ function evidenceWhy(status: Judgment['evidenceStatus']): string {
   }
 }
 
+const tick = (b: boolean): string => (b ? '✅' : '❌');
+
 function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
+  const mode = opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple';
+  const supported = results.filter((r) => r.supported);
+  const passed = supported.filter((r) => r.check.overall_pass).length;
+  const failed = supported.length - passed;
+  const sha = process.env.GITHUB_SHA?.slice(0, 8);
   const out: string[] = [];
-  out.push('## MCP tool-call test');
+
+  // Banner — a glance tells you the outcome.
+  out.push(`## 🧪 MCP tool-call test — ${failed === 0 ? '✅' : '❌'} ${passed} passed · ${failed} failed`);
   out.push('');
-  out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\` · **Prompt:** ${opts.prompt} · **Judge:** ${opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple'}`);
+  out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\``);
+  out.push(`**Prompt:** ${opts.prompt} · **Judge:** ${mode}${sha ? ` · **Commit:** \`${sha}\`` : ''}`);
   out.push('');
-  out.push('| Model | Verdict | Tool calls | Answer | Reason | Live evidence |');
-  out.push('|---|---|---|---|---|---|');
+
+  // Scannable table — judge stages + cross-check, no raw JSON in the cells.
+  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check |');
+  out.push('|---|---|---|---|---|');
   for (const r of results) {
-    const verdict = r.check.overall_pass ? 'PASS' : r.supported ? 'FAIL' : 'NO TOOL SUPPORT';
+    const verdict = r.check.overall_pass ? '✅ PASS' : r.supported ? '❌ FAIL' : '⚪ NO TOOL SUPPORT';
     const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
-    const answer = r.final_answer_preview.trim() ? 'yes' : 'no';
-    const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').replace(/[\n|]/g, ' ').slice(0, 200);
-    // The raw tool result the verifier captured (verify-live only); full result is in the JSON output.
-    // When there's no captured data, say WHY rather than a bare "—" (STORY-010).
-    const evidence = (r.check.agent?.evidence ?? '').replace(/[\n|]/g, ' ').slice(0, 200)
-      || evidenceWhy(r.check.agent?.evidenceStatus);
-    out.push(`| ${r.model} | ${verdict} | ${calls} | ${answer} | ${reason} | ${evidence} |`);
+    const s = r.check.agent?.stages;
+    const stages = s ? `${tick(s.tool)} · ${tick(s.query)} · ${tick(s.content)}` : '—';
+    const cc = r.check.agent?.crossCheckUnsupported;
+    const cross = cc === undefined ? '—' : cc.length ? `❌ ${cc.join(', ').slice(0, 60)}` : '✅ grounded';
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} |`);
+  }
+
+  // Per-model detail (reasoning + raw evidence) tucked behind a toggle — proof without the clutter.
+  for (const r of results) {
+    const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').trim();
+    const evidence = r.check.agent?.evidence ?? '';
+    out.push('');
+    out.push(`<details><summary>Judge detail — ${r.model}</summary>`);
+    out.push('');
+    if (reason) out.push(`**Reasoning:** ${reason.replace(/\n/g, ' ')}`);
+    out.push('');
+    if (evidence) {
+      out.push('**Live evidence:**');
+      out.push('```json');
+      out.push(evidence.slice(0, 4000));
+      out.push('```');
+    } else {
+      out.push(`**Live evidence:** ${evidenceWhy(r.check.agent?.evidenceStatus)}`);
+    }
+    out.push('</details>');
   }
   process.stdout.write(out.join('\n') + '\n');
 }

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -184,7 +184,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
     writeFileSync(
       opts.output,
       JSON.stringify(
-        { timestamp: new Date().toISOString(), server: { command: opts.server.command, args: opts.server.args }, prompt: opts.prompt, judge: opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple', results: full },
+        { timestamp: new Date().toISOString(), server: { command: opts.server.command, args: opts.server.args }, prompt: opts.prompt, judge: judgeLabel(opts), results: full },
         null,
         2
       )
@@ -208,20 +208,23 @@ function evidenceWhy(status: Judgment['evidenceStatus']): string {
 }
 
 const tick = (b: boolean): string => (b ? '✅' : '❌');
+const judgeLabel = (opts: McpTestOptions): string => (opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple');
+/** Escape so model/server-controlled text can't break out of the Markdown/<details>/code block. */
+const mdSafe = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
-  const mode = opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple';
   const supported = results.filter((r) => r.supported);
   const passed = supported.filter((r) => r.check.overall_pass).length;
   const failed = supported.length - passed;
   const sha = process.env.GITHUB_SHA?.slice(0, 8);
   const out: string[] = [];
 
-  // Banner — a glance tells you the outcome.
-  out.push(`## 🧪 MCP tool-call test — ${failed === 0 ? '✅' : '❌'} ${passed} passed · ${failed} failed`);
+  // Banner — a glance tells you the outcome. ⚪ when nothing was actually verified (don't fake a green).
+  const icon = failed > 0 ? '❌' : passed > 0 ? '✅' : '⚪';
+  out.push(`## 🧪 MCP tool-call test — ${icon} ${passed} passed · ${failed} failed`);
   out.push('');
   out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\``);
-  out.push(`**Prompt:** ${opts.prompt} · **Judge:** ${mode}${sha ? ` · **Commit:** \`${sha}\`` : ''}`);
+  out.push(`**Prompt:** ${opts.prompt} · **Judge:** ${judgeLabel(opts)}${sha ? ` · **Commit:** \`${sha}\`` : ''}`);
   out.push('');
 
   // Scannable table — judge stages + cross-check, no raw JSON in the cells.
@@ -242,15 +245,14 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
     const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').trim();
     const evidence = r.check.agent?.evidence ?? '';
     out.push('');
-    out.push(`<details><summary>Judge detail — ${r.model}</summary>`);
+    out.push(`<details><summary>Judge detail — ${mdSafe(r.model)}</summary>`);
     out.push('');
-    if (reason) out.push(`**Reasoning:** ${reason.replace(/\n/g, ' ')}`);
+    if (reason) out.push(`**Reasoning:** ${mdSafe(reason.replace(/\n/g, ' '))}`);
     out.push('');
     if (evidence) {
+      // HTML-escaped <pre> (not a ``` fence) so a ``` or </details> in the result can't break out.
       out.push('**Live evidence:**');
-      out.push('```json');
-      out.push(evidence.slice(0, 4000));
-      out.push('```');
+      out.push(`<pre>${mdSafe(evidence.slice(0, 4000))}</pre>`);
     } else {
       out.push(`**Live evidence:** ${evidenceWhy(r.check.agent?.evidenceStatus)}`);
     }

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -140,6 +140,12 @@ export interface Judgment {
    *  'no-data' (called but returned nothing), 'verifier-unavailable' (the verifier produced no
    *  verdict — couldn't start, or errored/timed out mid-run). */
   evidenceStatus?: 'captured' | 'denied' | 'not-called' | 'no-data' | 'verifier-unavailable';
+  /** verify-live: the verifier's per-stage rubric flags (tool selection / query / interpretation),
+   *  if it graded them — so the report can show *judge info*, not just the final pass/fail. */
+  stages?: { tool: boolean; query: boolean; content: boolean };
+  /** verify-live deterministic cross-check: the claimed facts NOT found in the live data
+   *  (empty = all grounded). Undefined when there was no captured evidence to check against. */
+  crossCheckUnsupported?: string[];
 }
 
 // ============================================


### PR DESCRIPTION
Fixes #314.

## Report (the ask)
The verify-live Step Summary dumped raw PHP-serialized JSON into a table cell. Now `printSummary()` produces a glanceable report:
- **Banner:** `✅ N passed · M failed` + server / prompt / judge / commit.
- **Scannable table** with the verifier's **judge info** — per-stage rubric (tool · query · content) + the deterministic cross-check result — not raw JSON.
- **Reasoning + raw evidence behind a `<details>` toggle.** Full data still in the `mcp-results.json` artifact.

The agent already graded the three stages (`tool_selection_ok`/`query_ok`/`interpretation_ok`) but `verifyOne` discarded them — now captured into `Judgment.stages` (+ `crossCheckUnsupported`). **The workflow YAML is unchanged** (it already tees stdout to the Summary).

## Security fix (surfaced by the task)
Rendering the evidence exposed that the captured `list_projects` result contains testlink project **`api_key`s** — which were already in the uploaded JSON artifact, and would now show in the Summary. Added `redactSecrets()`, applied **at capture**, so secrets a server returns never reach the report, artifact, or log.
- **Limitation (documented):** name-based denylist (`key|token|secret|password|credential`), string values only — catches the known case; a secret under an unanticipated field name on an arbitrary server could still leak. Fine for testlink; a field-allowlist would be stronger for untrusted servers.

## Validation (keyless)
Live run: banner + table (`✅·✅·✅` stages, `✅ grounded` cross-check) + collapsible; **2 api_keys → [redacted], 0 leaked**, verdict unchanged. `redactSecrets` + `unsupportedClaims` unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)