### PR TITLE
Recover a brace-short verifier response instead of FAILing it

### DIFF
--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -435,9 +435,27 @@ export class VerifierJudge {
 
   private extractJson(text: string): string | null {
     const start = text.indexOf('{');
-    const end = text.lastIndexOf('}');
-    if (start === -1 || end === -1 || end < start) return null;
-    return text.substring(start, end + 1);
+    if (start === -1) return null;
+    // Scan from the first '{' tracking string state to find the matching close. The
+    // ACP agent sometimes ends a turn one token short of its trailing '}' (or the final
+    // streamed chunk isn't captured), so a complete-but-unclosed object would otherwise
+    // be discarded — flipping a genuine verdict to a "No JSON" FAIL. Tolerate that by
+    // appending the missing closers, but only when the truncation is OUTSIDE a string
+    // (a value cut mid-string is genuinely unrecoverable → null).
+    let depth = 0;
+    let inStr = false;
+    let esc = false;
+    for (let i = start; i < text.length; i++) {
+      const c = text[i];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (c === '\\') esc = true;
+        else if (c === '"') inStr = false;
+      } else if (c === '"') inStr = true;
+      else if (c === '{') depth++;
+      else if (c === '}' && --depth === 0) return text.substring(start, i + 1);
+    }
+    return depth > 0 && !inStr ? text.substring(start) + '}'.repeat(depth) : null;
   }
 
   private async promptAgent(prompt: string): Promise<string> {


### PR DESCRIPTION
## Summary
- `verify-live`'s ACP agent sometimes ends its turn one token short of the trailing `}` (or the final streamed chunk isn't captured). The old `extractJson` used `indexOf('{')`/`lastIndexOf('}')` and discarded such a response as `No JSON in verifier response` — flipping a genuine PASS (all three rubric stages true, grounded reason) to **FAIL**.
- Replace it with a **string-aware brace walk** from the first `{`: return the balanced object when it closes; when truncated *outside* a string, append the missing closers so it parses; a response cut mid-string stays unrecoverable (`null`).

**Observed:** CI run 27865294894 (gpt-oss:20b, verify-live, multi-server menu) — verifier returned `pass:"true"` but a 454-char response with no `}` → false FAIL. The shape is non-deterministic (a re-run produced a complete fenced response and PASSed), so verify-live was a coin-flip from a false FAIL on any run.

Validated: the exact 454-char failing response now recovers to `pass=true`, braces inside string values don't miscount, and a mid-string truncation still returns `null` (7 cases). CI re-run on this branch (27865608868) is green: `✅ PASS · ✅·✅·✅ · ✅ grounded`.

Fixes #326

## Test plan
- [ ] `cd cicd/tests && npx tsc --noEmit` clean
- [ ] verify-live CI (gpt-oss:20b, distractor=playwright) green with the verdict intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)