### PR TITLE
Rebuild MCP capability matrix in long format with real campaign data

### DIFF
--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -23,8 +23,9 @@ the **test** dimension — the capability ladder rungs — so you can see, per m
 - **T2 — list suites (derived arg):** the model must *derive* `project_id` from a name, so the
   **query** stage does real work — the failure T1 can't catch.
 
-Reading the grid model-first answers "how capable is this model"; reading a column answers "which
-models clear this rung".
+The results table is one row per (model × test): reading a model's rows together answers "how
+capable is this model"; filtering to a test (e.g. all T2 rows) answers "which models clear this
+rung".
 
 ## How to produce a report
 

--- a/docs/reports/TEMPLATE.md
+++ b/docs/reports/TEMPLATE.md
@@ -1,42 +1,37 @@
-<!-- MCP capability matrix — blank form. Copy to docs/reports/mcp-capability-matrix-YYYY-MM-DD.md
-     and fill the {{placeholders}} from the test-mcp JSON output. See README.md for the field map
-     and the commands that produce the data. Snapshot form: one run = one report. -->
+<!-- MCP capability matrix — blank form. One row per (model × test). Copy to
+     docs/reports/mcp-capability-matrix-YYYY-MM-DD.md and fill the {{placeholders}}
+     from the test-mcp JSON output. See README.md for the field map and the commands
+     that produce the data. Snapshot form: one campaign = one report. -->
 
 ## 🧪 MCP capability matrix — {{✅|❌|⚪}} {{N}} passed · {{M}} failed
 
 **Commit:** `{{sha}}` · **Date:** {{YYYY-MM-DD}} · **Judge:** {{verify-live | dual | simple}}
-**Menu:** `{{server-a}} + {{server-b}}` · **num_ctx:** {{8192}} · **timeout:** {{1800}}s
+**Menu:** `{{server-a}} + {{server-b}}` · **num_ctx:** {{16384}} · **timeout:** {{3600}}s
 
 ### Tests
 - **T1 — list projects:** `{{prompt}}` · allow `{{list_projects}}`
 - **T2 — list suites (derived arg):** `{{prompt}}` · allow `{{list_projects, list_test_suites}}`
 
-## Matrix
+## Results
 
-<!-- One row per model. cell = verdict · stages(tool·query·content) · peak/ctx · time · tok/s · tools
-     markers: ✅ pass · ❌ fail · ⚪ no-tool-support · ⚠️ peak >90% num_ctx · ✂️ truncated (peak==ctx) · ⏳ not run · — not graded -->
+<!-- One row per (model × test). markers: ✅ pass · ❌ fail · ⚪ no-tool-support
+     · ⚠️ peak >90% num_ctx · ✂️ truncated (peak==ctx) · ⏳ not run · — not graded -->
 
-| Model | T1 — list projects | T2 — list suites (derived) |
-|---|---|---|
-| `{{model}}` | {{✅}} · {{✅·✅·✅}} · {{peak/ctx}} · {{time}}s · {{tps}} | {{⏳ not run}} |
+| Model | Test | Verdict | Stages (tool·query·content) | Cross-check | Peak/ctx | Time (s) | tok/s | Tool calls |
+|---|---|:--:|:--:|:--:|--:|--:|--:|---|
+| `{{model}}` | T1 projects | {{✅}} | {{✅·✅·✅}} | {{✅ grounded}} | {{peak/ctx}} | {{t}} | {{tps}} | {{list_projects}} |
+| `{{model}}` | T2 suites | {{❌}} | {{✅·✅·✅}} | {{❌ <claim>}} | {{peak/ctx}} | {{t}} | {{tps}} | {{list_projects, list_test_suites}} |
 
 ## Detail
 
-<!-- One <details> per model; nest its T1 and T2 inside. -->
+<!-- One <details> per model; T1 and T2 inside. -->
 
 <details><summary>{{model}}</summary>
 
-**T1 — list projects — {{verdict}}**
-- **Reason:** {{the verifier's own reason}}
-- **Tool calls:** {{list_projects}}
-- **Live evidence:**
-<pre>{{captured live data — secrets must be [redacted]}}</pre>
+- **T1 — {{verdict}}** — {{the verifier's reason}}. Tool calls: {{list_projects}}.
+- **T2 — {{verdict}}** — {{the verifier's reason}}. Tool calls: {{list_projects → list_test_suites(project_id)}}.
 
-**T2 — list suites — {{verdict}}**
-- **Reason:** {{…}}
-- **Tool calls:** {{list_projects → list_test_suites(project_id="1")}}
-- **Live evidence:**
-<pre>{{…}}</pre>
+<pre>{{captured live evidence — secrets must be [redacted]}}</pre>
 
 </details>
 
@@ -44,7 +39,6 @@
 
 <!-- Pull the cells that need eyes up here; omit a bullet when it doesn't apply. -->
 
-- ⚠️ **Near context limit:** {{model · test · peak/ctx}}
-- ✂️ **Truncation:** {{model · test — the menu didn't fit num_ctx}}
-- ⚪ **No tool support:** {{model}}
-- **Provenance / caveats:** {{which cells are verify-live vs simple; what's pending}}
+- ⚠️ **Near limit / ✂️ truncation:** {{model · test · peak/ctx}}
+- ❌ **Failures:** {{model · test — why (which stage / cross-check)}}
+- **Provenance / caveats:** {{CI run ids; which cells are verify-live vs simple; what's pending}}

--- a/docs/reports/mcp-capability-matrix-2026-06-20.md
+++ b/docs/reports/mcp-capability-matrix-2026-06-20.md
@@ -1,68 +1,54 @@
-<!-- A worked example of the MCP capability matrix (see TEMPLATE.md + README.md). Filled with real
-     data from this date's runs; T2 (derived-arg) was not run on the multi-server menu, so its cells
-     are honestly marked ⏳ not run rather than invented. -->
+<!-- A worked example of the MCP capability matrix (see TEMPLATE.md + README.md). Filled with
+     real data from two verify-live CI runs on the K80: T1 = run 27873966435, T2 = run 27874945352. -->
 
-## 🧪 MCP capability matrix — ✅ 3 passed · 0 failed · ⏳ 3 not run
+## 🧪 MCP capability matrix — ❌ 5 passed · 1 failed
 
-**Commit:** `79e1e5b6` · **Date:** 2026-06-20 · **Judge:** mixed — verify-live + simple (see provenance)
-**Menu:** `testlink + playwright` · **num_ctx:** 8192 · **timeout:** 1800s
+**Commit:** `9e04a7ed` · **Date:** 2026-06-20 · **Judge:** verify-live
+**Menu:** `testlink + playwright` · **num_ctx:** 16384 · **timeout:** 3600s
 
 ### Tests
 - **T1 — list projects:** `List the projects.` · allow `list_projects`
 - **T2 — list suites (derived arg):** `List the test suites in the ollama37 project.` · allow `list_projects, list_test_suites`
 
-## Matrix
+## Results
 
-<!-- cell = verdict · stages(tool·query·content) · peak/ctx · time · tok/s · tools
-     markers: ✅ pass · ❌ fail · ⚪ no-tool-support · ⚠️ peak >90% num_ctx · ✂️ truncated · ⏳ not run · — not graded -->
+<!-- markers: ✅ pass · ❌ fail · ⚪ no-tool-support · ⚠️ peak >90% num_ctx · ✂️ truncated · ⏳ not run · — not graded -->
 
-| Model | T1 — list projects | T2 — list suites (derived) |
-|---|---|---|
-| `gpt-oss:20b` | ✅ · ✅·✅·✅ · 3783/8192 · 96.4s · 11.7 · `list_projects` | ⏳ not run |
-| `qwen3.5:9b` | ✅ · — (simple) · ⚠️ 7518/8192 · 186.9s · 6.9 · `list_projects` | ⏳ not run |
-| `gemma4:e4b` | ✅ · — (simple) · 6796/8192 · 1104s · 1.1 · `list_projects` | ⏳ not run |
+| Model | Test | Verdict | Stages (tool·query·content) | Cross-check | Peak/ctx | Time (s) | tok/s | Tool calls |
+|---|---|:--:|:--:|:--:|--:|--:|--:|---|
+| `gpt-oss:20b` | T1 projects | ✅ | ✅·✅·✅ | ✅ grounded | 3783/16384 | 95.5 | 11.68 | list_projects |
+| `gpt-oss:20b` | T2 suites | ✅ | ✅·✅·✅ | ✅ grounded | 4038/16384 | 105.1 | 11.41 | list_projects, list_test_suites |
+| `qwen3.6:27b` | T1 projects | ✅ | ✅·✅·✅ | ✅ grounded | 7518/16384 | 665.0 | 2.33 | list_projects |
+| `qwen3.6:27b` | T2 suites | ❌ | ✅·✅·✅ | ❌ "top-level" | 7819/16384 | 979.9 | 2.33 | list_projects, list_test_suites |
+| `gemma4:26b` | T1 projects | ✅ | ✅·✅·✅ | ✅ grounded | 6796/16384 | 1485.9 | 1.18 | list_projects |
+| `gemma4:26b` | T2 suites | ✅ | ✅·✅·✅ | ✅ grounded | 7103/16384 | 1733.8 | 1.14 | list_projects, list_test_suites |
 
 ## Detail
 
 <details><summary>gpt-oss:20b</summary>
 
-**T1 — list projects — ✅ PASS** (verify-live, all three stages, cross-check grounded)
-- **Reason:** Called list_projects myself; ground truth shows exactly two projects: id 1 'ollama37' (prefix ollama37, tc_counter 33, active, is_public) and id 162 'testlink-mcp' (prefix tm, tc_counter 32, active, is_public). The model called the correct single tool with no arguments, and every fact in its table matches the retrieved data.
-- **Tool calls:** `list_projects` (ignored all 23 Playwright distractors)
-- **Live evidence:**
-<pre>[
-  { "id": "1",   "prefix": "ollama37", "tc_counter": "33", "is_public": "1",
-    "api_key": "[redacted]", "name": "ollama37" },
-  { "id": "162", "prefix": "tm",       "tc_counter": "32", "is_public": "1",
-    "api_key": "[redacted]", "name": "testlink-mcp" }
-]</pre>
-
-**T2 — list suites — ⏳ not run**
+- **T1 — ✅ PASS** — called `list_projects`, ignored the 23 Playwright distractors; answer matched the live two-project list.
+- **T2 — ✅ PASS** — drove the chain `list_projects` → `list_test_suites(project_id="1")`, deriving the id from the name; answer matched the real suites. Fast and most context-efficient.
 
 </details>
 
-<details><summary>qwen3.5:9b</summary>
+<details><summary>qwen3.6:27b</summary>
 
-**T1 — list projects — ✅ PASS** (simple mode — structural check only, stages not graded)
-- **Tool calls:** `list_projects` (ignored all 23 Playwright distractors)
-- **Note:** peak prompt 7518/8192 — ⚠️ within 10% of the window.
-
-**T2 — list suites — ⏳ not run**
+- **T1 — ✅ PASS** — correct `list_projects`, grounded.
+- **T2 — ❌ FAIL** — drove the chain correctly (the **query stage is ✅** — it derived `project_id` right), and the LLM judge marked all three stages ✅. But the **deterministic cross-check caught an unsupported `"top-level"` claim** in the answer that isn't in the live `list_test_suites` result, and overrode the PASS → FAIL. This is the STORY-011 trust mechanism working: a harness-side fact-check catching a confabulation the model judge waved through.
 
 </details>
 
-<details><summary>gemma4:e4b</summary>
+<details><summary>gemma4:26b</summary>
 
-**T1 — list projects — ✅ PASS** (simple mode — structural check only, stages not graded)
-- **Tool calls:** `list_projects` (ignored all 23 Playwright distractors)
-- **Note:** vision model — slow on the K80 (1.1 tok/s → 1104s).
-
-**T2 — list suites — ⏳ not run**
+- **T1 — ✅ PASS** — correct `list_projects`, grounded. Slow (vision model: 1.18 tok/s → 24.8 min).
+- **T2 — ✅ PASS** — drove the derived-argument chain correctly; answer matched the real suites. 28.9 min — inside the 3600s budget.
 
 </details>
 
 ## Notes / flags
 
-- ⚠️ **Near context limit:** `qwen3.5:9b` · T1 · 7518/8192 (~92% of num_ctx). It tokenizes the 50-tool menu larger than the others (gpt-oss 3783, gemma4 6796), so **T2 — which appends tool results to the prompt — would likely truncate at 8k**. Chained cases want `num_ctx` 12k–16k for qwen3.5-class models.
-- ⏳ **T2 pending:** the derived-arg case hasn't been run on the multi-server menu yet (issue #321 territory — proving the query stage catches a wrong/guessed `project_id`).
-- **Provenance:** `gpt-oss:20b` T1 is the **verify-live** CI run 27865608868 (full three-stage rubric + live evidence). `qwen3.5:9b` and `gemma4:e4b` T1 are local **simple-mode** runs (structural check; no stages graded — see `docs/traces/mcp-multiserver-model-comparison.md`). A fully verify-live matrix would re-run all three.
+- ❌ **Failure:** `qwen3.6:27b` · T2 — **not** a query-stage miss (it derived the id correctly); the **deterministic cross-check** rejected an unsupported `"top-level"` claim the LLM judge accepted. The matrix's value is exactly this: T1 can't catch it, and the cross-check catches what the judge model misses.
+- **Context:** no truncation — at 16384 the hottest cell is `qwen3.6:27b` T2 at **7819/16384** (48%). Note that at `num_ctx 8192` that prompt would sit at ⚠️ ~95% and the chained T2 could truncate — which is why this campaign used 16384 (qwen/gemma-family tokenizers render the 50-tool menu larger than gpt-oss).
+- **Speed:** gpt-oss:20b is far the fastest (1.6–1.8 min/test, 11+ tok/s); qwen3.6:27b ~11–16 min; gemma4:26b 25–29 min (vision overhead). gpt-oss is the best fit for routine runs.
+- **Provenance:** verify-live CI runs T1 = `27873966435`, T2 = `27874945352`; menu testlink + playwright; the temp guard was active (peak 67 °C T1, 69 °C T2 — both well under 80). Full per-model evidence is in each run's JSON artifact.


### PR DESCRIPTION
## Summary
Fixes the unreadable report table (six metrics crammed into one cell under a single test header) by switching to a **long** layout — one row per (model × test), one column per metric: Verdict · Stages (tool·query·content) · Cross-check · Peak/ctx · Time · tok/s · Tool calls. Essentially the live `printSummary` table plus a `Test` column, so a hand-filled report and a generated one match.

Fills the example with **real data from two verify-live CI runs** on the K80 (T1 = run 27873966435, T2 = run 27874945352): `gpt-oss:20b` / `qwen3.6:27b` / `gemma4:26b` × T1/T2, num_ctx 16384, timeout 3600. **5 passed, 1 failed** — `qwen3.6:27b` T2 is a genuine failure caught by the deterministic cross-check (an unsupported `"top-level"` claim the LLM judge accepted), which the report calls out as the matrix's whole point. Template + README updated to the long layout.

Docs only. Reviewed with `reviewing-typography` + `reviewing-phrasing` (both PASS).

## Test plan
- [x] All three files render (9-column table consistent, `<details>` balanced)
- [x] Numbers trace to the two CI runs; no invented data
- [x] Cross-references resolve (README ↔ template ↔ example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)