### PR TITLE
Remove K80 flash-attention special-case (~7× faster long context)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -14,21 +14,17 @@ OLLAMA_VERSION=2.0.1
 # Defaults are tuned for K80 hardware. Override here only if you know what
 # you're doing.
 
-# Flash attention. ON by default — gives a small speed bump (~3% tok/s) and
-# meaningful VRAM headroom (~13% on a 9B model) on K80.
-# Set to "0" to disable (useful for A/B debugging).
-# Note: if you disable FA, also set OLLAMA_KV_CACHE_TYPE=f16 below —
-# V-cache quantization requires flash attention, so q8_0 + FA off will
-# fail to load.
-# OLLAMA_FLASH_ATTENTION=0
+# Flash attention. On K80 (sm_37) FA is gated OFF — it's a net loss there
+# (~7x slower at long context; see #346), so the hardware gate disables it
+# regardless of this var. On cc>=7.0 cards (the widened build) the request is
+# honored and FA is on. Leaving this =1 is harmless on K80 (ignored).
+# OLLAMA_FLASH_ATTENTION=1
 
-# KV cache element type. Default "q8_0" cuts KV memory by ~47% with marginal
-# quality cost (chat/code unaffected; precision-sensitive workloads — math,
-# strict deterministic generation — may notice). Already higher precision
-# than the Q4 weights it's reading from.
-# Set to "f16" for full precision if you have VRAM to spare.
-# Set to "q4_0" only after KV rotation lands (see #102) — quality without
-# rotation degrades noticeably for q4_0 KV.
+# KV cache element type. Default "f16" on K80, because FA is off there and
+# V-cache quantization (q8_0) requires FA — so q8_0 won't load on the K80.
+# f16 costs ~2x the KV memory of q8_0; if a large model + long context doesn't
+# fit on a 12GB die, reduce num_ctx. q8_0/q4_0 are only usable on FA-capable
+# (cc>=7.0) cards.
 # OLLAMA_KV_CACHE_TYPE=f16
 
 # Verbose server logging.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,8 +18,11 @@ services:
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_DEBUG=${OLLAMA_DEBUG:-}
       # K80 perf defaults — see docker/.env.example to override.
+      # FA is gated off on K80 (sm_37) — it's a net loss there (see #346); the
+      # request is honored only on cc>=7.0 cards in the widened build. With FA
+      # off, q8_0 KV is unavailable (needs FA), so the default cache is f16.
       - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-1}
-      - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-q8_0}
+      - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     restart: unless-stopped

--- a/docs/stories/STORY-015.md
+++ b/docs/stories/STORY-015.md
@@ -1,0 +1,37 @@
+# STORY-015: K80 inference stops paying the flash-attention penalty
+
+## User Story
+
+As a maintainer running models on the Tesla K80,
+I want to remove the K80 flash-attention special-case so the K80 falls back to upstream's (FA-off) behavior,
+So that long-context and tool-calling runs aren't ~7× slower than they need to be on hardware where flash attention is a net loss.
+
+## The Need
+
+`ml/device.go` `FlashAttentionSupported()` carries a K80-specific clause that force-enables flash attention on compute 3.7. It was added in #108 (2026-04) to unlock the q8_0 KV cache (~47% KV memory saving) and was validated for **correctness** — bit-exact against the non-FA path on gemma3:4b. Its **speed** cost was never measured.
+
+A benchmark this session (#337) measured it on `gemma4:26b`: flash attention on the K80 is a **~7.4× slowdown at long context** (1.18 vs 8.74 tok/s decode on a 6,800-token prompt — a 25-minute tool-calling run drops to under 3 minutes) and ~29% slower on short prompts. On sm_37 (no tensor cores) the FA kernel is simply a net loss, and the special-case has been quietly imposing that cost on every K80 run.
+
+Removing the clause reverts the gate to pure upstream (`cc >= 7.0`, ≠ 7.2): K80 and Pascal get FA **off**, V100/T4/A100 get FA **on**. That is also exactly what the STORY-014 sync point (#345) is waiting for — STORY-014 deliberately leaves `ml/device.go` to this separate effort so the two don't collide.
+
+The cost is real and must be handled, not hidden: with FA off the q8_0 KV cache is no longer usable (V-cache quantization requires FA), so the K80 default cache must move to f16 — roughly **2× the KV memory**. KV rotation (#102) only benefits *quantized* KV, so on f16 it becomes a no-op carrying ~2–5% overhead.
+
+## Success Looks Like
+
+- K80 long-context decode runs at the ~7× faster non-FA speed — the FA penalty is gone for the workloads (tool-calling, long prompts) where it hurt most.
+- `FlashAttentionSupported()` is pure-upstream with no K80 special-case, so the gate is correct across the widened arch sweep — unblocking STORY-014 (#345).
+- The q8_0 → f16 VRAM tradeoff is **validated and documented** (does f16 still fit the largest supported models at long context?), not assumed — a maintainer knows what the change costs in memory before it ships.
+- A run that was correct before is still correct (FA-off output already validated in the #337 benchmark; no quality regression).
+
+## Open Questions
+
+- Whether to flip the docker default KV cache to f16 unconditionally for the K80 deployment, or gate it — the **VRAM-fit validation on the largest models at long context is the key risk** and decides this.
+- Whether and how to skip the now-pointless rotation on the f16 path (a ~2–5% optimization, possibly deferred to a follow-up).
+- Merge-order coordination with STORY-014 on `ml/device.go` so the two efforts don't conflict (per #345 — post the diff/merge there to unblock).
+
+## Status
+
+- Created: 2026-06-21
+- Evidence: #337 (benchmark + decision), #345 (STORY-014 sync point)
+- Plan: #346
+- Issues: #347 (code change), #348 (f16 VRAM validation), #349 (rotation-skip follow-up)

--- a/ml/device.go
+++ b/ml/device.go
@@ -438,11 +438,6 @@ func FlashAttentionSupported(l []DeviceInfo) bool {
 		supportsFA := gpu.Library == "cpu" ||
 			gpu.Name == "Metal" || gpu.Library == "Metal" ||
 			(gpu.Library == "CUDA" && gpu.ComputeMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
-			// ollama37: K80 (compute 3.7) uses fattn-vec, empirically validated
-			// against gemma3:4b in 2026-04 (issue #108). Output bit-exact match
-			// with the non-FA path; unlocks Q8_0 KV cache quant for ~47% memory
-			// reduction.
-			(gpu.Library == "CUDA" && gpu.ComputeMajor == 3 && gpu.ComputeMinor == 7) ||
 			gpu.Library == "ROCm"
 
 		if !supportsFA {


### PR DESCRIPTION
## Summary
- Remove the K80 `cc==3.7` clause in `ml/device.go` `FlashAttentionSupported()`. FA is a net loss on sm_37 (no tensor cores) — ~7× slower at long context (#337/#346). The gate is now pure-upstream (`cc>=7 && !7.2`): K80 + Pascal off, cc≥7.0 cards on.
- Coupled change: flip the K80 default `OLLAMA_KV_CACHE_TYPE` `q8_0 → f16` (q8_0 V-cache quant requires FA), and update `docker/.env.example`.

## Verification (CI, self-hosted K80)
- `gemma4:26b` load now reports `FlashAttention:false` + f16 KV; output correct (verifier passed).
- **MCP T1 decode:** 1.18 → **8.11 tok/s** (~7×); a 25-min tool-calling run → **2.7 min**.
- **Throughput ctx16384:** 9.23 → **11.45 tok/s** (+24%).

## ⚠️ Before merge
- [ ] **#348 — f16 VRAM-fit validation** on the largest supported models at long context. f16 KV is ~2× q8_0; the f16 default should **not** ship until we confirm big models still fit on a 12 GB die.
- [ ] Coordinate `ml/device.go` merge order with **STORY-014 (#345)** so the two efforts don't collide (diff posted there).

Fixes #347 · Part of #346 · Unblocks #345

## Test plan
- [x] FA-off via gate: MCP T1 + throughput reproduce the #337 gains, output correct
- [ ] #348 VRAM validation on the largest models

🤖 Generated with [Claude Code](https://claude.com/claude-code)