### PR TITLE
[STORY-013] GPU temperature guard — abort every K80 run at 80 °C

### DIFF
--- a/.github/workflows/test-fa-k80.yml
+++ b/.github/workflows/test-fa-k80.yml
@@ -159,7 +159,7 @@ jobs:
 
           # The subcommand emits the benchmark + judge markdown tables on stdout
           # (→ step summary) and writes the JSON report to --output.
-          npx tsx src/cli.ts test-fa "${ARGS[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts test-fa "${ARGS[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Restart production ollama37
         if: always()

--- a/.github/workflows/test-inference.yml
+++ b/.github/workflows/test-inference.yml
@@ -80,7 +80,9 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite inference $ID_FLAG --format json > /tmp/inference-results.json || true
+          rc=0
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts run --suite inference $ID_FLAG --format json > /tmp/inference-results.json || rc=$?
+          [ "$rc" -eq 75 ] && exit 1   # overheat → fail the job; any other non-zero stays tolerated (gated by the JSON below)
 
           echo "--- JSON Results ---"
           cat /tmp/inference-results.json

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -120,7 +120,7 @@ jobs:
           # The subcommand prints a markdown summary to stdout (→ step summary)
           # and writes the JSON report to --output. Exit code gates the job.
           # shellcheck disable=SC2086 -- intentional word splitting on models + flag
-          npx tsx src/cli.ts test-mcp $MODELS \
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts test-mcp $MODELS \
             --prompt "${{ inputs.prompt || 'List the projects.' }}" \
             --num-ctx "${{ inputs.num_ctx || '8192' }}" \
             --timeout "${{ inputs.timeout || '1800' }}" \

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -78,7 +78,9 @@ jobs:
           fi
 
           # Run models tests
-          npx tsx src/cli.ts run --suite models $ID_FLAG --format json > /tmp/models-results.json || true
+          rc=0
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts run --suite models $ID_FLAG --format json > /tmp/models-results.json || rc=$?
+          [ "$rc" -eq 75 ] && exit 1   # overheat → fail the job; any other non-zero stays tolerated (gated by the JSON below)
 
           echo "--- JSON Results ---"
           cat /tmp/models-results.json

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -59,7 +59,9 @@ jobs:
             echo "Running single test: ${{ inputs.test_id }}"
           fi
 
-          npx tsx src/cli.ts run --suite runtime $ID_FLAG --format json > /tmp/runtime-results.json || true
+          rc=0
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts run --suite runtime $ID_FLAG --format json > /tmp/runtime-results.json || rc=$?
+          [ "$rc" -eq 75 ] && exit 1   # overheat → fail the job; any other non-zero stays tolerated (gated by the JSON below)
 
           echo "--- JSON Results ---"
           cat /tmp/runtime-results.json

--- a/.github/workflows/test-throughput.yml
+++ b/.github/workflows/test-throughput.yml
@@ -77,7 +77,7 @@ jobs:
           # The subcommand prints a markdown summary to stdout (→ step summary)
           # and writes the JSON report to --output. Exit code gates the job.
           # shellcheck disable=SC2086 -- intentional word splitting on models + flag
-          npx tsx src/cli.ts bench-throughput $MODELS \
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts bench-throughput $MODELS \
             --num-predict "${{ inputs.num_predict || '128' }}" \
             --context "${{ inputs.context_size || '2048' }}" \
             --output /tmp/throughput-results.json \

--- a/cicd/scripts/gpu-temp-guard.sh
+++ b/cicd/scripts/gpu-temp-guard.sh
@@ -15,6 +15,8 @@
 set -u
 
 OVERHEAT_RC=75
+MAX_UNREADABLE=3        # consecutive unreadable polls -> abort (a hung driver / GPU off the bus is
+                        # exactly what an overheat causes; blindly continuing defeats the guard)
 threshold="${GPU_TEMP_LIMIT:-80}"
 interval="${GPU_TEMP_INTERVAL:-10}"
 
@@ -24,8 +26,8 @@ usage() {
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --threshold) threshold="$2"; shift 2 ;;
-        --interval)  interval="$2";  shift 2 ;;
+        --threshold) [ $# -ge 2 ] || { echo "gpu-temp-guard: --threshold needs a value" >&2; usage; exit 2; }; threshold="$2"; shift 2 ;;
+        --interval)  [ $# -ge 2 ] || { echo "gpu-temp-guard: --interval needs a value"  >&2; usage; exit 2; }; interval="$2";  shift 2 ;;
         --) shift; break ;;
         -h|--help) usage; exit 0 ;;
         *) echo "gpu-temp-guard: unknown option '$1'" >&2; usage; exit 2 ;;
@@ -61,27 +63,47 @@ cmd_pid=$!
 set +m
 
 peak=0
-overheat=0
+had_reading=0
+unreadable=0
+abort_reason=""
 while kill -0 "$cmd_pid" 2>/dev/null; do
     t="$(max_temp)"
+    t="${t%%.*}"                       # tolerate a decimal reading, e.g. "82.0" -> "82"
     if [[ "$t" =~ ^[0-9]+$ ]]; then
+        had_reading=1
+        unreadable=0
         [ "$t" -gt "$peak" ] && peak="$t"
         if [ "$t" -gt "$threshold" ]; then
-            overheat=1
-            kill -TERM -"$cmd_pid" 2>/dev/null   # negative pid = the whole process group
-            sleep 2
-            kill -KILL -"$cmd_pid" 2>/dev/null
+            abort_reason="OVERHEAT - peak ${peak}°C exceeded ${threshold}°C"
+            break
+        fi
+    else
+        # nvidia-smi gave no usable reading. A few in a row (a hung driver / GPU off the
+        # bus) means we can't verify safety, so fail closed rather than run blind.
+        unreadable=$((unreadable + 1))
+        if [ "$unreadable" -ge "$MAX_UNREADABLE" ]; then
+            abort_reason="temperature UNREADABLE for ${unreadable} polls (nvidia-smi failing) - cannot verify"
             break
         fi
     fi
     sleep "$interval"
 done
+
+if [ -n "$abort_reason" ]; then
+    kill -TERM -"$cmd_pid" 2>/dev/null     # negative pid = the whole process group
+    sleep 2
+    kill -KILL -"$cmd_pid" 2>/dev/null
+fi
 wait "$cmd_pid" 2>/dev/null
 cmd_rc=$?
 
-if [ "$overheat" -eq 1 ]; then
-    note "🌡️ GPU OVERHEAT - peak ${peak}°C exceeded ${threshold}°C; run aborted"
+if [ -n "$abort_reason" ]; then
+    note "🌡️ GPU GUARD ABORT - ${abort_reason}; run killed"
     exit "$OVERHEAT_RC"
 fi
-note "🌡️ Peak GPU temp: ${peak}°C (limit ${threshold}°C)"
+if [ "$had_reading" -eq 0 ]; then
+    note "🌡️ Peak GPU temp: unknown (nvidia-smi returned no valid reading)"
+else
+    note "🌡️ Peak GPU temp: ${peak}°C (limit ${threshold}°C)"
+fi
 exit "$cmd_rc"

--- a/cicd/scripts/gpu-temp-guard.sh
+++ b/cicd/scripts/gpu-temp-guard.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# gpu-temp-guard.sh - run a command under a K80 GPU temperature guard.
+#
+# Runs <command>, polling nvidia-smi for the hottest GPU die. If it crosses the
+# threshold, the command (and its whole process group) is killed and the script
+# exits 75 - a distinct "overheat" code the caller can act on. Otherwise it exits
+# with the command's own code. Either way the peak temperature is appended to
+# $GITHUB_STEP_SUMMARY (and stderr), so every run records how hot it got.
+#
+# Usage: gpu-temp-guard.sh [--threshold N] [--interval S] -- <command> [args...]
+#
+# Knobs (flags override env):
+#   --threshold / GPU_TEMP_LIMIT     hard abort, °C   (default 80)
+#   --interval  / GPU_TEMP_INTERVAL  poll period, s   (default 10)
+set -u
+
+OVERHEAT_RC=75
+threshold="${GPU_TEMP_LIMIT:-80}"
+interval="${GPU_TEMP_INTERVAL:-10}"
+
+usage() {
+    echo "Usage: $0 [--threshold N] [--interval S] -- <command> [args...]" >&2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --threshold) threshold="$2"; shift 2 ;;
+        --interval)  interval="$2";  shift 2 ;;
+        --) shift; break ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "gpu-temp-guard: unknown option '$1'" >&2; usage; exit 2 ;;
+    esac
+done
+if [ $# -eq 0 ]; then
+    echo "gpu-temp-guard: no command given" >&2; usage; exit 2
+fi
+
+# Record a line in the step summary (CI) and on stderr (always visible). stdout is
+# left untouched so the wrapped command's `| tee` / `> file.json` redirects are clean.
+note() {
+    echo "$1" >&2
+    [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$1" >> "$GITHUB_STEP_SUMMARY"
+    return 0
+}
+
+# No NVIDIA tooling (e.g. a dev box without a card): run unguarded rather than fail.
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+    echo "gpu-temp-guard: nvidia-smi not found - running WITHOUT a temperature guard" >&2
+    "$@"
+    exit $?
+fi
+
+max_temp() {
+    nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits 2>/dev/null \
+        | sort -rn | head -1
+}
+
+set -m                  # job control: the background job gets its own process group
+"$@" &
+cmd_pid=$!
+set +m
+
+peak=0
+overheat=0
+while kill -0 "$cmd_pid" 2>/dev/null; do
+    t="$(max_temp)"
+    if [[ "$t" =~ ^[0-9]+$ ]]; then
+        [ "$t" -gt "$peak" ] && peak="$t"
+        if [ "$t" -gt "$threshold" ]; then
+            overheat=1
+            kill -TERM -"$cmd_pid" 2>/dev/null   # negative pid = the whole process group
+            sleep 2
+            kill -KILL -"$cmd_pid" 2>/dev/null
+            break
+        fi
+    fi
+    sleep "$interval"
+done
+wait "$cmd_pid" 2>/dev/null
+cmd_rc=$?
+
+if [ "$overheat" -eq 1 ]; then
+    note "🌡️ GPU OVERHEAT - peak ${peak}°C exceeded ${threshold}°C; run aborted"
+    exit "$OVERHEAT_RC"
+fi
+note "🌡️ Peak GPU temp: ${peak}°C (limit ${threshold}°C)"
+exit "$cmd_rc"

--- a/docs/stories/STORY-013.md
+++ b/docs/stories/STORY-013.md
@@ -1,0 +1,32 @@
+# STORY-013: Every K80 GPU run guards its own temperature and aborts before it overheats
+
+## User Story
+
+As a maintainer running model tests on the self-hosted K80,
+I want every workflow that loads a model to abort the moment a GPU die crosses 80 °C and to record the run's peak temperature,
+So that an overheating run is stopped automatically and the heat is attributable to the exact run that caused it — instead of relying on an anonymous local monitor or hardware throttling.
+
+## The Need
+
+The only temperature protection today is an ad-hoc `nvidia-smi` loop a human starts by hand alongside a run. It's anonymous — nothing ties the temperature to which CI run, commit, or person triggered the GPU load — and it isn't part of CI at all, so most runs have no guard whatsoever. When a run overheats, nothing stops it short of the K80's own hardware throttling, and afterward there's no record of how hot it got or which run did it. A maintainer should be able to trust that any model run on the K80 is temperature-guarded and self-documenting, without remembering to babysit it.
+
+## Success Looks Like
+
+- A GPU run whose temperature crosses the limit (80 °C) **fails the job** with a clear overheat error, rather than continuing to cook or depending on hardware throttling.
+- Every guarded run shows its **peak GPU temperature** in its own run record (the step summary), so the heat is attributable to that exact run.
+- The guard covers **all the Ollama-inference workflows** on the K80 (the MCP, throughput, flash-attention, inference, models, and runtime runs), applied consistently rather than copy-pasted into each.
+- The same guard works when a maintainer runs a model test **locally**, not only in CI.
+- A run that stays cool is unaffected — no change to its result, just a recorded peak.
+
+## Open Questions
+
+- The mechanism — a reusable wrapper script the workflows call, a composite GitHub action, or another shape — decided in planning.
+- Whether the threshold and sample interval should be knobs (and their defaults), and whether there's a separate "warn" band below the hard-abort line.
+- Exactly which workflows are in scope, and whether non-Ollama GPU work (e.g. MLX smoke) or build-only jobs should be guarded too.
+- How the abort is wired so the job fails cleanly mid-run (killing the model process, surviving the `| tee` to the step summary).
+
+## Status
+
+- Created: 2026-06-20
+- Plan: #331
+- Issues: #332, #333, #334


### PR DESCRIPTION
## Summary
Every Ollama-inference workflow on the K80 now runs under a temperature guard that **aborts the job if any GPU die crosses 80 °C** and records the run's **peak temp** in its own step summary — replacing the ad-hoc, anonymous local `nvidia-smi` loop.

- **`cicd/scripts/gpu-temp-guard.sh`** (`#332`) — wraps a command in its own process group, polls `nvidia-smi`, kills the whole tree + exits **75** on overheat (else the command's own code); always writes `Peak GPU temp: N°C`. Knobs default 80 °C / 10 s (`GPU_TEMP_LIMIT`/`GPU_TEMP_INTERVAL`). **Fails closed** if `nvidia-smi` can't be read (the driver-hang case an overheat causes), degrades to unguarded when there's no GPU at all.
- **Pattern A** (`#333`) — `test-mcp`, `test-throughput`, `test-fa-k80` wrap the runner; `pipefail` + `| tee` carry the 75.
- **Pattern B** (`#334`) — `test-inference`, `test-models`, `test-runtime` wrap it and replace `|| true` with `|| rc=$?` + `[ "$rc" -eq 75 ] && exit 1`, so an overheat fails while normal test-failures stay JSON-gated.

Fixes #332
Fixes #333
Fixes #334
Part of STORY-013

## Test plan
- [x] Script unit (local): flag-no-value → exit 2; cool → exit 0 + peak; `--threshold 1` → kills child → exit 75; fake `nvidia-smi` erroring → UNREADABLE abort exit 75; `82.0` parsed → 82; process-group kill leaves no orphan; shellcheck clean.
- [ ] CI (Pattern A): run `test-mcp.yml` with a fast model → `Peak GPU temp: N°C` in the summary, job passes.
- [ ] CI (Pattern B): run `test-inference.yml` → peak shown; a normal result still gated by the JSON (not masked / mis-failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)