### PR TITLE
[STORY-014] Widen CUDA build to the 470 datacenter arch sweep (37→86)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,7 @@
       "name": "CUDA 11 K80",
       "inherits": ["CUDA"],
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "37",
+        "CMAKE_CUDA_ARCHITECTURES": "37-real;50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real",
         "CMAKE_CUDA_FLAGS": "-Wno-deprecated-gpu-targets -t 2"
       }
     },

--- a/cicd/tests/testcases/build/TC-BUILD-002.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-002.yml
@@ -2,7 +2,7 @@ id: TC-BUILD-002
 name: Runtime Image Build
 suite: build
 priority: 2
-timeout: 14400000
+timeout: 3600000
 dependencies:
   - TC-BUILD-001
 intent:
@@ -12,7 +12,7 @@ intent:
 steps:
   - name: Navigate and build runtime image
     command: cd ${OLLAMA37_ROOT}/docker && OLLAMA_VERSION=${OLLAMA_VERSION:-0.0.0} make build-runtime-local-no-cache 2>&1
-    timeout: 14400000
+    timeout: 3600000
     expectPatterns:
       - "Runtime image built successfully"
     rejectPatterns:
@@ -31,10 +31,11 @@ criteria: |
   - Build completes without errors
   - Final message: "Runtime image built successfully!"
   - Runtime image exists (ollama37:latest)
-  - Image size is larger than the old sm_37-only build (multi-stage build) because
-    the CUDA library now bundles native cubin for the full 470 datacenter sweep
-    (sm_37/50/52/60/61/70/75/80/86)
+  - Image size is somewhat larger than the old sm_37-only build (multi-stage build)
+    because the CUDA library now bundles native cubin for the full 470 datacenter
+    sweep (sm_37/50/52/60/61/70/75/80/86)
 
-  Note: CUDA compilation now covers 9 architectures, so the build takes much longer
-  than the old single-arch ~18 min — budget on the order of 2-3 hours. Timeout is set
-  to 4 h. Each GPU still loads only its own cubin at runtime; this is build cost only.
+  Note: CUDA compilation now covers 9 architectures, but nvcc shares the compile
+  front-end across targets, so the build is only modestly slower than the old
+  single-arch ~18 min — measured ~20 min for the full suite on run 27895485876.
+  Timeout is 1 h for margin. Each GPU still loads only its own cubin at runtime.

--- a/cicd/tests/testcases/build/TC-BUILD-002.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-002.yml
@@ -2,7 +2,7 @@ id: TC-BUILD-002
 name: Runtime Image Build
 suite: build
 priority: 2
-timeout: 1800000
+timeout: 14400000
 dependencies:
   - TC-BUILD-001
 intent:
@@ -12,7 +12,7 @@ intent:
 steps:
   - name: Navigate and build runtime image
     command: cd ${OLLAMA37_ROOT}/docker && OLLAMA_VERSION=${OLLAMA_VERSION:-0.0.0} make build-runtime-local-no-cache 2>&1
-    timeout: 1800000
+    timeout: 14400000
     expectPatterns:
       - "Runtime image built successfully"
     rejectPatterns:
@@ -31,6 +31,10 @@ criteria: |
   - Build completes without errors
   - Final message: "Runtime image built successfully!"
   - Runtime image exists (ollama37:latest)
-  - Image size approximately 1.5GB (multi-stage build)
+  - Image size is larger than the old sm_37-only build (multi-stage build) because
+    the CUDA library now bundles native cubin for the full 470 datacenter sweep
+    (sm_37/50/52/60/61/70/75/80/86)
 
-  Note: Build time is approximately 17-18 minutes for CUDA compilation.
+  Note: CUDA compilation now covers 9 architectures, so the build takes much longer
+  than the old single-arch ~18 min — budget on the order of 2-3 hours. Timeout is set
+  to 4 h. Each GPU still loads only its own cubin at runtime; this is build cost only.

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -22,9 +22,12 @@ RUN cd /usr/local/src \
 WORKDIR /usr/local/src/ollama37
 
 # Configure build with CMake
-# Use "CUDA 11 K80" preset: compiles native CUBIN for sm_37 (no PTX JIT needed)
-# The "CUDA 11" preset only embeds PTX (37-virtual), requiring ~3-4 min of JIT
-# compilation on every container restart. Native CUBIN eliminates this entirely.
+# Use "CUDA 11 K80" preset: compiles native CUBIN for the 470-era datacenter sweep
+# (sm_37/50/52/60/61/70/75/80/86 — Kepler through Ampere), all -real so there's no
+# PTX JIT on container restart. Each GPU loads only its own cubin, so the K80 path is
+# byte-identical; the extra cubins are dead weight other cards never touch.
+# The "CUDA 11" preset embeds PTX instead, requiring ~3-4 min of JIT compilation on
+# every container restart. Native CUBIN eliminates that.
 # Set LD_LIBRARY_PATH during build so CMake can locate GCC 10 runtime libraries
 # and properly link against them (required for C++ standard library and atomics)
 RUN bash -c 'LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib64:$LD_LIBRARY_PATH \

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -1,7 +1,7 @@
 # Ollama37 Runtime Image
 # Multi-stage build: compiles in builder image, copies only runtime artifacts to slim image
 #
-# Image size: ~800 MB - 1.5 GB (vs ~8-12 GB for single-stage builder image)
+# Image size: ~1.9 GB for the 9-arch CUDA sweep (vs ~8-12 GB for single-stage builder image)
 # The runtime image contains only: ollama binary, GGML/CUDA libraries, CUDA runtime
 # libs, and GCC 10 runtime libs. No compilers, build tools, or source code.
 

--- a/docker/runtime/Dockerfile.local
+++ b/docker/runtime/Dockerfile.local
@@ -27,9 +27,12 @@ ARG GIT_COMMIT=HEAD
 RUN echo "Build commit: ${GIT_COMMIT}" > /tmp/build-commit
 
 # Configure build with CMake
-# Use "CUDA 11 K80" preset: compiles native CUBIN for sm_37 (no PTX JIT needed)
-# The "CUDA 11" preset only embeds PTX (37-virtual), requiring ~3-4 min of JIT
-# compilation on every container restart. Native CUBIN eliminates this entirely.
+# Use "CUDA 11 K80" preset: compiles native CUBIN for the 470-era datacenter sweep
+# (sm_37/50/52/60/61/70/75/80/86 — Kepler through Ampere), all -real so there's no
+# PTX JIT on container restart. Each GPU loads only its own cubin, so the K80 path is
+# byte-identical; the extra cubins are dead weight other cards never touch.
+# The "CUDA 11" preset embeds PTX instead, requiring ~3-4 min of JIT compilation on
+# every container restart. Native CUBIN eliminates that.
 # Set LD_LIBRARY_PATH during build so CMake can locate GCC 10 runtime libraries
 # and properly link against them (required for C++ standard library and atomics)
 RUN bash -c 'LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib64:$LD_LIBRARY_PATH \

--- a/docker/runtime/Dockerfile.local
+++ b/docker/runtime/Dockerfile.local
@@ -5,7 +5,7 @@
 #
 # Usage: docker build -f docker/runtime/Dockerfile.local -t ollama37:latest .
 #
-# Image size: ~800 MB - 1.5 GB (vs ~8-12 GB for single-stage builder image)
+# Image size: ~1.9 GB for the 9-arch CUDA sweep (vs ~8-12 GB for single-stage builder image)
 # The runtime image contains only: ollama binary, GGML/CUDA libraries, CUDA runtime
 # libs, and GCC 10 runtime libs. No compilers, build tools, or source code.
 

--- a/docs/research/470-arch-support-map.md
+++ b/docs/research/470-arch-support-map.md
@@ -1,0 +1,153 @@
+# Which GPUs *could* this project support? (Driver 470 arch map)
+
+**Related**: [#223](https://github.com/dogkeeper886/ollama37/issues/223) (K80 + P100 mixed-GPU crash)
+**Date**: 2026-06-21
+**Status**: Research / reference. No code change proposed here — this is the map you consult before any multi-architecture work.
+
+## TL;DR
+
+The project is pinned to the NVIDIA **470 driver** and **CUDA 11.4** because that's the
+only combination that still runs the Tesla K80. That same combination can *physically*
+run a lot more than the K80 — everything from Kepler up to Ampere (A100-class cards).
+
+But "the card can run code" and "the project runs *correctly* on the card" are two
+different things. There are **two layers**, and both have to line up:
+
+1. **Build layer** — did we compile machine code for this GPU's architecture? If not,
+   the first kernel launch crashes with XID 43 (this is exactly what happened to the
+   P100 in #223).
+2. **Code layer** — the kernels contain `if (compute_capability >= X)` switches that
+   pick a fast path or a fallback. Compiling for a new card *turns those switches on*,
+   and some of those paths have never been exercised on this project's one tested card
+   (the K80). So each new architecture needs its switches traced and its output checked.
+
+So: yes, in theory we can support every card the 470 driver supports. The build half is
+easy. The code half — the "sm gates" — is the real work.
+
+## The two layers, in one picture
+
+```
+  YOU WANT TO SUPPORT A NEW CARD (say, a P100)
+                 |
+   ┌─────────────┴──────────────┐
+   |                            |
+ LAYER 1: BUILD               LAYER 2: CODE GATES
+ "does machine code           "is the code that runs
+  exist for this card?"        actually right for it?"
+
+ CMAKE_CUDA_ARCHITECTURES     cc >= GGML_CUDA_CC_*  (in the CUDA kernels)
+ in CMakePresets.json         FlashAttentionSupported() (in ml/device.go)
+   |                            |
+   | miss the arch →            | wrong branch taken →
+   v                            v
+   XID 43, instant crash        runs, but maybe slow
+   (the #223 P100 bug)          or subtly wrong output
+```
+
+Layer 1 is a one-line list. Layer 2 is where you have to think.
+
+## What the 470 + CUDA 11.4 stack can run
+
+The limit is the **overlap** of two things:
+
+- **Driver 470** is the *last* driver that still supports the K80 (Kepler). It runs
+  everything from Kepler up through Ampere.
+- **CUDA 11.4** is the newest toolkit that pairs with the 470 driver, and it can *compile*
+  for those same architectures (sm_37 up to sm_87).
+
+Newer cards — Ada (RTX 40-series) and Hopper (H100) — need a newer driver and CUDA 12+,
+which would **drop the K80**. That trade is the whole reason this project sits where it does.
+
+```
+   OLDER ───────────────────────────────────────────────────────► NEWER
+   Kepler   Maxwell   Pascal   Volta   Turing   Ampere │ Ada   Hopper
+   3.5 3.7  5.0 5.2   6.0 6.1  7.0     7.5      8.0 8.6 │ 8.9   9.0
+   K40 K80  M40 M60   P100     V100    T4       A100    │ RTX40 H100
+            GTX9xx    P40                       A40     │ L4
+   └──────────── 470 driver + CUDA 11.4 cover this ─────┘ └─ needs 520+/CUDA12 ─┘
+                                                            (would drop the K80)
+```
+
+| Architecture | Compute cap (sm) | Example data-center cards | In range? |
+|---|---|---|---|
+| Kepler | 3.5 / 3.7 | K40, **K80** | ✅ (the one we test) |
+| Maxwell | 5.0 / 5.2 | M40, M60 | ✅ |
+| Pascal | 6.0 | **P100** | ✅ |
+| Pascal | 6.1 | **P40, P4** (+ GTX 10-series) | ✅ |
+| Volta | 7.0 | **V100** | ✅ |
+| Turing | 7.5 | **T4** | ✅ |
+| Ampere | 8.0 | **A100** | ✅ |
+| Ampere | 8.6 | **A40, A10, A16, A2** | ✅ |
+| Ada / Hopper | 8.9 / 9.0 | RTX 40-series, L4, H100 | ❌ needs newer driver |
+
+(Embedded Tegra/Jetson parts — 5.3, 6.2, 7.2, 8.7 — are technically in the toolkit's
+range but aren't relevant to a desktop 470 driver, so they're left off.)
+
+## The code gates ("sm gates") you'd have to trace
+
+These are the `if (compute_capability >= X)` switches inside the CUDA kernels. Compiling
+for a card decides which side of each switch it lands on. A ✅ means the hardware feature
+is present; the support question is whether the project's code handles that crossing.
+
+| Gate (where it lives) | Turns on at | K80 3.7 | Maxwell 5.x | P100 6.0 | P40/10xx 6.1 | V100 7.0 | T4 7.5 | Ampere 8.x |
+|---|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| FP16 math (`common.cuh:250`) | 6.0 | ✗ | ✗ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| *Fast* FP16 (`common.cuh:254,289`) | 6.0 but **not 6.1** | ✗ | ✗ | ✅ | ✗* | ✅ | ✅ | ✅ |
+| dp4a int8 dot (`common.cuh:520`) | 6.1 | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ | ✅ |
+| FP16 tensor cores (`common.cuh:295`) | 7.0 | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
+| int8 tensor cores (`common.cuh:308`) | 7.5 | ✗ | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ |
+| Ampere MMA / async copy (`common.cuh:312`) | 8.0 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✅ |
+| Flash attention (`ml/device.go:440`) | 7.0 (not 7.2) **+ K80 special-case** | ✅† | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
+
+\* sm_6.1 has FP16 hardware but it's deliberately rate-limited, so upstream excludes it
+from the "fast" path on purpose. Not a bug — a real subtlety to preserve.
+
+† The K80 only passes the flash-attention gate because this fork added a hand-written
+special-case for it (issues #108 / #112). No other sub-7.0 card has that, including the P100.
+
+## What this means in plain terms
+
+The gates sort the cards into three buckets:
+
+- **Volta and newer (7.0+) — basically free.** These are the cards upstream ggml targets
+  every day, so the tensor-core and flash-attention paths are well-worn. Add them to the
+  build list and they mostly just work. The K80 patches don't get in the way — they all
+  live behind `cc < 7.0` branches.
+
+- **Pascal (6.0 and 6.1) — the real gap.** These switch on FP16 and dp4a code paths that
+  the **K80-only build never even compiles**, so nothing here has run them. And the
+  flash-attention gate has no Pascal entry (that's the missing piece behind the #223 P100
+  crash). This is the bucket that needs careful tracing and a real test on the hardware.
+
+- **Maxwell (5.x) — easy but dull.** It sits below every feature gate, so it rides the
+  exact same plain-vanilla code paths the K80 already uses. Low risk, low reward.
+
+### One landmine to remember
+
+The flash-attention gate excludes compute **7.2** on purpose
+(`!(major == 7 && minor == 2)` in `ml/device.go:440`). That's the Jetson Xavier. If
+embedded parts ever come into scope, that exclusion will bite — it looks like a card that
+*should* qualify (it's ≥ 7.0) but is intentionally turned off.
+
+## How you'd actually add a card (the recipe)
+
+1. **Build:** add its `sm` number to `CMAKE_CUDA_ARCHITECTURES` (keep it **real**, not
+   `-virtual`, so there's no slow first-run JIT). → check: the card boots a small model
+   without XID 43.
+2. **Trace the gates:** walk the table above for that card's compute capability and note
+   every gate it newly crosses. Each crossing is a code path that hasn't run here before.
+3. **Validate on real hardware:** run a known prompt, compare output against a card we
+   already trust (or against CPU). Bit-exact or clearly-equivalent output = the crossed
+   paths are sound. This is the step the maintainer can't do without owning the card —
+   which is why support is a hardware commitment, not just a code change.
+
+## References
+
+- Build presets: `CMakePresets.json` (the `CUDA 11 K80` preset pins `"37"`)
+- Arch fallback logic: `ml/backend/ggml/ggml/src/ggml-cuda/CMakeLists.txt:8-44`
+- Code gates: `ml/backend/ggml/ggml/src/ggml-cuda/common.cuh:80-85` (thresholds),
+  `:250-314` (the feature switches), `:520` (dp4a)
+- Flash-attention gate: `ml/device.go:436-453`
+- Runtime "does this GPU work" filter: `discover/runner.go:154`
+- K80 background: `docs/research/k80-quant-audit.md`, `docs/research/k80-fusion-audit.md`
+- Toolchain pins: `docker/builder/Dockerfile` (CUDA 11.4, GCC 10), `docker/runtime/Dockerfile`

--- a/docs/research/470-arch-support-map.md
+++ b/docs/research/470-arch-support-map.md
@@ -97,13 +97,15 @@ is present; the support question is whether the project's code handles that cros
 | FP16 tensor cores (`common.cuh:295`) | 7.0 | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
 | int8 tensor cores (`common.cuh:308`) | 7.5 | ✗ | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ |
 | Ampere MMA / async copy (`common.cuh:312`) | 8.0 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✅ |
-| Flash attention (`ml/device.go:440`) | 7.0 (not 7.2) **+ K80 special-case** | ✅† | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
+| Flash attention (`ml/device.go:440`) | 7.0 (not 7.2) | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
 
 \* sm_6.1 has FP16 hardware but it's deliberately rate-limited, so upstream excludes it
 from the "fast" path on purpose. Not a bug — a real subtlety to preserve.
 
-† The K80 only passes the flash-attention gate because this fork added a hand-written
-special-case for it (issues #108 / #112). No other sub-7.0 card has that, including the P100.
+The flash-attention gate is now pure-upstream (`cc >= 7.0`, ≠7.2): FA is **off** for the
+K80 and Pascal, **on** for Volta and up. The fork once carried a hand-written K80
+special-case (issues #108 / #112) but it was removed in #350 after a benchmark showed FA
+is a net slowdown on the K80 — so no sub-7.0 card, including the P100, gets FA.
 
 ## What this means in plain terms
 
@@ -115,9 +117,10 @@ The gates sort the cards into three buckets:
   live behind `cc < 7.0` branches.
 
 - **Pascal (6.0 and 6.1) — the real gap.** These switch on FP16 and dp4a code paths that
-  the **K80-only build never even compiles**, so nothing here has run them. And the
-  flash-attention gate has no Pascal entry (that's the missing piece behind the #223 P100
-  crash). This is the bucket that needs careful tracing and a real test on the hardware.
+  the **K80-only build never even compiles**, so nothing here has run them. (The #223 P100
+  crash itself was the build layer — no sm_60 cubin — not a code gate.) Pascal also sits
+  below the pure-upstream FA gate, so it runs FA-off like the K80. This is the bucket that
+  needs careful tracing and a real test on the hardware.
 
 - **Maxwell (5.x) — easy but dull.** It sits below every feature gate, so it rides the
   exact same plain-vanilla code paths the K80 already uses. Low risk, low reward.

--- a/docs/stories/STORY-014.md
+++ b/docs/stories/STORY-014.md
@@ -1,0 +1,72 @@
+# STORY-014: The prebuilt image runs on the whole 470-era datacenter GPU fleet, not just the K80
+
+## User Story
+
+As a user running ollama37 on NVIDIA datacenter GPUs other than — or alongside — the Tesla K80,
+I want the prebuilt image to run on the full range of cards the 470 driver and CUDA 11.4 toolkit support (Pascal through Ampere, not only Kepler sm_37),
+So that a P100, P40, V100, T4, A100, or a mixed box like K80 + P100 just works instead of crashing the moment a model loads.
+
+## The Need
+
+The shipped image compiles GPU code for the K80 (sm_37) **only**. Any other card the
+470 driver can drive — P100, V100, T4, A100, and the rest of the Pascal-through-Ampere
+range — has no machine code to run, so the first kernel launch faults with XID 43. This
+is exactly what closed issue [#223](https://github.com/dogkeeper886/ollama37/issues/223)
+reported: a K80 + P100 box where the P100 crashes after a model loads.
+
+The project pins itself to the 470 driver / CUDA 11.4 precisely *because* that's the
+last combination that still runs the K80. The quiet upside is that the same combination
+can physically run everything up to Ampere — the project is leaving that whole fleet on
+the table for no technical reason, only because the build targets a single architecture.
+A user who has a P100 (or a mix) and is already on the 470 driver should be able to pull
+the same image K80 users pull and have it run on their hardware.
+
+The trade the user has accepted: this is one image for the whole fleet (not a separate
+variant), so the K80 build gets longer and the image larger — but a K80's actual
+inference stays identical.
+
+## Success Looks Like
+
+- A non-K80 datacenter GPU in the 470 range (P100 first, as the #223 case) **runs a
+  model without XID 43** — it loads and produces sane output, instead of crashing.
+- A **mixed box** (K80 + a newer card) uses all its GPUs, with the newer card no longer
+  taking down the run.
+- An existing **K80-only user sees no change in behavior** — same model output as before;
+  the only difference is a longer build and a bigger image.
+- Putting a non-K80 card in the box **does not silently degrade the K80's own
+  performance** — the newer card is additive, not a regression for the K80 already there.
+
+*Honesty note: there is no representative hardware to prove these on. The maintainer's
+only non-K80 card is an RTX 2060 on a separate host with a different driver — it can't be
+paired with the K80 (so no mixed-arch test) and isn't the 470 target, making it at most a
+weak best-effort smoke check that the sm_75 build runs. The #223 P100 case and the
+mixed-arch scenario are built-for but stay validation-pending until a real Pascal card on
+the 470 stack is available; until then, confidence rests on code-trace and the fact that
+the higher-arch paths are intact, upstream-maintained code.*
+
+## Open Questions
+
+- **Validation hardware (largely open).** The only non-K80 card available is an RTX 2060
+  on a separate host with a different driver — not the 470 target, and it can't be paired
+  with the K80, so no mixed-arch test. At best it's a weak best-effort smoke check of the
+  sm_75 build. Real validation — the #223 mixed-arch-on-470 scenario and Pascal's specific
+  gate crossings (sm_60 fast-FP16, sm_61 dp4a) — needs hardware we don't have (the #223
+  reporter, a cloud instance, or a CI runner); until then we rely on code-trace + intact
+  upstream code.
+- The exact architecture list and how it's expressed in the build (keeping native code,
+  not PTX, so there's no first-run JIT), worked out on the issue against
+  `docs/research/470-arch-support-map.md`.
+- How to extend the flash-attention gate (`ml/device.go`) to the newer cards without
+  regressing the K80's existing special-case.
+- Whether the three K80-specific workarounds that assume an all-K80 box — the CUBLAS
+  two-tier fallback, the VMM granularity alignment, and the ghost-GPU layout fix —
+  behave correctly on a non-K80 or mixed box, or only need an audit to confirm.
+- Whether the longer build time and larger image are acceptable as the cost of a single
+  fleet-wide image, or warrant revisiting the one-image decision.
+
+## Status
+
+- Created: 2026-06-21
+- Plan: #340
+- Issues: #341, #342, #343, #344
+- Blocked on: #345 (sync point — K80-FA-removal result must land first)

--- a/docs/stories/STORY-014.md
+++ b/docs/stories/STORY-014.md
@@ -68,5 +68,5 @@ the higher-arch paths are intact, upstream-maintained code.*
 
 - Created: 2026-06-21
 - Plan: #340
-- Issues: #341, #342, #343, #344
+- Issues: #341 (PR #353, in review), #342, #343, #344
 - Blocked on: #345 (sync point — K80-FA-removal result must land first)

--- a/docs/stories/STORY-014.md
+++ b/docs/stories/STORY-014.md
@@ -56,8 +56,10 @@ the higher-arch paths are intact, upstream-maintained code.*
 - The exact architecture list and how it's expressed in the build (keeping native code,
   not PTX, so there's no first-run JIT), worked out on the issue against
   `docs/research/470-arch-support-map.md`.
-- How to extend the flash-attention gate (`ml/device.go`) to the newer cards without
-  regressing the K80's existing special-case.
+- ~~How to extend the flash-attention gate (`ml/device.go`) to the newer cards without
+  regressing the K80's existing special-case.~~ Resolved: follow upstream — STORY-014
+  leaves the FA gate untouched; the K80 special-case was removed in #350, leaving the
+  pure-upstream `cc >= 7.0` gate that's already correct for the whole sweep.
 - Whether the three K80-specific workarounds that assume an all-K80 box — the CUBLAS
   two-tier fallback, the VMM granularity alignment, and the ghost-GPU layout fix —
   behave correctly on a non-K80 or mixed box, or only need an audit to confirm.


### PR DESCRIPTION
## Summary
- Change the `CUDA 11 K80` preset's `CMAKE_CUDA_ARCHITECTURES` from `"37"` to the full 470-era datacenter sweep `37/50/52/60/61/70/75/80/86` (all `-real` native cubin, no PTX/JIT) so the image runs on Pascal→Ampere cards, not just the K80 — the fix for the XID 43 crash in #223.
- The ggml-cuda backend is intact upstream (not trimmed), so the higher arches just re-activate existing gated code. A K80 still loads only its own sm_37 cubin → **byte-identical inference**; the other 8 cubins are dead weight it never touches.
- Updated the now-stale "sm_37 only" preset comments and the image-size header in both runtime Dockerfiles; bumped TC-BUILD-002's timeout (the 9-arch build is slower than the old single-arch one).

## Measured (CI run 27895485876, green)
- **Build:** ~20 min for all 9 arches (nvcc shares the compile front-end, so it's only modestly slower than the old ~18 min single-arch — the "build cost" objection largely evaporates).
- **Image size:** 1.88 GB (was ~1.5 GB sm_37-only; well under the TC-BUILD-003 3 GB cap).
- Build suite TC-BUILD-001/002/003 all pass, 0 failures, no CUDA errors.

## Also in this PR (transparency)
- `docs/stories/STORY-014.md` and `docs/research/470-arch-support-map.md` — the story + its reference doc. Bundled with the first implementation PR, matching how STORY-015.md landed in #350.

## Test plan
- [x] 9-arch image builds clean on the CUDA 11.4 builder (CI green)
- [x] K80 **build** suite unchanged (0 failures)
- [ ] K80 **inference** suites — not run here; provably byte-identical (K80 loads only its sm_37 cubin), but a maintainer may want to confirm before merge
- [ ] Definitive `cuobjdump --list-elf` that each sm_NN cubin is embedded + on-real-hardware run — tracked in #342

Fixes #341
Part of STORY-014 · plan #340

Generated with [Claude Code](https://claude.com/claude-code)