### PR TITLE
test-mcp: adjustable model timeout (default 10 min) + perf in report (#316)

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: "4096"
         type: string
+      timeout:
+        description: "Per-model Ollama response timeout (seconds) — heavy models on the K80 need more"
+        required: false
+        default: "600"
+        type: string
       judge_mode:
         description: "Verification mode (simple = structural check; dual = also run the keyless agent judge for groundedness; verify-live = the keyless verifier calls the server's read-only tools itself and checks the answer against LIVE data)"
         required: false
@@ -108,6 +113,7 @@ jobs:
           npx tsx src/cli.ts test-mcp $MODELS \
             --prompt "${{ inputs.prompt || 'List the projects.' }}" \
             --num-ctx "${{ inputs.num_ctx || '4096' }}" \
+            --timeout "${{ inputs.timeout || '600' }}" \
             --mcp-command "${{ inputs.mcp_command || 'docker' }}" \
             --mcp-args "${{ inputs.mcp_args || 'run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest' }}" \
             --mcp-env "TESTLINK_URL,TESTLINK_API_KEY" \

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -309,12 +309,14 @@ program
   .option('--verify-live', 'Verify the answer against LIVE truth: the judge calls the server\'s read-only tools itself (supersedes --judge)', false)
   .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (fail-closed: empty verifies nothing)', '')
   .option('--verify-server-name <name>', 'mcp__<name>__<tool> label the verifier registers the server under', 'mcp')
+  .option('--timeout <seconds>', 'Per-model Ollama response timeout (heavy models need more)', '600')
   .option('-o, --output <file>', 'Write the JSON report to this file')
   .action(async (models: string[], options) => {
     const code = await runMcpTest({
       models,
       prompt: options.prompt,
       numCtx: Number(options.numCtx),
+      timeoutMs: Number(options.timeout) * 1000,
       judge: options.judge,
       verifyLive: options.verifyLive,
       verifyAllow: options.verifyAllow ? String(options.verifyAllow).split(',').map((s: string) => s.trim()).filter(Boolean) : undefined,

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -119,7 +119,7 @@ function asArgs(raw: unknown): Record<string, unknown> {
 export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
   const numCtx = opts.numCtx ?? 4096;
   const maxIters = opts.maxIters ?? 5;
-  const timeoutMs = opts.timeoutMs ?? 600000;
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? (opts.timeoutMs as number) : 600000;
   let totalDurNs = 0;
   let evalDurNs = 0;
 

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -35,6 +35,9 @@ export interface McpHostOptions {
   numCtx?: number;
   /** Max chat↔tool rounds before giving up (guards against a tool loop). */
   maxIters?: number;
+  /** Per-call Ollama response timeout (ms). Default 600000 (10 min) — heavy models on slow
+   *  hardware (the K80) need more than fetch's implicit ~5-min default. */
+  timeoutMs?: number;
 }
 
 export interface ToolCallRecord {
@@ -59,6 +62,11 @@ export interface McpTrajectory {
   toolCalls: ToolCallRecord[];
   toolResults: ToolResultRecord[];
   finalAnswer: string;
+  /** Ollama generation perf, summed across the chat↔tool rounds. */
+  inTokens: number;
+  outTokens: number;
+  totalDurationS: number;
+  evalTps: number;
   error?: string;
 }
 
@@ -74,14 +82,18 @@ export function mcpToOllamaTools(tools: Array<{ name: string; description?: stri
   }));
 }
 
-async function chat(host: string, model: string, messages: unknown[], tools: unknown[], numCtx: number): Promise<any> {
+async function chat(host: string, model: string, messages: unknown[], tools: unknown[], numCtx: number, timeoutMs: number): Promise<any> {
   const res = await fetch(`${host}/api/chat`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ model, messages, tools, stream: false, options: { temperature: 0, seed: 42, num_ctx: numCtx } }),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   return res.json();
 }
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+const tps = (tokens: number, durNs: number): number => (durNs > 0 ? round2(tokens / (durNs / 1e9)) : 0);
 
 /** Join an MCP CallToolResult's content blocks into a single text payload. */
 function resultText(content: unknown): string {
@@ -107,6 +119,9 @@ function asArgs(raw: unknown): Record<string, unknown> {
 export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
   const numCtx = opts.numCtx ?? 4096;
   const maxIters = opts.maxIters ?? 5;
+  const timeoutMs = opts.timeoutMs ?? 600000;
+  let totalDurNs = 0;
+  let evalDurNs = 0;
 
   const transport = new StdioClientTransport({
     command: opts.server.command,
@@ -124,6 +139,10 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     toolCalls: [],
     toolResults: [],
     finalAnswer: '',
+    inTokens: 0,
+    outTokens: 0,
+    totalDurationS: 0,
+    evalTps: 0,
   };
 
   const messages: any[] = [{ role: 'user', content: opts.prompt }];
@@ -139,7 +158,7 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     const tools = mcpToOllamaTools(listed.tools);
 
     for (let i = 0; i < maxIters; i++) {
-      const raw = await chat(opts.host, opts.model, messages, tools, numCtx);
+      const raw = await chat(opts.host, opts.model, messages, tools, numCtx, timeoutMs);
 
       if (!raw || typeof raw !== 'object') {
         throw new Error('ollama /api/chat: no/invalid response');
@@ -151,6 +170,13 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
         traj.error = String(raw.error);
         return traj;
       }
+      // Accumulate generation perf across the rounds (Ollama durations are ns).
+      traj.inTokens += raw.prompt_eval_count ?? 0;
+      traj.outTokens += raw.eval_count ?? 0;
+      totalDurNs += raw.total_duration ?? 0;
+      evalDurNs += raw.eval_duration ?? 0;
+      traj.totalDurationS = round2(totalDurNs / 1e9);
+      traj.evalTps = tps(traj.outTokens, evalDurNs);
 
       const msg = raw.message;
       const toolCalls: any[] = msg?.tool_calls ?? [];

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -119,7 +119,10 @@ function asArgs(raw: unknown): Record<string, unknown> {
 export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
   const numCtx = opts.numCtx ?? 4096;
   const maxIters = opts.maxIters ?? 5;
-  const timeoutMs = Number.isFinite(opts.timeoutMs) ? (opts.timeoutMs as number) : 600000;
+  // Clamp to a sane (1s … 1h) window: rejects NaN/0/negative (→ default) and caps huge values that
+  // would overflow the 32-bit timer and abort instantly. Bad --timeout can't silently fail every model.
+  const reqMs = Number(opts.timeoutMs);
+  const timeoutMs = Number.isFinite(reqMs) && reqMs > 0 ? Math.min(reqMs, 3_600_000) : 600000;
   let totalDurNs = 0;
   let evalDurNs = 0;
 

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -36,6 +36,8 @@ export interface McpTestOptions {
   verifyAllow?: string[];
   /** mcp__<name>__<tool> label the verifier registers the server under. */
   verifyServerName?: string;
+  /** Per-model Ollama response timeout (ms). Default 600000 (10 min). */
+  timeoutMs?: number;
   output?: string;
 }
 
@@ -52,6 +54,10 @@ interface McpModelResult {
   tool_results: { name: string; isError: boolean }[];
   final_answer_preview: string;
   error?: string;
+  /** Ollama generation perf for this model. */
+  out_tokens: number;
+  total_duration_s: number;
+  eval_tps: number;
   check: { overall_pass: boolean; simple: McpSimpleVerdict; agent: Judgment | null };
 }
 
@@ -108,7 +114,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
 
   for (const model of opts.models) {
     process.stderr.write(`--- ${model} ---\n`);
-    const traj = await runMcpHost({ host: opts.host, model, prompt: opts.prompt, server: opts.server, numCtx: opts.numCtx });
+    const traj = await runMcpHost({ host: opts.host, model, prompt: opts.prompt, server: opts.server, numCtx: opts.numCtx, timeoutMs: opts.timeoutMs });
     trajByModel.set(model, traj);
     const simple = simpleMcpCheck(traj);
     results.push({
@@ -119,9 +125,12 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
       tool_results: traj.toolResults.map((r) => ({ name: r.name, isError: r.isError })),
       final_answer_preview: traj.finalAnswer.slice(0, 200),
       error: traj.error,
+      out_tokens: traj.outTokens,
+      total_duration_s: traj.totalDurationS,
+      eval_tps: traj.evalTps,
       check: { overall_pass: simple.pass, simple, agent: null },
     });
-    process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass}\n`);
+    process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass} · ${traj.outTokens} tok @ ${traj.evalTps} tok/s in ${traj.totalDurationS}s\n`);
   }
 
   // Agent-level check, only for models that passed the structural check. Two modes:
@@ -228,8 +237,8 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   out.push('');
 
   // Scannable table — judge stages + cross-check, no raw JSON in the cells.
-  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check |');
-  out.push('|---|---|---|---|---|');
+  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Out tok | tok/s |');
+  out.push('|---|---|---|---|---|--:|--:|--:|');
   for (const r of results) {
     const verdict = r.check.overall_pass ? '✅ PASS' : r.supported ? '❌ FAIL' : '⚪ NO TOOL SUPPORT';
     const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
@@ -237,7 +246,7 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
     const stages = s ? `${tick(s.tool)} · ${tick(s.query)} · ${tick(s.content)}` : '—';
     const cc = r.check.agent?.crossCheckUnsupported;
     const cross = cc === undefined ? '—' : cc.length ? `❌ ${cc.join(', ').slice(0, 60)}` : '✅ grounded';
-    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} |`);
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} |`);
   }
 
   // Per-model detail (reasoning + raw evidence) tucked behind a toggle — proof without the clutter.

--- a/docs/stories/STORY-012.md
+++ b/docs/stories/STORY-012.md
@@ -1,0 +1,49 @@
+# STORY-012: The MCP test climbs the capability ladder — real tool use, not just the trivial rung
+
+## User Story
+
+As a maintainer of ollama37's MCP capability test,
+I want test cases that exercise harder tool use — starting with a tool that takes arguments,
+So that the verifier's three-stage rubric actually does work, instead of rubber-stamping the easiest possible case.
+
+## The Need
+
+The MCP test only ever drives one read-only, **no-argument** tool (`list_projects`). We just built
+a verifier that grades three stages — tool selection, query, interpretation — but against a single
+no-arg tool two of those stages are no-ops: there is only one tool to "select", and "query" is
+meaningless when the tool takes no arguments. So a trustworthy judge is rubber-stamping the
+trivial rung.
+
+To actually know a model can drive tools — and to know the verifier catches a model that drives
+them *badly* — the test has to climb the ladder. The first real rung is a tool that takes
+arguments: the model must supply the right ones to get the right result, and the verifier's
+"query" stage genuinely passes or fails on whether it did. Higher rungs (choosing the right tool
+among many, create-then-verify write chains, multi-step where one result drives the next call)
+come later; this story is about taking the first real step off the trivial case.
+
+## Success Looks Like
+
+- At least one test case drives a tool that **takes arguments** against the real server.
+- The model has to supply the **correct arguments** to get the right result — a no-arg call won't do.
+- The verifier's **query stage genuinely passes/fails** on whether the model queried correctly — no
+  longer an automatic pass.
+- A model that picks the right tool but calls it with **wrong or invented arguments** is caught: the
+  verdict reflects the query failure, not just whether the final answer happened to look right.
+- The harder case runs the same way as today's — locally and on the self-hosted CI runner, keyless,
+  read-only.
+
+## Open Questions
+
+- Which testlink tool to use for the first arguments case (e.g. a get-by-id or a filtered query) —
+  decided when the work is planned.
+- Whether to add cases by writing more runner code, or by introducing **declarative test-case
+  definitions** (the "MCP YAML" idea) so new rungs can be added without editing the runner.
+- The higher rungs — multi-tool selection, CRUD write-chains (which need a write-safe strategy),
+  recursive multi-step — sequenced after this first arguments rung.
+- How to keep any write-path cases read-only-by-default and safe, given the verifier's exact
+  allow-list.
+
+## Status
+
+- Created: 2026-06-19
+- Issues: none


### PR DESCRIPTION
Fixes #316.

## Why
The Ollama `/api/chat` call had **no explicit timeout** → undici's implicit ~5-min default. The K80 is slow enough that even `gemma4:e4b` takes **~288 s @ 2 tok/s** (near the cliff), and `gemma4:26b` blew past it → `fetch failed`, no verdict. And the report showed no perf, so you couldn't tell a slow model from a broken one.

## What
- **Adjustable timeout:** `chat()` uses `AbortSignal.timeout(timeoutMs)`; default **600000 (10 min, doubled)**, set via `--timeout <seconds>` and a `timeout` workflow input. NaN-guarded.
- **Perf in the report:** capture Ollama's `eval_count` / `total_duration` / `eval_duration` (summed across chat↔tool rounds) → new **Time (s) · Out tok · tok/s** columns + a stderr line + the JSON artifact.

## Validation
- Perf columns populate: `gemma4:e4b → 288.44 s, 140 tok, 2.11 tok/s`.
- `--timeout 1` aborts cleanly in ~1 s (`"operation aborted due to timeout"` → FAIL), no 5-min hang.
- Build clean; code-review fix (NaN guard) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)