### PR TITLE
Share extractJson between agent + verifier judges (fix truncated-response FAIL)

### DIFF
--- a/cicd/tests/src/judge/agent-judge.ts
+++ b/cicd/tests/src/judge/agent-judge.ts
@@ -29,6 +29,7 @@ import {
 } from '@agentclientprotocol/sdk';
 import { TestResult, Judgment } from '../types.js';
 import { CONFIG } from '../config.js';
+import { extractJson } from './extract-json.js';
 
 export class AgentJudge {
   private agentCmd: string;
@@ -248,13 +249,6 @@ export class AgentJudge {
    * Extract the first JSON object from a model response, tolerating prose or
    * markdown fences around it.
    */
-  private extractJson(text: string): string | null {
-    const start = text.indexOf('{');
-    const end = text.lastIndexOf('}');
-    if (start === -1 || end === -1 || end < start) return null;
-    return text.substring(start, end + 1);
-  }
-
   /**
    * Run one prompt turn through the agent and return its raw reply text.
    * Bounded by CONFIG.judge.timeout. On timeout/failure the turn isn't actually
@@ -297,7 +291,7 @@ export class AgentJudge {
 
     process.stderr.write(`  [judge] Raw response for ${testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
 
-    const json = this.extractJson(responseText);
+    const json = extractJson(responseText);
     if (!json) {
       process.stderr.write(`  [judge] WARNING: No JSON object in response for ${testId}\n`);
       return {

--- a/cicd/tests/src/judge/extract-json.ts
+++ b/cicd/tests/src/judge/extract-json.ts
@@ -1,0 +1,33 @@
+/**
+ * Extract a JSON object from an agent/verifier reply.
+ *
+ * Scans from the first '{' tracking string state to find the matching close. The
+ * ACP agent sometimes ends a turn one token short of its trailing '}' (or the final
+ * streamed chunk isn't captured), so a complete-but-unclosed object would otherwise
+ * be discarded — flipping a genuine verdict to a "No JSON" FAIL. Tolerate that by
+ * appending the missing closers, but only when the truncation is OUTSIDE a string
+ * (a value cut mid-string is genuinely unrecoverable → null).
+ *
+ * Shared by agent-judge.ts and verifier-judge.ts so the recovery can't drift between
+ * them — it did once: the fix (#327) landed in verifier-judge.ts while agent-judge.ts
+ * kept the old indexOf/lastIndexOf version and still FAILed genuine verdicts on
+ * truncated responses.
+ */
+export function extractJson(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+    } else if (c === '"') inStr = true;
+    else if (c === '{') depth++;
+    else if (c === '}' && --depth === 0) return text.substring(start, i + 1);
+  }
+  return depth > 0 && !inStr ? text.substring(start) + '}'.repeat(depth) : null;
+}

--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -44,6 +44,7 @@ import {
 import type { McpServerConfig } from '../mcp/host.js';
 import type { Judgment } from '../types.js';
 import { CONFIG } from '../config.js';
+import { extractJson } from './extract-json.js';
 
 /** VERIFY_DEBUG=1 → reveal every ACP event (sessionUpdate kinds, tool calls, permission/trust
  *  requests) so nothing the adapter emits is swallowed silently. */
@@ -433,31 +434,6 @@ export class VerifierJudge {
     }, null, 2);
   }
 
-  private extractJson(text: string): string | null {
-    const start = text.indexOf('{');
-    if (start === -1) return null;
-    // Scan from the first '{' tracking string state to find the matching close. The
-    // ACP agent sometimes ends a turn one token short of its trailing '}' (or the final
-    // streamed chunk isn't captured), so a complete-but-unclosed object would otherwise
-    // be discarded — flipping a genuine verdict to a "No JSON" FAIL. Tolerate that by
-    // appending the missing closers, but only when the truncation is OUTSIDE a string
-    // (a value cut mid-string is genuinely unrecoverable → null).
-    let depth = 0;
-    let inStr = false;
-    let esc = false;
-    for (let i = start; i < text.length; i++) {
-      const c = text[i];
-      if (inStr) {
-        if (esc) esc = false;
-        else if (c === '\\') esc = true;
-        else if (c === '"') inStr = false;
-      } else if (c === '"') inStr = true;
-      else if (c === '{') depth++;
-      else if (c === '}' && --depth === 0) return text.substring(start, i + 1);
-    }
-    return depth > 0 && !inStr ? text.substring(start) + '}'.repeat(depth) : null;
-  }
-
   private async promptAgent(prompt: string): Promise<string> {
     this.turnText = '';
     this.toolEvidence = '';
@@ -484,7 +460,7 @@ export class VerifierJudge {
     if (!responseText) {
       return { testId: t.testId, pass: false, reason: 'Verifier returned empty response', evidenceStatus };
     }
-    const json = this.extractJson(responseText);
+    const json = extractJson(responseText);
     if (!json) {
       return { testId: t.testId, pass: false, reason: `No JSON in verifier response: ${responseText.substring(0, 200)}`, evidenceStatus };
     }


### PR DESCRIPTION
## RCA
The dual/agent judge marked **genuine passes as FAIL** with \`Failed to parse agent response\` — observed when a gemma4:26b run produced correct output (right tool call, grounded answer) but the agent's own verdict was \`pass: true\`. The harness couldn't parse it.

**Root cause:** the truncation-recovery fix (#327) was applied only to \`verifier-judge.ts\`. \`agent-judge.ts\` kept a **duplicate** of the old \`indexOf('{')\`/\`lastIndexOf('}')\` \`extractJson\`, so it still hard-failed when the ACP agent ended a turn a token short of its trailing \`}\` (or the final streamed chunk wasn't captured). One fix, two copies, applied to the wrong one.

## Fix
Extract the string-aware brace-walk recovery into a shared **\`cicd/tests/src/judge/extract-json.ts\`** that **both** judges import. The duplication *was* the root cause of the drift — sharing it makes a future fix-in-one-copy-miss-the-other impossible.
- `verifier-judge.ts`: behavior unchanged (identical logic moved out)
- `agent-judge.ts`: now gets the recovery it was missing

## Verification
- **`/code-review medium`**: clean (`[]`) — shared logic is byte-identical to the proven #327 brace-walk; both call sites + imports correct.
- **Validated green**: re-ran the exact failing scenario (`test-mcp` gemma4:26b dual judge) on this branch — the workflow runs the test-runner from the branch, so it used the fixed judge. Result: `overall_pass: true`, `agent.pass: true` (the verdict parsed where it failed before). Run 27926063525.

## Follow-up (optional, not in this PR)
A unit test for `extractJson` (balanced / truncated-outside-string→recovers / mid-string→null / no-brace→null) would lock the behavior deterministically — exactly the test that would've caught the original drift. Happy to add it.

Related: #327 (the prior fix this aligns with). Test-harness only — no runtime-image impact.

Generated with [Claude Code](https://claude.com/claude-code)