### PR TITLE
Unload each model between runs so only one is resident

### DIFF
--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -132,6 +132,23 @@ async function chat(host: string, model: string, messages: unknown[], tools: unk
   });
 }
 
+/** Evict a model from Ollama (keep_alive: 0). Best-effort: a benchmark loops over models
+ *  sequentially, so each must be released before the next loads — otherwise Ollama's default
+ *  keep-alive leaves the previous one resident and two models contend for the GPU (skewing
+ *  timings, risking OOM). A failed unload must never fail the test. */
+export async function unloadModel(host: string, model: string): Promise<void> {
+  try {
+    await fetch(`${host}/api/generate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model, keep_alive: 0 }),
+      signal: AbortSignal.timeout(30000),
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 const tps = (tokens: number, durNs: number): number => (durNs > 0 ? round2(tokens / (durNs / 1e9)) : 0);
 

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -12,7 +12,7 @@
  * with --output, a JSON report. Exit code is non-zero if any model fails.
  */
 import { writeFileSync } from 'node:fs';
-import { runMcpHost, type McpServerConfig, type McpTrajectory } from './host.js';
+import { runMcpHost, unloadModel, type McpServerConfig, type McpTrajectory } from './host.js';
 import { AgentJudge, VerifierJudge } from '../judge/index.js';
 import { TestResult, Judgment } from '../types.js';
 
@@ -138,6 +138,8 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
       check: { overall_pass: simple.pass, simple, agent: null },
     });
     process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass} · ${traj.outTokens} tok @ ${traj.evalTps} tok/s in ${traj.totalDurationS}s\n`);
+    // Release this model before the next loads, so only one is ever resident (no GPU contention).
+    await unloadModel(opts.host, model);
   }
 
   // Agent-level check, only for models that passed the structural check. Two modes:


### PR DESCRIPTION
## Summary
`test-mcp` loops over models sequentially but never released a model after its run, so Ollama's default 5-min keep-alive kept the previous one resident while the next loaded — **two model runners in VRAM at once** (observed: ollama37 log `loaded runners count=2`), contending for the GPU and skewing every timing number.

- `host.ts`: best-effort `unloadModel(host, model)` helper — `POST /api/generate` with `keep_alive: 0`, 30s bound, swallows errors (a failed unload must never fail the test).
- `test-mcp.ts`: call it at the end of each loop iteration, so the test isolates itself **one model at a time** without forcing `OLLAMA_MAX_LOADED_MODELS=1` on the shared server.

**Verified on the K80** (qwen3:4b → ministral-3:3b): the container log shows the unload firing *between* models — `/api/generate` (unload) at 13:15:19, then model #2 loads at 13:15:21 — so the count never reaches 2. Both models PASS, clean timings, `tsc` clean. GPU peaked 62°C.

Fixes #329

## Test plan
- [ ] Multi-model run: container log holds `loaded runners count=1` (never 2)
- [ ] A failed unload (e.g. Ollama momentarily down) does not fail the test
- [ ] `cd cicd/tests && npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)