### PR TITLE
Multi-server MCP host — Playwright distractor for tool selection

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -14,14 +14,14 @@ on:
         default: "List the projects."
         type: string
       num_ctx:
-        description: "Context window size"
+        description: "Context window size (8192 fits a merged multi-server tool menu; one server fits in 4096)"
         required: false
-        default: "4096"
+        default: "8192"
         type: string
       timeout:
-        description: "Per-model Ollama response timeout (seconds) — heavy models on the K80 need more"
+        description: "Per-call Ollama response timeout (seconds) — a multi-server menu on the K80 takes ~18 min/round; a single server is far faster"
         required: false
-        default: "600"
+        default: "1800"
         type: string
       judge_mode:
         description: "Verification mode (simple = structural check; dual = also run the keyless agent judge for groundedness; verify-live = the keyless verifier calls the server's read-only tools itself and checks the answer against LIVE data)"
@@ -51,6 +51,16 @@ on:
         description: "Args for the MCP server (space-separated)"
         required: false
         default: "run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest"
+        type: string
+      distractor_command:
+        description: "Optional second (menu-only) MCP server command, e.g. npx for Playwright — its tools become distractors the model must NOT pick (the verifier never touches it). Leave empty for one server."
+        required: false
+        default: ""
+        type: string
+      distractor_args:
+        description: "Args for the distractor MCP server, e.g. @playwright/mcp@latest"
+        required: false
+        default: ""
         type: string
 
 env:
@@ -112,11 +122,13 @@ jobs:
           # shellcheck disable=SC2086 -- intentional word splitting on models + flag
           npx tsx src/cli.ts test-mcp $MODELS \
             --prompt "${{ inputs.prompt || 'List the projects.' }}" \
-            --num-ctx "${{ inputs.num_ctx || '4096' }}" \
-            --timeout "${{ inputs.timeout || '600' }}" \
+            --num-ctx "${{ inputs.num_ctx || '8192' }}" \
+            --timeout "${{ inputs.timeout || '1800' }}" \
             --mcp-command "${{ inputs.mcp_command || 'docker' }}" \
             --mcp-args "${{ inputs.mcp_args || 'run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest' }}" \
             --mcp-env "TESTLINK_URL,TESTLINK_API_KEY" \
+            --distractor-command "${{ inputs.distractor_command }}" \
+            --distractor-args "${{ inputs.distractor_args }}" \
             --output /tmp/mcp-results.json \
             $JUDGE_FLAG | tee -a "$GITHUB_STEP_SUMMARY"
 

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -300,16 +300,18 @@ program
   .description("Test whether models can drive a real MCP server's tools")
   .argument('<models...>', 'One or more model names to test')
   .option('--prompt <text>', 'Prompt that should trigger a tool call', CONFIG.mcp.prompt)
-  .option('-c, --num-ctx <n>', 'Context window size', '4096')
+  .option('-c, --num-ctx <n>', 'Context window size (8192 fits a merged multi-server tool menu; one server fits in 4096)', '8192')
   .option('--judge', 'Also run the agent judge on the final answer (dual mode)', false)
   .option('-H, --host <url>', 'Ollama host', process.env.OLLAMA_HOST || 'http://localhost:11434')
   .option('--mcp-command <cmd>', 'Command to launch the stdio MCP server', CONFIG.mcp.command)
   .option('--mcp-args <args>', 'Args for the MCP server (space-separated; no spaces within a single arg)', CONFIG.mcp.args.join(' '))
   .option('--mcp-env <names>', 'Comma-separated env var names to forward to the server as creds (overrides MCP_ENV)', '')
+  .option('--distractor-command <cmd>', 'Optional second (menu-only) MCP server, e.g. playwright — its tools join the menu as distractors the model must NOT pick; the verifier never touches it')
+  .option('--distractor-args <args>', 'Args for the distractor MCP server (space-separated; no spaces within a single arg)', '')
   .option('--verify-live', 'Verify the answer against LIVE truth: the judge calls the server\'s read-only tools itself (supersedes --judge)', false)
   .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (fail-closed: empty verifies nothing)', '')
-  .option('--verify-server-name <name>', 'mcp__<name>__<tool> label the verifier registers the server under', 'mcp')
-  .option('--timeout <seconds>', 'Per-model Ollama response timeout (heavy models need more)', '600')
+  .option('--verify-server-name <name>', 'Name of the server the verifier spawns (the primary server is registered under this name); its tools are mcp__<name>__<tool>', 'mcp')
+  .option('--timeout <seconds>', 'Per-call Ollama response timeout (a multi-server menu on the K80 takes ~18 min/round; a single server is far faster)', '1800')
   .option('-o, --output <file>', 'Write the JSON report to this file')
   .action(async (models: string[], options) => {
     const code = await runMcpTest({
@@ -322,12 +324,24 @@ program
       verifyAllow: options.verifyAllow ? String(options.verifyAllow).split(',').map((s: string) => s.trim()).filter(Boolean) : undefined,
       verifyServerName: options.verifyServerName,
       host: options.host,
-      server: {
-        command: options.mcpCommand,
-        args: String(options.mcpArgs).split(' ').filter(Boolean),
-        cwd: CONFIG.mcp.cwd,
-        env: options.mcpEnv ? pickEnv(options.mcpEnv) : CONFIG.mcp.env,
-      },
+      // Primary server (the verifier's read-only target) is named after --verify-server-name
+      // so the verifier can find it. An optional distractor server joins the model's menu only.
+      servers: [
+        {
+          name: options.verifyServerName,
+          command: options.mcpCommand,
+          args: String(options.mcpArgs).split(' ').filter(Boolean),
+          cwd: CONFIG.mcp.cwd,
+          env: options.mcpEnv ? pickEnv(options.mcpEnv) : CONFIG.mcp.env,
+        },
+        ...(options.distractorCommand
+          ? [{
+              name: 'distractor',
+              command: options.distractorCommand,
+              args: String(options.distractorArgs).split(' ').filter(Boolean),
+            }]
+          : []),
+      ],
       output: options.output,
     });
     await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -111,6 +111,9 @@ async function chat(host: string, model: string, messages: unknown[], tools: unk
       (res) => {
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(c));
+        // The response is a separate emitter from req — a reset mid-body (a real risk on a
+        // slow/OOMing K80 backend) errors here, not on req. Without this it's an uncaught throw.
+        res.on('error', reject);
         res.on('end', () => {
           try {
             resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -13,11 +13,16 @@
  * the catch-returns-FAIL shape in perf/fa.ts). The server choice + its
  * credentials are config, not code.
  */
+import http from 'node:http';
+import https from 'node:https';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 
 /** How to spawn the stdio MCP server. testlink-mcp is just one such config. */
 export interface McpServerConfig {
+  /** Identifies the server when several share one menu — e.g. the verifier picks
+   *  its read-only server by this name. Defaults to 'mcp' when unset. */
+  name?: string;
   command: string;
   args: string[];
   cwd?: string;
@@ -31,7 +36,10 @@ export interface McpHostOptions {
   host: string;
   model: string;
   prompt: string;
-  server: McpServerConfig;
+  /** One or more stdio MCP servers whose tools are merged into a single menu the
+   *  model picks from. Two+ servers make "tool selection" a real choice (the model
+   *  must reach for the right one); a tool call routes back to its owning server. */
+  servers: McpServerConfig[];
   numCtx?: number;
   /** Max chat↔tool rounds before giving up (guards against a tool loop). */
   maxIters?: number;
@@ -55,10 +63,13 @@ export interface McpTrajectory {
   model: string;
   /** false ⇢ the model's template can't do tools (Ollama rejected `tools`). */
   supported: boolean;
-  /** Tool names the MCP server exposed. */
+  /** Tool names the MCP server(s) exposed (merged across servers). */
   toolNames: string[];
   /** Required arg names per tool, from each tool's inputSchema.required. */
   toolRequired: Record<string, string[]>;
+  /** Which server each tool came from (toolName → server name) — lets a caller
+   *  pick out one server's tools (e.g. the verifier's read-only server). */
+  toolServer: Record<string, string>;
   toolCalls: ToolCallRecord[];
   toolResults: ToolResultRecord[];
   finalAnswer: string;
@@ -85,14 +96,37 @@ export function mcpToOllamaTools(tools: Array<{ name: string; description?: stri
   }));
 }
 
+/** POST /api/chat over node:http so the per-call timeout is honored end-to-end.
+ *  fetch() (undici) imposes its own ~300s headers/body timeout that AbortSignal
+ *  can't lift — it silently kills slow K80 generations at 5 min. node:http has no
+ *  such cap, so timeoutMs (via AbortSignal) is the only deadline. */
 async function chat(host: string, model: string, messages: unknown[], tools: unknown[], numCtx: number, timeoutMs: number): Promise<any> {
-  const res = await fetch(`${host}/api/chat`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ model, messages, tools, stream: false, options: { temperature: 0, seed: 42, num_ctx: numCtx } }),
-    signal: AbortSignal.timeout(timeoutMs),
+  const body = JSON.stringify({ model, messages, tools, stream: false, options: { temperature: 0, seed: 42, num_ctx: numCtx } });
+  const url = new URL(`${host}/api/chat`);
+  const transport = url.protocol === 'https:' ? https : http;
+  return new Promise((resolve, reject) => {
+    const req = transport.request(
+      url,
+      { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) } },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch {
+            reject(new Error('ollama /api/chat: invalid JSON response'));
+          }
+        });
+      },
+    );
+    const signal = AbortSignal.timeout(timeoutMs);
+    const onAbort = () => req.destroy(new Error(`ollama /api/chat timed out after ${timeoutMs}ms`));
+    signal.addEventListener('abort', onAbort, { once: true });
+    req.on('close', () => signal.removeEventListener('abort', onAbort));
+    req.on('error', reject);
+    req.end(body);
   });
-  return res.json();
 }
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
@@ -129,19 +163,26 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
   let totalDurNs = 0;
   let evalDurNs = 0;
 
-  const transport = new StdioClientTransport({
-    command: opts.server.command,
-    args: opts.server.args,
-    cwd: opts.server.cwd,
-    env: { ...getDefaultEnvironment(), ...(opts.server.env ?? {}) },
-  });
-  const client = new Client({ name: 'ollama37-mcp-host', version: '1.0.0' });
+  // One client per server; their tools are merged into a single menu, and a tool
+  // call routes back to the server that owns the name (toolToClient).
+  const clients = opts.servers.map((s) => ({
+    name: s.name ?? 'mcp',
+    client: new Client({ name: 'ollama37-mcp-host', version: '1.0.0' }),
+    transport: new StdioClientTransport({
+      command: s.command,
+      args: s.args,
+      cwd: s.cwd,
+      env: { ...getDefaultEnvironment(), ...(s.env ?? {}) },
+    }),
+  }));
+  const toolToClient = new Map<string, Client>();
 
   const traj: McpTrajectory = {
     model: opts.model,
     supported: true,
     toolNames: [],
     toolRequired: {},
+    toolServer: {},
     toolCalls: [],
     toolResults: [],
     finalAnswer: '',
@@ -155,14 +196,25 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
   const messages: any[] = [{ role: 'user', content: opts.prompt }];
 
   try {
-    await client.connect(transport);
-    const listed = await client.listTools();
-    traj.toolNames = listed.tools.map((t) => t.name);
-    for (const t of listed.tools) {
-      const req = (t.inputSchema as any)?.required;
-      traj.toolRequired[t.name] = Array.isArray(req) ? req : [];
+    // Connect every server, list its tools, and merge into one menu. A tool name
+    // exposed by two servers can't be routed unambiguously — fail fast rather than
+    // silently send the call to the wrong one.
+    const merged: Array<{ name: string; description?: string; inputSchema?: unknown }> = [];
+    for (const { name: serverName, client, transport } of clients) {
+      await client.connect(transport);
+      const listed = await client.listTools();
+      for (const t of listed.tools) {
+        if (toolToClient.has(t.name)) {
+          throw new Error(`tool name collision: "${t.name}" exposed by "${traj.toolServer[t.name]}" and "${serverName}"`);
+        }
+        toolToClient.set(t.name, client);
+        traj.toolServer[t.name] = serverName;
+        traj.toolRequired[t.name] = Array.isArray((t.inputSchema as any)?.required) ? (t.inputSchema as any).required : [];
+        merged.push(t);
+      }
     }
-    const tools = mcpToOllamaTools(listed.tools);
+    traj.toolNames = merged.map((t) => t.name);
+    const tools = mcpToOllamaTools(merged);
 
     for (let i = 0; i < maxIters; i++) {
       const raw = await chat(opts.host, opts.model, messages, tools, numCtx, timeoutMs);
@@ -205,13 +257,19 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
         // the verdict under test, so capture it and feed it back, don't crash.
         let content: string;
         let isError: boolean;
-        try {
-          const result: any = await client.callTool({ name, arguments: args });
-          content = resultText(result?.content);
-          isError = Boolean(result?.isError);
-        } catch (e) {
-          content = `tool call failed: ${e instanceof Error ? e.message : String(e)}`;
+        const owner = toolToClient.get(name);
+        if (!owner) {
+          content = `tool call failed: unknown tool "${name}"`;
           isError = true;
+        } else {
+          try {
+            const result: any = await owner.callTool({ name, arguments: args });
+            content = resultText(result?.content);
+            isError = Boolean(result?.isError);
+          } catch (e) {
+            content = `tool call failed: ${e instanceof Error ? e.message : String(e)}`;
+            isError = true;
+          }
         }
         traj.toolResults.push({ name, content, isError });
         messages.push({ role: 'tool', content, tool_name: name });
@@ -227,6 +285,6 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     traj.error = e instanceof Error ? e.message : String(e);
     return traj;
   } finally {
-    await client.close().catch(() => {});
+    for (const { client } of clients) await client.close().catch(() => {});
   }
 }

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -64,6 +64,9 @@ export interface McpTrajectory {
   finalAnswer: string;
   /** Ollama generation perf, summed across the chat↔tool rounds. */
   inTokens: number;
+  /** Largest single round's prompt tokens — the value Ollama checks against num_ctx
+   *  (the summed inTokens spans rounds and can't be compared to the window). */
+  maxPromptTokens: number;
   outTokens: number;
   totalDurationS: number;
   evalTps: number;
@@ -143,6 +146,7 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
     toolResults: [],
     finalAnswer: '',
     inTokens: 0,
+    maxPromptTokens: 0,
     outTokens: 0,
     totalDurationS: 0,
     evalTps: 0,
@@ -175,6 +179,7 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
       }
       // Accumulate generation perf across the rounds (Ollama durations are ns).
       traj.inTokens += raw.prompt_eval_count ?? 0;
+      traj.maxPromptTokens = Math.max(traj.maxPromptTokens, raw.prompt_eval_count ?? 0);
       traj.outTokens += raw.eval_count ?? 0;
       totalDurNs += raw.total_duration ?? 0;
       evalDurNs += raw.eval_duration ?? 0;

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -24,7 +24,9 @@ const JUDGE_CRITERIA =
 export interface McpTestOptions {
   models: string[];
   prompt: string;
-  server: McpServerConfig;
+  /** Servers whose tools are merged into one menu for the model. With more than one,
+   *  picking the right tool is a real choice — extra servers act as distractors. */
+  servers: McpServerConfig[];
   host: string;
   numCtx: number;
   judge: boolean;
@@ -34,7 +36,9 @@ export interface McpTestOptions {
   /** Exact tool names the verifier may call. Fail-closed: if empty/unset, the verifier
    *  verifies nothing — pass an explicit allow-list (no prefix heuristic across servers). */
   verifyAllow?: string[];
-  /** mcp__<name>__<tool> label the verifier registers the server under. */
+  /** Selects WHICH server the verifier spawns (by McpServerConfig.name) and the
+   *  mcp__<name>__<tool> label it registers it under — the verifier only ever sees
+   *  this one server, so distractor servers stay out of its reach. */
   verifyServerName?: string;
   /** Per-model Ollama response timeout (ms). Default 600000 (10 min). */
   timeoutMs?: number;
@@ -116,7 +120,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
 
   for (const model of opts.models) {
     process.stderr.write(`--- ${model} ---\n`);
-    const traj = await runMcpHost({ host: opts.host, model, prompt: opts.prompt, server: opts.server, numCtx: opts.numCtx, timeoutMs: opts.timeoutMs });
+    const traj = await runMcpHost({ host: opts.host, model, prompt: opts.prompt, servers: opts.servers, numCtx: opts.numCtx, timeoutMs: opts.timeoutMs });
     trajByModel.set(model, traj);
     const simple = simpleMcpCheck(traj);
     results.push({
@@ -153,30 +157,45 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
   };
 
   if (eligible.length > 0 && opts.verifyLive) {
-    // Full server tool list (same server for every model) → the verifier's allow/deny.
-    // Fail-closed: only an explicit --verify-allow opens tools. No prefix heuristic —
-    // it can't tell a read-only `get_x` from a destructive `get_and_purge` on an
-    // arbitrary server, and the verifier's contract is exact-name allow-listing.
-    const allToolNames = Array.from(new Set(eligible.flatMap((r) => r.tool_names)));
+    // The verifier spawns ONLY its named server (read-only, fail-closed); distractor
+    // servers on the model's menu never reach it. Hand it that server's tools only —
+    // filtered by which server each came from — so its deny-list doesn't sprout bogus
+    // rules for tools it can't even see. Fail-closed: only --verify-allow opens tools.
+    const verifyServerName = opts.verifyServerName ?? 'mcp';
+    const verifyServer = opts.servers.find((s) => (s.name ?? 'mcp') === verifyServerName);
+    const toolServer = trajByModel.get(eligible[0].model)?.toolServer ?? {};
+    const verifyToolNames = Array.from(new Set(eligible.flatMap((r) => r.tool_names))).filter((n) => toolServer[n] === verifyServerName);
     const allowTools = opts.verifyAllow ?? [];
-    const verifier = new VerifierJudge(
-      { server: opts.server, serverName: opts.verifyServerName ?? 'mcp', toolNames: allToolNames, allowTools },
-      '',
-    );
-    if (await verifier.isAvailable()) {
-      applyVerdicts(
-        await verifier.verify(eligible.map((r) => ({ testId: r.model, prompt: opts.prompt, answer: trajByModel.get(r.model)!.finalAnswer, toolCalls: r.tool_calls }))),
-      );
-    } else {
-      // Fail closed: a verify-live run whose verifier can't even start has NOT verified anything,
-      // so it must not green-light on the structural check alone. Mark every eligible model FAIL.
-      process.stderr.write('[ERROR] verify-live requested but the verifier agent is unavailable (auth/availability) — failing closed\n');
+    if (!verifyServer) {
+      // Misconfigured: verify-live asked, but no server matches the name. Don't fall back
+      // to some other server (could be a distractor) — fail closed.
+      process.stderr.write(`[ERROR] verify-live: no configured server named "${verifyServerName}" — failing closed\n`);
       applyVerdicts(eligible.map((r) => ({
         testId: r.model,
         pass: false,
-        reason: 'verify-live could not run: verifier agent unavailable (auth/availability)',
+        reason: `verify-live could not run: no server named "${verifyServerName}"`,
         evidenceStatus: 'verifier-unavailable' as const,
       })));
+    } else {
+      const verifier = new VerifierJudge(
+        { server: verifyServer, serverName: verifyServerName, toolNames: verifyToolNames, allowTools },
+        '',
+      );
+      if (await verifier.isAvailable()) {
+        applyVerdicts(
+          await verifier.verify(eligible.map((r) => ({ testId: r.model, prompt: opts.prompt, answer: trajByModel.get(r.model)!.finalAnswer, toolCalls: r.tool_calls }))),
+        );
+      } else {
+        // Fail closed: a verify-live run whose verifier can't even start has NOT verified anything,
+        // so it must not green-light on the structural check alone. Mark every eligible model FAIL.
+        process.stderr.write('[ERROR] verify-live requested but the verifier agent is unavailable (auth/availability) — failing closed\n');
+        applyVerdicts(eligible.map((r) => ({
+          testId: r.model,
+          pass: false,
+          reason: 'verify-live could not run: verifier agent unavailable (auth/availability)',
+          evidenceStatus: 'verifier-unavailable' as const,
+        })));
+      }
     }
   } else if (eligible.length > 0 && opts.judge) {
     const agentJudge = new AgentJudge();
@@ -196,7 +215,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
     writeFileSync(
       opts.output,
       JSON.stringify(
-        { timestamp: new Date().toISOString(), server: { command: opts.server.command, args: opts.server.args }, prompt: opts.prompt, judge: judgeLabel(opts), results: full },
+        { timestamp: new Date().toISOString(), servers: opts.servers.map((s) => ({ name: s.name ?? 'mcp', command: s.command, args: s.args })), prompt: opts.prompt, judge: judgeLabel(opts), results: full },
         null,
         2
       )
@@ -239,7 +258,8 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   const icon = failed > 0 ? '❌' : passed > 0 ? '✅' : '⚪';
   out.push(`## 🧪 MCP tool-call test — ${icon} ${passed} passed · ${failed} failed`);
   out.push('');
-  out.push(`**Server:** \`${opts.server.command} ${opts.server.args.join(' ')}\``);
+  const serverLabel = opts.servers.map((s) => `\`${s.command} ${s.args.join(' ')}\``).join(' + ');
+  out.push(`**Server${opts.servers.length > 1 ? 's' : ''}:** ${serverLabel}`);
   out.push(`**Prompt:** ${opts.prompt} · **Judge:** ${judgeLabel(opts)}${sha ? ` · **Commit:** \`${sha}\`` : ''}`);
   out.push('');
 

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -56,6 +56,8 @@ interface McpModelResult {
   error?: string;
   /** Ollama generation perf for this model. */
   out_tokens: number;
+  /** Largest single round's prompt tokens — compare to num_ctx for truncation headroom. */
+  max_prompt_tokens: number;
   total_duration_s: number;
   eval_tps: number;
   check: { overall_pass: boolean; simple: McpSimpleVerdict; agent: Judgment | null };
@@ -126,6 +128,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
       final_answer_preview: traj.finalAnswer.slice(0, 200),
       error: traj.error,
       out_tokens: traj.outTokens,
+      max_prompt_tokens: traj.maxPromptTokens,
       total_duration_s: traj.totalDurationS,
       eval_tps: traj.evalTps,
       check: { overall_pass: simple.pass, simple, agent: null },
@@ -217,6 +220,10 @@ function evidenceWhy(status: Judgment['evidenceStatus']): string {
 }
 
 const tick = (b: boolean): string => (b ? '✅' : '❌');
+/** Peak single-round prompt tokens vs the context window — ⚠️ within 10% of num_ctx
+ *  (Ollama silently truncates a prompt that crosses it). */
+const peakCtx = (peak: number, numCtx: number): string =>
+  peak > 0 ? `${peak > numCtx * 0.9 ? '⚠️ ' : ''}${peak}/${numCtx}` : '—';
 const judgeLabel = (opts: McpTestOptions): string => (opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple');
 /** Escape so model/server-controlled text can't break out of the Markdown/<details>/code block. */
 const mdSafe = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -237,8 +244,8 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   out.push('');
 
   // Scannable table — judge stages + cross-check, no raw JSON in the cells.
-  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Out tok | tok/s |');
-  out.push('|---|---|---|---|---|--:|--:|--:|');
+  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Peak in/ctx | Out tok | tok/s |');
+  out.push('|---|---|---|---|---|--:|--:|--:|--:|');
   for (const r of results) {
     const verdict = r.check.overall_pass ? '✅ PASS' : r.supported ? '❌ FAIL' : '⚪ NO TOOL SUPPORT';
     const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
@@ -246,7 +253,7 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
     const stages = s ? `${tick(s.tool)} · ${tick(s.query)} · ${tick(s.content)}` : '—';
     const cc = r.check.agent?.crossCheckUnsupported;
     const cross = cc === undefined ? '—' : cc.length ? `❌ ${cc.join(', ').slice(0, 60)}` : '✅ grounded';
-    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} |`);
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${peakCtx(r.max_prompt_tokens, opts.numCtx)} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} |`);
   }
 
   // Per-model detail (reasoning + raw evidence) tucked behind a toggle — proof without the clutter.

--- a/docs/stories/STORY-012.md
+++ b/docs/stories/STORY-012.md
@@ -48,3 +48,4 @@ come later; this story is about taking the first real step off the trivial case.
 - Created: 2026-06-19
 - Plan: #318
 - Issues: #320, #321, #322, #324
+- PRs: #325 (open) — multi-server host / Playwright distractor (#324)

--- a/docs/stories/STORY-012.md
+++ b/docs/stories/STORY-012.md
@@ -47,4 +47,4 @@ come later; this story is about taking the first real step off the trivial case.
 
 - Created: 2026-06-19
 - Plan: #318
-- Issues: #320, #321, #322
+- Issues: #320, #321, #322, #324

--- a/docs/tests/TS-05-mcp.md
+++ b/docs/tests/TS-05-mcp.md
@@ -21,6 +21,7 @@ logical flow.
 - **Objective:** the model calls the right tool against the live server and produces a grounded answer.
 - **Script:** `cli.ts test-mcp <tool-capable-model> --judge` (default server: testlink-mcp)
 - **Preconditions:** Ollama up with the model pulled; testlink-mcp reachable with `TESTLINK_URL` / `TESTLINK_API_KEY`. Locally these are read from `cicd/tests/.env` (copy `cicd/tests/.env.example`); in CI they come from the matching GitHub secrets.
+- **Multi-server menu (optional):** add `--distractor-command <cmd> --distractor-args <args>` (e.g. `--distractor-command npx --distractor-args "@playwright/mcp@latest"`) to merge a second server's tools into the menu as distractors. The objective, ground truth, and the verifier's testlink-only allow-list are unchanged — but `tool_selection` must now **reject** the distractor tools and still pick `list_projects`. A correct run never calls a distractor tool, so the distractor server never does any work. The merged testlink+Playwright menu is ~50 tools (~6.8k prompt tokens), so use `--num-ctx 8192` to avoid truncation and a generous `--timeout` — on the K80 a correct run takes ~18 min (verified: `list_projects` chosen, distractors ignored, PASS).
 
 | # | Action | Expected Result |
 |---|--------|-----------------|
@@ -69,6 +70,7 @@ logical flow.
 - **Objective:** the model must pick the right tool *and* supply a **derived** argument, so the verifier's **query** stage does real work — unlike the no-argument `list_projects`, where "queried correctly" is a no-op. The model is asked by project *name* and must resolve it to the id itself.
 - **Script:** `cli.ts test-mcp <tool-capable-model> --prompt "List the test suites in the ollama37 project." --verify-live --verify-allow list_projects,list_test_suites --verify-server-name testlink`
 - **Preconditions:** as TC-04, plus the testlink `ollama37` project has test suites (Build/Inference/Runtime/Models Tests). Chained tool use is slow on the K80 (~8 min end-to-end); use a generous `--timeout`.
+- **Multi-server menu (optional):** as TC-01, add `--distractor-command/--distractor-args` to make `tool_selection` harder — the model must reject the distractor tools *and* still derive the `project_id`. Both the selection and query stages then do real work. The merged menu enlarges every prompt, so watch the `Peak in/ctx` report column against `--num-ctx`.
 
 | # | Action | Expected Result |
 |---|--------|-----------------|

--- a/docs/traces/mcp-multiserver-model-comparison.md
+++ b/docs/traces/mcp-multiserver-model-comparison.md
@@ -1,0 +1,52 @@
+# Multi-server MCP test — model comparison (50-tool menu)
+
+Records the first end-to-end runs of the multi-server MCP capability test (issue #324,
+[STORY-012](../stories/STORY-012.md)): the model is given a **merged menu of two servers**
+and must pick the right tool, ignoring the other server's tools as distractors.
+
+## Setup
+
+- **Servers merged into one menu:** `testlink-mcp` (27 tools, via Docker) + `@playwright/mcp`
+  (23 browser tools, via npx) = **50 tools**.
+- **Prompt:** `List the projects.` — the correct answer uses testlink's `list_projects`; the 23
+  Playwright tools are distractors the model must **not** pick.
+- **Mode:** simple (structural check — did it call a real tool, succeed, and answer?). Not yet
+  verify-live (the three-stage rubric).
+- **Context:** `--num-ctx 8192`. **Timeout:** 1800s (30 min) ceiling. **Hardware:** Tesla K80.
+- Date: 2026-06-20.
+
+## Results
+
+| Model | Verdict | Tool called | Peak in/ctx | Time | tok/s |
+|---|---|---|--:|--:|--:|
+| **gpt-oss:20b** | ✅ PASS | `list_projects` | **3783/8192** | **94.7s (1.6 min)** | **11.36** |
+| qwen3.5:9b | ✅ PASS | `list_projects` | ⚠️ 7518/8192 | 186.9s (3.1 min) | 6.89 |
+| gemma4:e4b | ✅ PASS | `list_projects` | 6796/8192 | 1104s (18.4 min) | 1.13 |
+
+All three correctly picked `list_projects` and **ignored all 23 Playwright distractors** — the
+multi-server tool-selection capability works across models. A correct run never calls a browser
+tool, so Playwright never launches Chromium.
+
+## Findings
+
+1. **Prompt token size is tokenizer/template-dependent for the *same* menu** — gpt-oss renders the
+   50-tool menu in **3783** tokens, gemma4 in **6796**, qwen3.5 in **7518**. A ~2× spread for
+   identical content.
+2. **gpt-oss:20b is the best fit** — fastest (1.6 min, 11.36 tok/s) *and* the most context-efficient
+   (54% headroom). No near-limit warning.
+3. **qwen3.5:9b runs near the 8k ceiling already on the simple case** (⚠️ 7518/8192, ~8% headroom).
+   It works well here (GPU 100%, ~70 °C — healthy), but a **chained case** (TC-05, which appends
+   `list_projects` *and* `list_test_suites` results to the history) would very likely cross 8192 and
+   truncate. The `Peak in/ctx` column flagged this with ⚠️.
+4. **gemma4:e4b is slow** (vision-model overhead, 1.13 tok/s → 18.4 min). It's why the per-call
+   timeout has to be generous; faster models finish in 1–3 min and never approach the ceiling.
+
+## Recommendations
+
+- **Default model for the multi-server scenario:** `gpt-oss:20b` (fast + efficient). CI currently
+  defaults to `gemma4:e4b`.
+- **For the next-level chained cases** (distractors + a derived-argument chain): raise context to
+  **12288 or 16384**, especially for qwen3.5-class models whose simple-case prompt already sits near
+  8k. gpt-oss has the headroom to stay at 8k.
+- **Timeout:** 1800s (30 min) ceiling is fine — it only bounds the slow gemma4 path; fast models
+  return in seconds-to-minutes well under it.


### PR DESCRIPTION
## Summary
- `runMcpHost` now drives a **list** of MCP servers — connects each, merges their tools into one menu, routes each call to its owning server, throws on a tool-name collision, and closes all clients. The model must pick the right toolbox, so the verifier's `tool_selection` stage finally does real work.
- New CLI flags `--distractor-command/--distractor-args` add a **menu-only** server (e.g. Playwright). The read-only verifier spawns **only** its `--verify-server-name` server, so distractors never reach it.
- **Timeout made honest**: `/api/chat` moved from `fetch` to `node:http`. `fetch` (undici) imposes a hidden ~300s headers/body timeout that `AbortSignal` can't lift — it silently killed slow K80 generations at exactly 5 min. `node:http` has no such cap, so `--timeout` is the only deadline (+ `res.on('error')` so a mid-body reset rejects cleanly instead of crashing).
- Defaults sized for the merged menu: `num_ctx 8192` (the ~50-tool prompt peaks ~6.8k tokens — 4096 truncated it) and per-call `--timeout 1800` (a correct run takes ~18 min on the K80). A new `Peak in/ctx` report column flags ⚠️ near the context limit.

Verified end-to-end on the self-hosted K80 across three tool-capable models (gpt-oss:20b, qwen3.5:9b, gemma4:e4b): each merged testlink (27 tools) + Playwright (23 tools) into a 50-tool menu, **chose `list_projects` and ignored all 23 browser distractors**, PASS, no truncation, no Chromium launched. See `docs/traces/mcp-multiserver-model-comparison.md`.

Fixes #324
Part of STORY-012

## Test plan
- [ ] CI `test-mcp.yml` on the self-hosted K80: `judge_mode=verify-live`, `distractor_command=npx`, `distractor_args=@playwright/mcp@latest`, `verify_allow=list_projects`, `verify_server_name=testlink` → PASS, report renders, verifier touches only testlink
- [ ] Single-server (first level) unchanged: omit the distractor flags → one server, fast PASS
- [ ] `cd cicd/tests && npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)