### PR TITLE
Lower graphSafetyMultiplier to 2.5 to stop K80 CPU offload

### DIFF
--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -13,7 +13,7 @@ on:
         default: false
         type: boolean
       graph_safety_multiplier:
-        description: "Override OLLAMA_GRAPH_SAFETY_MULTIPLIER (#352 graph-buffer margin). Empty = built-in 3.5"
+        description: "Override OLLAMA_GRAPH_SAFETY_MULTIPLIER (#352 graph-buffer margin). Empty = built-in 2.5"
         required: false
         type: string
   workflow_call:

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: false
         type: boolean
+      graph_safety_multiplier:
+        description: "Override OLLAMA_GRAPH_SAFETY_MULTIPLIER (#352 graph-buffer margin). Empty = built-in 3.5"
+        required: false
+        type: string
   workflow_call:
     inputs:
       debug:
@@ -32,6 +36,7 @@ jobs:
     env:
       OLLAMA37_ROOT: ${{ github.workspace }}
       OLLAMA_DEBUG: ${{ inputs.debug && '1' || '' }}
+      OLLAMA_GRAPH_SAFETY_MULTIPLIER: ${{ inputs.graph_safety_multiplier }}
     outputs:
       result: ${{ steps.runtime-tests.outcome }}
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,11 @@ services:
       # to turn it on where supported. With FA off, q8_0 KV needs FA, so cache is f16.
       - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-}
       - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}
+      # Compute-buffer safety margin (#352). Default 3.5 over-reserves on the K80's
+      # small dies, offloading large models to CPU. Lower it (e.g. 1.5-2.0) to keep
+      # large models on GPU — but not so low it trips "failed to allocate compute
+      # buffers". Unset = use the built-in 3.5 default.
+      - OLLAMA_GRAPH_SAFETY_MULTIPLIER=${OLLAMA_GRAPH_SAFETY_MULTIPLIER:-}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,10 +24,10 @@ services:
       # to turn it on where supported. With FA off, q8_0 KV needs FA, so cache is f16.
       - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-}
       - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}
-      # Compute-buffer safety margin (#352). Default 3.5 over-reserves on the K80's
-      # small dies, offloading large models to CPU. Lower it (e.g. 1.5-2.0) to keep
-      # large models on GPU — but not so low it trips "failed to allocate compute
-      # buffers". Unset = use the built-in 3.5 default.
+      # Compute-buffer safety margin (#352). The built-in default 2.5 keeps large
+      # models (deepseek-r1:32b) on the K80's small dies instead of offloading to CPU.
+      # Raising it over-reserves and re-triggers that offload; lowering it too far
+      # risks "failed to allocate compute buffers". Unset = use the built-in 2.5 default.
       - OLLAMA_GRAPH_SAFETY_MULTIPLIER=${OLLAMA_GRAPH_SAFETY_MULTIPLIER:-}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/docs/reports/deepseek-r1-k80-vram-throughput.md
+++ b/docs/reports/deepseek-r1-k80-vram-throughput.md
@@ -61,24 +61,37 @@ collapsing throughput to **0.43 tok/s**. **14b is 100% on GPU** (6.05 tok/s) and
 so at 16k, the per-die over-reservation only bites the 32b's footprint. Calibration target = **32b**;
 **14b = the OOM-guard** (currently healthy at 3.5×, must stay healthy when the multiplier drops).
 
-## AFTER — `OLLAMA_GRAPH_SAFETY_MULTIPLIER` = _&lt;calibrated&gt;_
+## AFTER — `OLLAMA_GRAPH_SAFETY_MULTIPLIER` = **2.5** (calibrated, now the default)
 
 | Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
 |---|---|---|---|---|
-| `deepseek-r1:1.5b` | _pending run_ | | | |
+| `deepseek-r1:1.5b` | pass | 34.34 | 100% | 2 892 — die0 |
 | `deepseek-r1:7b`   | _not pulled on runner — pending_ | | | |
 | `deepseek-r1:8b`   | _not pulled on runner — pending_ | | | |
-| `deepseek-r1:14b`  | _pending run_ | | | |
-| `deepseek-r1:32b`  | _pending run_ | | | |
+| `deepseek-r1:14b`  | pass | 5.85 | 100% | 17 862 — dies 0–1 |
+| `deepseek-r1:32b`  | pass | **2.77** | **100%** | 34 008 — 4 dies (uses the once-stranded VRAM) |
+
+### The multiplier sweep (32b @ 16k — finding the value)
+
+| Multiplier | 32b GPU% | 32b tok/s | verdict |
+|---|---|---|---|
+| 3.5 (original) | 93% | 0.43 | broken — #352 |
+| 3.0 | 99% | 1.40 | nearly — 1 layer on CPU still tanks it |
+| **2.5 (chosen)** | **100%** | **2.77** | **fixed — highest value with full GPU placement** |
+| 2.0 | 100% | 2.79 | fixed (less OOM margin) |
 
 ## Analysis
 
-_Filled once both passes are in:_
-- Which sizes offloaded BEFORE (low GPU%/tok/s with free VRAM) and recovered AFTER.
-- OOM check: did 14b / 32b load without `failed to allocate compute buffers` at the AFTER value?
-- Whether a **single** multiplier satisfies all sizes, or the data shows a single constant can't
-  (large wants it low, the OOM-guard wants it high) → conditional fix needed.
-- **Chosen value:** the lowest multiplier keeping large models on GPU without OOM.
+- **BEFORE:** only `deepseek-r1:32b` reproduced #352 — 93% GPU / 0.43 tok/s with ~15.9 GB free.
+  `14b` and `1.5b` were already 100% on GPU. The bug needs the 32b's multi-die footprint.
+- **AFTER @ 2.5:** 32b → **100% GPU, 2.77 tok/s** (6.4× faster), now using all four dies. `14b`
+  stays 100% on GPU with **no `failed to allocate compute buffers`** — the OOM-guard passes.
+- **A single constant suffices** here — no conditional fix needed. 2.5 satisfies both the fit (32b)
+  and the OOM-guard (14b).
+- **Why 2.5, not 2.0:** the failure modes are asymmetric — too high merely offloads (slow but
+  works), too low fails to allocate (won't load). So we pick the **highest** value that still puts
+  32b 100% on GPU, maximizing the margin against the OOM the multiplier guards. 2.5 is that value
+  (3.0 already drops to 99%); 2.0 also works but sits further from the safety margin.
 
 ## How to reproduce
 

--- a/docs/reports/deepseek-r1-k80-vram-throughput.md
+++ b/docs/reports/deepseek-r1-k80-vram-throughput.md
@@ -24,7 +24,7 @@ onto the K80's GPUs** — *without* breaking small models or reintroducing the
 | Flash attention | off (forced off on sm_37) |
 | KV cache | f16 |
 | Context (`num_ctx`) | **16384** (the #352 repro — where the graph reservation is largest) |
-| `num_predict` | 128 |
+| `num_predict` | 16 — low on purpose: the broken (CPU-offloaded) 32b runs at ~0.3 tok/s, so 128 tokens exceeds the HTTP timeout. 16 lets it finish; offload%/VRAM are exact, tok/s is directional. Same value used for AFTER (apples-to-apples). |
 | Judge | simple |
 | **Only variable between BEFORE/AFTER** | `OLLAMA_GRAPH_SAFETY_MULTIPLIER` |
 
@@ -46,21 +46,30 @@ free pooled memory.
 
 | Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
 |---|---|---|---|---|
-| `deepseek-r1:1.5b` | _pending_ | | | |
-| `deepseek-r1:7b`   | _pending_ | | | |
-| `deepseek-r1:8b`   | _pending_ | | | |
-| `deepseek-r1:14b`  | _pending_ | | | |
-| `deepseek-r1:32b`  | _pending_ | | | |
+| `deepseek-r1:1.5b` | pass | 34.37 | 100% | 2 892 — die0 only |
+| `deepseek-r1:7b`   | _not pulled on runner — pending_ | | | |
+| `deepseek-r1:8b`   | _not pulled on runner — pending_ | | | |
+| `deepseek-r1:14b`  | pass | 6.05 | 100% | 19 838 — dies 0–2 |
+| `deepseek-r1:32b`  | pass | **0.43** | **93%** | 29 868 — 4 dies, **~15.9 GB free** |
+
+_Run [27952933017](https://github.com/dogkeeper886/ollama37/actions/runs/27952933017), git `f86abb1`,
+`num_predict=16`, `num_ctx=16384`. (`Check=pass` only means the response was non-empty — 32b
+"passes" but at 0.43 tok/s it is effectively unusable.)_
+
+**Headline:** only **32b** reproduces #352 — 7% of layers stranded on CPU with **~15.9 GB VRAM free**,
+collapsing throughput to **0.43 tok/s**. **14b is 100% on GPU** (6.05 tok/s) and 1.5b trivially so —
+so at 16k, the per-die over-reservation only bites the 32b's footprint. Calibration target = **32b**;
+**14b = the OOM-guard** (currently healthy at 3.5×, must stay healthy when the multiplier drops).
 
 ## AFTER — `OLLAMA_GRAPH_SAFETY_MULTIPLIER` = _&lt;calibrated&gt;_
 
 | Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
 |---|---|---|---|---|
-| `deepseek-r1:1.5b` | _pending_ | | | |
-| `deepseek-r1:7b`   | _pending_ | | | |
-| `deepseek-r1:8b`   | _pending_ | | | |
-| `deepseek-r1:14b`  | _pending_ | | | |
-| `deepseek-r1:32b`  | _pending_ | | | |
+| `deepseek-r1:1.5b` | _pending run_ | | | |
+| `deepseek-r1:7b`   | _not pulled on runner — pending_ | | | |
+| `deepseek-r1:8b`   | _not pulled on runner — pending_ | | | |
+| `deepseek-r1:14b`  | _pending run_ | | | |
+| `deepseek-r1:32b`  | _pending run_ | | | |
 
 ## Analysis
 

--- a/docs/reports/deepseek-r1-k80-vram-throughput.md
+++ b/docs/reports/deepseek-r1-k80-vram-throughput.md
@@ -1,0 +1,92 @@
+# DeepSeek-R1 on Tesla K80 — VRAM & Throughput, before/after the graph-multiplier change
+
+**Issue:** [#352](https://github.com/dogkeeper886/ollama37/issues/352) — large models offload to CPU with VRAM free
+**Branch:** `issue-352-plan-a-graph-multiplier`
+**Status:** _data pending — tables below are populated from K80 runs_
+
+## Purpose
+
+Measure whether lowering the fork-only `graphSafetyMultiplier` (the 3.5× compute-graph
+over-reservation in `llm/memory.go`) moves large legacy-engine DeepSeek-R1 models **off CPU
+onto the K80's GPUs** — *without* breaking small models or reintroducing the
+`failed to allocate compute buffers` OOM the 3.5× was added to guard.
+
+#352 is a **per-die accounting** bug, not a capacity bug: the model fits in pooled VRAM, but the
+3.5× graph reservation is charged to *every* die, so layers stop fitting per-die and spill to CPU
+**while pooled VRAM sits free**. Lowering the multiplier should reclaim that wrongly-reserved VRAM.
+
+## Hardware & configuration
+
+| | |
+|---|---|
+| Runner | Tesla K80 — 4 × 12 GB dies (~45.8 GB pooled) |
+| Engine | legacy llama.cpp (every size below is `qwen2`/`llama` arch → legacy path, the one with the static estimator) |
+| Flash attention | off (forced off on sm_37) |
+| KV cache | f16 |
+| Context (`num_ctx`) | **16384** (the #352 repro — where the graph reservation is largest) |
+| `num_predict` | 128 |
+| Judge | simple |
+| **Only variable between BEFORE/AFTER** | `OLLAMA_GRAPH_SAFETY_MULTIPLIER` |
+
+Columns come straight from `cli.ts bench-throughput`: **Gen tok/s**, **GPU%** (higher = more layers
+on GPU), **VRAM used (MiB)**. A model that offloads shows *low GPU% + low tok/s + low VRAM* despite
+free pooled memory.
+
+## Models under test
+
+| Tag | Arch | ~Weights (Q4_K_M) | Single-die or multi-die |
+|---|---|---|---|
+| `deepseek-r1:1.5b` | qwen2 | ~1.1 GB | 1 die |
+| `deepseek-r1:7b` | qwen2 | ~4.7 GB | 1 die |
+| `deepseek-r1:8b` | llama | ~4.9 GB | 1 die |
+| `deepseek-r1:14b` | qwen2 | ~9 GB | 1–2 dies |
+| `deepseek-r1:32b` | qwen2 | ~20 GB | 3–4 dies |
+
+## BEFORE — `OLLAMA_GRAPH_SAFETY_MULTIPLIER` unset (= 3.5, default)
+
+| Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
+|---|---|---|---|---|
+| `deepseek-r1:1.5b` | _pending_ | | | |
+| `deepseek-r1:7b`   | _pending_ | | | |
+| `deepseek-r1:8b`   | _pending_ | | | |
+| `deepseek-r1:14b`  | _pending_ | | | |
+| `deepseek-r1:32b`  | _pending_ | | | |
+
+## AFTER — `OLLAMA_GRAPH_SAFETY_MULTIPLIER` = _&lt;calibrated&gt;_
+
+| Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
+|---|---|---|---|---|
+| `deepseek-r1:1.5b` | _pending_ | | | |
+| `deepseek-r1:7b`   | _pending_ | | | |
+| `deepseek-r1:8b`   | _pending_ | | | |
+| `deepseek-r1:14b`  | _pending_ | | | |
+| `deepseek-r1:32b`  | _pending_ | | | |
+
+## Analysis
+
+_Filled once both passes are in:_
+- Which sizes offloaded BEFORE (low GPU%/tok/s with free VRAM) and recovered AFTER.
+- OOM check: did 14b / 32b load without `failed to allocate compute buffers` at the AFTER value?
+- Whether a **single** multiplier satisfies all sizes, or the data shows a single constant can't
+  (large wants it low, the OOM-guard wants it high) → conditional fix needed.
+- **Chosen value:** the lowest multiplier keeping large models on GPU without OOM.
+
+## How to reproduce
+
+The throughput workflow measures whatever is **deployed** on the runner; it does not set the
+multiplier. So each pass is *deploy → run*:
+
+**BEFORE** (default 3.5×, current deployment):
+```
+gh workflow run test-throughput.yml \
+  -f models="deepseek-r1:1.5b deepseek-r1:7b deepseek-r1:8b deepseek-r1:14b deepseek-r1:32b" \
+  -f context_size=16384
+```
+
+**AFTER** (on the runner): build & deploy the `issue-352-plan-a-graph-multiplier` image, set the
+value in `docker/.env`, restart, then run the same workflow:
+```
+echo "OLLAMA_GRAPH_SAFETY_MULTIPLIER=1.5" >> docker/.env   # try 2.0 / 1.5 / ...
+docker compose up -d --force-recreate
+# then the same `gh workflow run test-throughput.yml ...` as above
+```

--- a/docs/reports/deepseek-r1-k80-vram-throughput.md
+++ b/docs/reports/deepseek-r1-k80-vram-throughput.md
@@ -47,8 +47,8 @@ free pooled memory.
 | Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
 |---|---|---|---|---|
 | `deepseek-r1:1.5b` | pass | 34.37 | 100% | 2 892 — die0 only |
-| `deepseek-r1:7b`   | _not pulled on runner — pending_ | | | |
-| `deepseek-r1:8b`   | _not pulled on runner — pending_ | | | |
+| `deepseek-r1:7b`   | pass | 11.32 | 100% | 8 270 — die0 |
+| `deepseek-r1:8b`   | pass | 11.33 | 100% | 8 399 — die0 |
 | `deepseek-r1:14b`  | pass | 6.05 | 100% | 19 838 — dies 0–2 |
 | `deepseek-r1:32b`  | pass | **0.43** | **93%** | 29 868 — 4 dies, **~15.9 GB free** |
 
@@ -66,8 +66,8 @@ so at 16k, the per-die over-reservation only bites the 32b's footprint. Calibrat
 | Model | Check | Gen tok/s | GPU% | VRAM used (MiB) |
 |---|---|---|---|---|
 | `deepseek-r1:1.5b` | pass | 34.34 | 100% | 2 892 — die0 |
-| `deepseek-r1:7b`   | _not pulled on runner — pending_ | | | |
-| `deepseek-r1:8b`   | _not pulled on runner — pending_ | | | |
+| `deepseek-r1:7b`   | pass | 11.34 | 100% | 8 270 — die0 |
+| `deepseek-r1:8b`   | pass | 11.37 | 100% | 8 399 — die0 |
 | `deepseek-r1:14b`  | pass | 5.85 | 100% | 17 862 — dies 0–1 |
 | `deepseek-r1:32b`  | pass | **2.77** | **100%** | 34 008 — 4 dies (uses the once-stranded VRAM) |
 
@@ -83,7 +83,9 @@ so at 16k, the per-die over-reservation only bites the 32b's footprint. Calibrat
 ## Analysis
 
 - **BEFORE:** only `deepseek-r1:32b` reproduced #352 — 93% GPU / 0.43 tok/s with ~15.9 GB free.
-  `14b` and `1.5b` were already 100% on GPU. The bug needs the 32b's multi-die footprint.
+  `14b`, `8b`, `7b`, and `1.5b` were already 100% on GPU. The bug needs the 32b's multi-die footprint.
+- **Small models are multiplier-neutral:** `7b`/`8b` (single-die) read **100% GPU at both 3.5 and
+  2.5** (~11.3 tok/s, flat) — the fix changes nothing for models that already fit one die.
 - **AFTER @ 2.5:** 32b → **100% GPU, 2.77 tok/s** (6.4× faster), now using all four dies. `14b`
   stays 100% on GPU with **no `failed to allocate compute buffers`** — the OOM-guard passes.
 - **A single constant suffices** here — no conditional fix needed. 2.5 satisfies both the fit (32b)

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -401,8 +401,8 @@ func estimateGPULayers(gpus []ml.DeviceInfo, f *ggml.GGML, projectors []string, 
 	// can't adopt without breaking the CUDA-11.4 / sm_37 pin.
 	graphSafetyMultiplier := 2.5
 	if v := os.Getenv("OLLAMA_GRAPH_SAFETY_MULTIPLIER"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
-			graphSafetyMultiplier = f
+		if m, err := strconv.ParseFloat(v, 64); err == nil && m > 0 {
+			graphSafetyMultiplier = m
 		}
 	}
 	graphPartialOffload = uint64(float64(graphPartialOffload) * graphSafetyMultiplier)

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/ollama/ollama/api"
@@ -384,14 +385,22 @@ func estimateGPULayers(gpus []ml.DeviceInfo, f *ggml.GGML, projectors []string, 
 	// - Grouped-query attention (GQA): Complex attention patterns need more workspace
 	// - MoE architectures: Multiple expert activations need simultaneous storage
 	//
-	// SOLUTION: Apply 3.5× conservative safety margin to prevent allocation failures.
+	// SOLUTION: Apply a conservative safety margin to prevent allocation failures.
 	// This ensures GPU selection uses realistic memory requirements, enabling proper
 	// multi-GPU distribution when needed.
 	//
-	// TRADE-OFF: May cause some models to use 2 GPUs when 1 GPU might suffice,
-	// but prevents catastrophic allocation failures. Future improvement: implement
-	// measurement-based approach using llama_measure_memory_requirements() API.
+	// TRADE-OFF: too high over-reserves — on the K80's small 12 GB dies the default
+	// 3.5× reserves so much graph per die that large models (deepseek-r1:32b) offload
+	// to CPU with VRAM free (#352); too low risks the allocation failures this guards.
+	// The right value is layout-dependent, so it's tunable via the env var below for
+	// K80 calibration. Future fix: measurement-based estimate (upstream's BackendMemory),
+	// which the fork can't adopt without breaking the CUDA-11.4 / sm_37 pin.
 	graphSafetyMultiplier := 3.5
+	if v := os.Getenv("OLLAMA_GRAPH_SAFETY_MULTIPLIER"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			graphSafetyMultiplier = f
+		}
+	}
 	graphPartialOffload = uint64(float64(graphPartialOffload) * graphSafetyMultiplier)
 	graphFullOffload = uint64(float64(graphFullOffload) * graphSafetyMultiplier)
 

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -389,13 +389,17 @@ func estimateGPULayers(gpus []ml.DeviceInfo, f *ggml.GGML, projectors []string, 
 	// This ensures GPU selection uses realistic memory requirements, enabling proper
 	// multi-GPU distribution when needed.
 	//
-	// TRADE-OFF: too high over-reserves — on the K80's small 12 GB dies the default
-	// 3.5× reserves so much graph per die that large models (deepseek-r1:32b) offload
+	// TRADE-OFF: too high over-reserves — on the K80's small 12 GB dies the original
+	// 3.5× reserved so much graph per die that large models (deepseek-r1:32b) offloaded
 	// to CPU with VRAM free (#352); too low risks the allocation failures this guards.
-	// The right value is layout-dependent, so it's tunable via the env var below for
-	// K80 calibration. Future fix: measurement-based estimate (upstream's BackendMemory),
-	// which the fork can't adopt without breaking the CUDA-11.4 / sm_37 pin.
-	graphSafetyMultiplier := 3.5
+	// The two failure modes are asymmetric (too high → slow CPU offload; too low → won't
+	// load), so we bias toward the margin. 2.5 was calibrated on the K80: the highest
+	// value that keeps deepseek-r1:32b 100% on GPU at 16k (0.43→2.77 tok/s) while
+	// deepseek-r1:14b still fits without OOM — see
+	// docs/reports/deepseek-r1-k80-vram-throughput.md. Tunable via the env var below.
+	// Future fix: measurement-based estimate (upstream's BackendMemory), which the fork
+	// can't adopt without breaking the CUDA-11.4 / sm_37 pin.
+	graphSafetyMultiplier := 2.5
 	if v := os.Getenv("OLLAMA_GRAPH_SAFETY_MULTIPLIER"); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
 			graphSafetyMultiplier = f


### PR DESCRIPTION
## Summary
- **Root cause:** the fork-only `graphSafetyMultiplier = 3.5` (`llm/memory.go`) inflates the compute-graph estimate and reserves it on *every* K80 die, so large models offload to CPU while pooled VRAM sits free (#352). It's a per-die accounting bug, not a capacity bug.
- **Fix:** lower the default to **2.5** — the highest value that keeps `deepseek-r1:32b` 100% on GPU at 16k while `deepseek-r1:14b` still loads without `failed to allocate compute buffers`. The failure modes are asymmetric (too high → slow CPU offload; too low → won't load), so we bias toward the margin. Overridable via `OLLAMA_GRAPH_SAFETY_MULTIPLIER`.
- **Why not the "upstream" fix:** upstream deleted its static estimator for a measured `BackendMemory`/`-ngl auto` path the fork's pinned llama.cpp can't provide without breaking the CUDA-11.4/sm_37 pin. The estimator is now fork-owned, so tuning it is maintenance, not divergence. (Routing `qwen2` to the new engine was tried and failed; details on the issue.)

**Calibration (K80, deepseek-r1:32b @ ctx 16384):**

| multiplier | 32b GPU% | 32b tok/s |
|---|---|---|
| 3.5 (orig) | 93% | 0.43 |
| 3.0 | 99% | 1.40 |
| **2.5 (new default)** | **100%** | **2.77** |

Full 5-model before/after + sweep: `docs/reports/deepseek-r1-k80-vram-throughput.md`.

Fixes #352

## Test plan
- [x] `deepseek-r1:32b` @ 16k: 93%/0.43 tok/s → **100%/2.77 tok/s** on the K80
- [x] `deepseek-r1:14b` OOM-guard: stays 100% GPU, no `failed to allocate compute buffers`
- [x] `1.5b`/`7b`/`8b` (single-die): 100% GPU at both 3.5 and 2.5 (fix is neutral for small models)
- [ ] **Build CI is currently blocked** — the runner's `ollama37-builder:latest` image was pruned, so `test-build` does a cold toolchain rebuild that exceeds the 1h `TC-BUILD-002` timeout. Needs the builder image restored on the runner (runner-side, unrelated to this diff) before build-CI can pass.

Generated with [Claude Code](https://claude.com/claude-code)