### PR TITLE
Bump .env.example OLLAMA_VERSION to 2.2.1

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -8,7 +8,7 @@
 
 # Ollama version to embed in the binary
 # This version is displayed by 'ollama --version' and in logs
-OLLAMA_VERSION=2.0.1
+OLLAMA_VERSION=2.2.1
 
 # --- Runtime tuning (optional; container reads these via docker compose) ---
 # Defaults are tuned for K80 hardware. Override here only if you know what


### PR DESCRIPTION
## Summary
`docker/.env.example` defaulted `OLLAMA_VERSION=2.0.1` — stale; a local `make build` reading it would stamp the binary `2.0.1`. Bump to `2.2.1` to match the current release.

Only affects **local dev builds** — the published image uses the repo variable `vars.OLLAMA_VERSION` (already 2.2.1, correct). Surfaced in the docker-config review during the v2.2.1 work.

Docs/config only — no code or image impact.

Generated with [Claude Code](https://claude.com/claude-code)