### PR TITLE
Unpin flash-attention default + fix stale docker docs

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -14,12 +14,10 @@ OLLAMA_VERSION=2.0.1
 # Defaults are tuned for K80 hardware. Override here only if you know what
 # you're doing.
 
-# Flash attention. On K80 (sm_37) FA is gated OFF — it's a net loss there
-# (~7x slower at long context; see #346), so the hardware gate disables it
-# regardless of this var. Default is 0: on a K80, =1 logs a spurious "flash
-# attention enabled but not supported" warning every load. On cc>=7.0 cards
-# (the widened build, experimental) set =1 to enable FA.
-# OLLAMA_FLASH_ATTENTION=0
+# Flash attention. Left unset by default — ollama's hardware gate forces it OFF on
+# the K80 (sm_37) regardless (a net loss there, ~7x slower at long context; see #346).
+# On cc>=7.0 cards (the widened build, experimental) set =1 to enable FA.
+# OLLAMA_FLASH_ATTENTION=1
 
 # KV cache element type. Default "f16" on K80, because FA is off there and
 # V-cache quantization (q8_0) requires FA — so q8_0 won't load on the K80.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -16,9 +16,10 @@ OLLAMA_VERSION=2.0.1
 
 # Flash attention. On K80 (sm_37) FA is gated OFF — it's a net loss there
 # (~7x slower at long context; see #346), so the hardware gate disables it
-# regardless of this var. On cc>=7.0 cards (the widened build) the request is
-# honored and FA is on. Leaving this =1 is harmless on K80 (ignored).
-# OLLAMA_FLASH_ATTENTION=1
+# regardless of this var. Default is 0: on a K80, =1 logs a spurious "flash
+# attention enabled but not supported" warning every load. On cc>=7.0 cards
+# (the widened build, experimental) set =1 to enable FA.
+# OLLAMA_FLASH_ATTENTION=0
 
 # KV cache element type. Default "f16" on K80, because FA is off there and
 # V-cache quantization (q8_0) requires FA — so q8_0 won't load on the K80.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Ollama37 Docker Build System
 
-**Multi-stage Docker build for Ollama with CUDA 11.4 and Compute Capability 3.7 support (Tesla K80)**
+**Multi-stage Docker build for Ollama on CUDA 11.4 — built and tested for the Tesla K80 (compute capability 3.7); the image also compiles native CUBIN for the wider `sm_37`–`sm_86` datacenter range (Kepler→Ampere, experimental).**
 
 ## Overview
 
@@ -143,7 +143,7 @@ docker/
 
 **Build stage** (FROM ollama37-builder):
 1. Clone/copy ollama37 source
-2. Configure with CMake ("CUDA 11 K80" preset — native CUBIN for sm_37, no PTX JIT)
+2. Configure with CMake ("CUDA 11 K80" preset — native CUBIN for sm_37–sm_86, no PTX JIT)
 3. Build C/C++/CUDA libraries (`cmake --build`)
 4. Install artifacts to `dist/` (`cmake --install` with CPU and CUDA components)
    - Automatically bundles CUDA runtime libs (cublas, cublasLt, cudart)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,12 +18,11 @@ services:
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_DEBUG=${OLLAMA_DEBUG:-}
       # K80 perf defaults — see docker/.env.example to override.
-      # FA is gated off on K80 (sm_37) — it's a net loss there (see #346). Default
-      # off: =1 on a K80 logs a spurious "flash attention enabled but not supported"
-      # warning every load, and on the experimental cc>=7.0 cards we'd rather not
-      # auto-enable an unvalidated path — set =1 there to turn FA on. With FA off,
-      # q8_0 KV is unavailable (needs FA), so the default cache is f16.
-      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-0}
+      # Flash attention is left unset (not pinned): ollama's hardware gate forces it
+      # off on the K80 (sm_37) anyway — it's a net loss there (see #346) — and we don't
+      # auto-enable it on the experimental cc>=7.0 cards. Set OLLAMA_FLASH_ATTENTION=1
+      # to turn it on where supported. With FA off, q8_0 KV needs FA, so cache is f16.
+      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-}
       - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,10 +18,12 @@ services:
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_DEBUG=${OLLAMA_DEBUG:-}
       # K80 perf defaults — see docker/.env.example to override.
-      # FA is gated off on K80 (sm_37) — it's a net loss there (see #346); the
-      # request is honored only on cc>=7.0 cards in the widened build. With FA
-      # off, q8_0 KV is unavailable (needs FA), so the default cache is f16.
-      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-1}
+      # FA is gated off on K80 (sm_37) — it's a net loss there (see #346). Default
+      # off: =1 on a K80 logs a spurious "flash attention enabled but not supported"
+      # warning every load, and on the experimental cc>=7.0 cards we'd rather not
+      # auto-enable an unvalidated path — set =1 there to turn FA on. With FA off,
+      # q8_0 KV is unavailable (needs FA), so the default cache is f16.
+      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-0}
       - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility


### PR DESCRIPTION
## Summary
Two things, both surfaced while prepping the v2.2.0 release:

**1. Don't pin `OLLAMA_FLASH_ATTENTION` (hybrid)** — compose + `.env.example`
After #350 removed K80 flash attention, the compose still *pinned* `FA=1`, which on a K80 is gated off but logs a spurious `flash attention enabled but not supported by gpu` warning every model load (`llm/server.go:249`). Rather than re-pin it to `0` (a fork opinion that can drift stale again — exactly what just happened), **leave it unset** via the `${OLLAMA_FLASH_ATTENTION:-}` empty-default pattern already used in this file for `OLLAMA_DEBUG`:
- ollama's **hardware gate** already forces FA off on the K80 (the tested target) — no warning, no pinned opinion to rot.
- the experimental cc≥7 cards aren't auto-enabled (don't turn on an unvalidated path); set `OLLAMA_FLASH_ATTENTION=1` to opt in.
- the var still passes through for override, and stays documented in `.env.example`.
- KV cache stays pinned `f16` (the meaningful default — q8_0 needs FA).

**2. Stale "sm_37 only" docs** (`docker/README.md`)
The subtitle and a build-step note still said the preset compiles "native CUBIN for sm_37" — #341's 9-arch widening made that false. Updated to `sm_37`–`sm_86` (same fix already applied to the Dockerfiles in #344).

## Test plan
- [x] compose leaves FA unset (`:-`), KV pinned `f16`; mirrors the `OLLAMA_DEBUG` pattern
- [x] `.env.example` documents the FA knob (set `=1` to enable on capable cards)
- [x] `docker/README.md` no longer claims sm_37-only
- docs/config only — no build impact

Generated with [Claude Code](https://claude.com/claude-code)