### PR TITLE
Add MCP capability matrix report form (template, example, README)

### DIFF
--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,83 @@
+# `docs/reports/` — the MCP capability matrix
+
+A structured record of MCP capability-test results: each model run against each test on the
+multi-server menu, captured as a **model × test matrix** with per-cell verdict, three-stage
+rubric, context headroom, and perf. One run = one report (a snapshot).
+
+## Files
+
+| File | What it is |
+|---|---|
+| [`TEMPLATE.md`](./TEMPLATE.md) | The blank form. Copy it to start a new report. |
+| [`mcp-capability-matrix-2026-06-20.md`](./mcp-capability-matrix-2026-06-20.md) | A worked example, filled with real data. |
+| `README.md` | This file — the format and how to produce it. |
+
+New reports are dated snapshots: `mcp-capability-matrix-YYYY-MM-DD.md`.
+
+## Why a matrix
+
+The single-run report (`cli.ts test-mcp` stdout) covers one prompt across models. The matrix adds
+the **test** dimension — the capability ladder rungs — so you can see, per model, both:
+
+- **T1 — list projects:** the model picks the right tool from the merged menu (tool selection).
+- **T2 — list suites (derived arg):** the model must *derive* `project_id` from a name, so the
+  **query** stage does real work — the failure T1 can't catch.
+
+Reading the grid model-first answers "how capable is this model"; reading a column answers "which
+models clear this rung".
+
+## How to produce a report
+
+Run each test on the distractor menu with `--output`, then fill `TEMPLATE.md` from the JSON. From
+`cicd/tests/`:
+
+```bash
+# T1 — list projects
+npx tsx src/cli.ts test-mcp <models> \
+  --verify-live --verify-allow list_projects --verify-server-name testlink \
+  --distractor-command npx --distractor-args "@playwright/mcp@latest" \
+  --prompt "List the projects." --output t1.json
+
+# T2 — list suites (derived arg)
+npx tsx src/cli.ts test-mcp <models> \
+  --verify-live --verify-allow list_projects,list_test_suites --verify-server-name testlink \
+  --distractor-command npx --distractor-args "@playwright/mcp@latest" \
+  --prompt "List the test suites in the ollama37 project." --output t2.json
+```
+
+`num_ctx` (8192) and `timeout` (1800s) default to the multi-server values; raise `--num-ctx` to
+12288–16384 for the chained T2 case on models that already sit near 8k on T1.
+
+## Field map (JSON → cell)
+
+Each `results[]` entry in the `--output` JSON (`McpModelResult` / `Judgment` in
+`cicd/tests/src/mcp/test-mcp.ts`) fills one cell:
+
+| Column | JSON field |
+|---|---|
+| verdict | `check.overall_pass` → ✅/❌; `supported === false` → ⚪ |
+| stages (tool·query·content) | `check.agent.stages.{tool,query,content}` (verify-live/dual only; else `—`) |
+| cross-check | `check.agent.crossCheckUnsupported` (empty → grounded) |
+| peak/ctx | `max_prompt_tokens` / the run's `num_ctx` (⚠️ when >90%, ✂️ when ==) |
+| time | `total_duration_s` |
+| tok/s | `eval_tps` |
+| tools | `tool_calls[].name` |
+| detail: reason / evidence | `check.agent.reason` / `check.agent.evidence` (+ `evidenceStatus`) |
+
+## Markers
+
+| Mark | Meaning |
+|---|---|
+| ✅ | pass |
+| ❌ | fail |
+| ⚪ | no tool support (model template can't do tools — not a harness failure) |
+| ⚠️ | peak prompt > 90% of `num_ctx` (near truncation) |
+| ✂️ | truncated (peak == `num_ctx` — the menu didn't fit) |
+| ⏳ | not run |
+| — | not graded (e.g. simple mode has no rubric stages) |
+
+## Future
+
+A small `merge-mcp-tests t1.json:T1 t2.json:T2` aggregator would read the per-test JSONs and emit
+the matrix automatically (markdown + a machine-readable twin). Not built yet — reports are filled
+from the template by hand for now.

--- a/docs/reports/TEMPLATE.md
+++ b/docs/reports/TEMPLATE.md
@@ -1,0 +1,50 @@
+<!-- MCP capability matrix — blank form. Copy to docs/reports/mcp-capability-matrix-YYYY-MM-DD.md
+     and fill the {{placeholders}} from the test-mcp JSON output. See README.md for the field map
+     and the commands that produce the data. Snapshot form: one run = one report. -->
+
+## 🧪 MCP capability matrix — {{✅|❌|⚪}} {{N}} passed · {{M}} failed
+
+**Commit:** `{{sha}}` · **Date:** {{YYYY-MM-DD}} · **Judge:** {{verify-live | dual | simple}}
+**Menu:** `{{server-a}} + {{server-b}}` · **num_ctx:** {{8192}} · **timeout:** {{1800}}s
+
+### Tests
+- **T1 — list projects:** `{{prompt}}` · allow `{{list_projects}}`
+- **T2 — list suites (derived arg):** `{{prompt}}` · allow `{{list_projects, list_test_suites}}`
+
+## Matrix
+
+<!-- One row per model. cell = verdict · stages(tool·query·content) · peak/ctx · time · tok/s · tools
+     markers: ✅ pass · ❌ fail · ⚪ no-tool-support · ⚠️ peak >90% num_ctx · ✂️ truncated (peak==ctx) · ⏳ not run · — not graded -->
+
+| Model | T1 — list projects | T2 — list suites (derived) |
+|---|---|---|
+| `{{model}}` | {{✅}} · {{✅·✅·✅}} · {{peak/ctx}} · {{time}}s · {{tps}} | {{⏳ not run}} |
+
+## Detail
+
+<!-- One <details> per model; nest its T1 and T2 inside. -->
+
+<details><summary>{{model}}</summary>
+
+**T1 — list projects — {{verdict}}**
+- **Reason:** {{the verifier's own reason}}
+- **Tool calls:** {{list_projects}}
+- **Live evidence:**
+<pre>{{captured live data — secrets must be [redacted]}}</pre>
+
+**T2 — list suites — {{verdict}}**
+- **Reason:** {{…}}
+- **Tool calls:** {{list_projects → list_test_suites(project_id="1")}}
+- **Live evidence:**
+<pre>{{…}}</pre>
+
+</details>
+
+## Notes / flags
+
+<!-- Pull the cells that need eyes up here; omit a bullet when it doesn't apply. -->
+
+- ⚠️ **Near context limit:** {{model · test · peak/ctx}}
+- ✂️ **Truncation:** {{model · test — the menu didn't fit num_ctx}}
+- ⚪ **No tool support:** {{model}}
+- **Provenance / caveats:** {{which cells are verify-live vs simple; what's pending}}

--- a/docs/reports/mcp-capability-matrix-2026-06-20.md
+++ b/docs/reports/mcp-capability-matrix-2026-06-20.md
@@ -1,0 +1,68 @@
+<!-- A worked example of the MCP capability matrix (see TEMPLATE.md + README.md). Filled with real
+     data from this date's runs; T2 (derived-arg) was not run on the multi-server menu, so its cells
+     are honestly marked ⏳ not run rather than invented. -->
+
+## 🧪 MCP capability matrix — ✅ 3 passed · 0 failed · ⏳ 3 not run
+
+**Commit:** `79e1e5b6` · **Date:** 2026-06-20 · **Judge:** mixed — verify-live + simple (see provenance)
+**Menu:** `testlink + playwright` · **num_ctx:** 8192 · **timeout:** 1800s
+
+### Tests
+- **T1 — list projects:** `List the projects.` · allow `list_projects`
+- **T2 — list suites (derived arg):** `List the test suites in the ollama37 project.` · allow `list_projects, list_test_suites`
+
+## Matrix
+
+<!-- cell = verdict · stages(tool·query·content) · peak/ctx · time · tok/s · tools
+     markers: ✅ pass · ❌ fail · ⚪ no-tool-support · ⚠️ peak >90% num_ctx · ✂️ truncated · ⏳ not run · — not graded -->
+
+| Model | T1 — list projects | T2 — list suites (derived) |
+|---|---|---|
+| `gpt-oss:20b` | ✅ · ✅·✅·✅ · 3783/8192 · 96.4s · 11.7 · `list_projects` | ⏳ not run |
+| `qwen3.5:9b` | ✅ · — (simple) · ⚠️ 7518/8192 · 186.9s · 6.9 · `list_projects` | ⏳ not run |
+| `gemma4:e4b` | ✅ · — (simple) · 6796/8192 · 1104s · 1.1 · `list_projects` | ⏳ not run |
+
+## Detail
+
+<details><summary>gpt-oss:20b</summary>
+
+**T1 — list projects — ✅ PASS** (verify-live, all three stages, cross-check grounded)
+- **Reason:** Called list_projects myself; ground truth shows exactly two projects: id 1 'ollama37' (prefix ollama37, tc_counter 33, active, is_public) and id 162 'testlink-mcp' (prefix tm, tc_counter 32, active, is_public). The model called the correct single tool with no arguments, and every fact in its table matches the retrieved data.
+- **Tool calls:** `list_projects` (ignored all 23 Playwright distractors)
+- **Live evidence:**
+<pre>[
+  { "id": "1",   "prefix": "ollama37", "tc_counter": "33", "is_public": "1",
+    "api_key": "[redacted]", "name": "ollama37" },
+  { "id": "162", "prefix": "tm",       "tc_counter": "32", "is_public": "1",
+    "api_key": "[redacted]", "name": "testlink-mcp" }
+]</pre>
+
+**T2 — list suites — ⏳ not run**
+
+</details>
+
+<details><summary>qwen3.5:9b</summary>
+
+**T1 — list projects — ✅ PASS** (simple mode — structural check only, stages not graded)
+- **Tool calls:** `list_projects` (ignored all 23 Playwright distractors)
+- **Note:** peak prompt 7518/8192 — ⚠️ within 10% of the window.
+
+**T2 — list suites — ⏳ not run**
+
+</details>
+
+<details><summary>gemma4:e4b</summary>
+
+**T1 — list projects — ✅ PASS** (simple mode — structural check only, stages not graded)
+- **Tool calls:** `list_projects` (ignored all 23 Playwright distractors)
+- **Note:** vision model — slow on the K80 (1.1 tok/s → 1104s).
+
+**T2 — list suites — ⏳ not run**
+
+</details>
+
+## Notes / flags
+
+- ⚠️ **Near context limit:** `qwen3.5:9b` · T1 · 7518/8192 (~92% of num_ctx). It tokenizes the 50-tool menu larger than the others (gpt-oss 3783, gemma4 6796), so **T2 — which appends tool results to the prompt — would likely truncate at 8k**. Chained cases want `num_ctx` 12k–16k for qwen3.5-class models.
+- ⏳ **T2 pending:** the derived-arg case hasn't been run on the multi-server menu yet (issue #321 territory — proving the query stage catches a wrong/guessed `project_id`).
+- **Provenance:** `gpt-oss:20b` T1 is the **verify-live** CI run 27865608868 (full three-stage rubric + live evidence). `qwen3.5:9b` and `gemma4:e4b` T1 are local **simple-mode** runs (structural check; no stages graded — see `docs/traces/mcp-multiserver-model-comparison.md`). A fully verify-live matrix would re-run all three.


### PR DESCRIPTION
## Summary
Standardize how MCP capability-test results are recorded — a **model × test matrix** (T1 list-projects, T2 list-suites/derived-arg) on the multi-server menu, with per-cell verdict, three-stage rubric, peak/ctx, and perf. Docs only; no runner code.

- `docs/reports/TEMPLATE.md` — the blank form (one snapshot per run).
- `docs/reports/mcp-capability-matrix-2026-06-20.md` — worked example from this session's real runs (gpt-oss T1 verify-live; qwen3.5/gemma4 T1 simple; T2 ⏳ not run — no invented data).
- `docs/reports/README.md` — format, the `test-mcp --output` commands that produce the data, a JSON→cell field map, and the marker legend.

A future `merge-mcp-tests` aggregator (to auto-generate the matrix from the per-test JSONs) is noted as future work, not built. Reviewed with `reviewing-artifacts` — all PASS.

No linked issue — documentation scaffolding.

## Test plan
- [ ] All three files render (tables aligned, `<details>`/`<pre>` balanced)
- [ ] Cross-references resolve (README ↔ template ↔ example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)