### PR TITLE
docs: STORY-016 lfm2.5 support + TS-04 model test case (TC-016)

### DIFF
--- a/cicd/tests/testcases/models/TC-MODELS-017.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-017.yml
@@ -1,0 +1,75 @@
+id: TC-MODELS-017
+name: lfm2.5:8b-a1b Inference
+suite: models
+priority: 17
+timeout: 900000
+dependencies: []
+intent:
+  user_story: |
+    Validate lfm2.5:8b-a1b (Liquid LFM2 MoE, 8B total / ~1B active, ~5.2 GB) runs on
+    K80 compute 3.7 (single GPU). Acceptance for STORY-016: the fork already vendors the
+    lfm2/lfm2moe llama.cpp arch, so this gates that the GGUF loads and generates coherently
+    once the Go parser/renderer port lands — red until then.
+  notes: |
+    Prerequisite: lfm2.5:8b-a1b pre-pulled on the runner. The request pins "think": false
+    so the answer isn't buried inside a <think> span (lfm2.5 has a thinking mode).
+    Acceptable warning (NOT an error): "flash attention enabled but not supported by gpu".
+
+steps:
+  - name: Test inference
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"lfm2.5:8b-a1b","prompt":"What is 2+2? Answer briefly.","stream":false,"think":false,"options":{"num_predict":200}}' \
+        | head -c 2000
+    expectPatterns:
+      - "response"
+    rejectPatterns:
+      - "CUBLAS_STATUS"
+      - "CUDA error"
+
+  - name: Check GPU memory
+    command: docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    expectPatterns:
+      - "[0-9]+ MiB"
+
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
+  - name: Unload model
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"lfm2.5:8b-a1b","keep_alive":0}'
+      echo "Model unloaded"
+    expectPatterns:
+      - "Model unloaded"
+
+criteria: |
+  Validate lfm2.5:8b-a1b (Liquid LFM2 MoE, ~5.2 GB VRAM) runs on K80 (compute 3.7).
+  Prerequisite: Model must be pre-pulled before running this test.
+
+  Expected:
+  - API returns JSON with "response" field (coherent, no garbage)
+  - GPU memory is allocated (visible in nvidia-smi)
+  - GPU count: ~5.2 GB fits a single K80 die (11441 MiB), so GPU_COUNT_OK on one GPU.
+  - No CUDA/CUBLAS errors in output
+  - Model unloads successfully
+
+  Acceptable warnings (NOT errors):
+  - "flash attention enabled but not supported by gpu" - K80 does not support
+    flash attention, this is a normal fallback warning, NOT an error

--- a/docs/stories/STORY-016.md
+++ b/docs/stories/STORY-016.md
@@ -64,4 +64,5 @@ both are out of scope here.
 ## Status
 
 - Created: 2026-07-09
-- Issues: none
+- Docs PR: #377 (story + TS-04 TC-16 + TC-MODELS-017.yml)
+- Issues: none — port issue to follow via `dw-plan`

--- a/docs/stories/STORY-016.md
+++ b/docs/stories/STORY-016.md
@@ -1,0 +1,67 @@
+# STORY-016: Support lfm2.5 (Liquid LFM2 MoE) on the K80, with CI coverage
+
+## User Story
+
+As a maintainer running models on the Tesla K80,
+I want lfm2.5:8b-a1b to run coherently and make real tool calls on the K80, and to be
+exercised by the model, throughput, and MCP CI suites on the self-hosted runner,
+So that the fork gains a fast on-device MoE with verified tool-calling, regression-guarded
+like every other supported model.
+
+## The Need
+
+`ollama.com/library/lfm2.5` is Liquid AI's hybrid LFM2 MoE (8B total / ~1B active,
+~5.2 GB, 125K context) — a text model with tool-calling and thinking. At ~5.2 GB it fits
+on a single K80, and a 1B-active MoE is the kind of workload the K80 handles well.
+
+The fork is already most of the way there: the vendored llama.cpp carries the
+LFM2/LFM2MOE architecture (arch enums, compute graph, tensor schema), so the GGUF can load
+and run. What's missing is the Go-side glue that upstream already has — the tool-call
+parser and the prompt renderer (and the import converter). Without the parser and renderer,
+lfm2.5 can emit text but cannot make grounded tool calls, so it can't be trusted for the
+agentic / MCP workloads this fork cares about.
+
+The model also isn't in CI yet. Every supported model earns a model-suite regression, and
+the tool-calling and throughput behaviour should be measured on the real K80 runner rather
+than assumed. A reviewed test doc should drive that coverage before the implementation is
+accepted.
+
+Scope is the text lfm2.5:8b-a1b (text + tools + thinking). The vision variant is a separate
+model (lfm2.5-vl) with its own converter, and there is no audio variant in upstream code —
+both are out of scope here.
+
+## Success Looks Like
+
+- `ollama run lfm2.5:8b-a1b` produces coherent output on the K80 — no CUDA/CUBLAS errors,
+  no garbage — and the model fits within a single K80 GPU.
+- lfm2.5 makes **real, grounded tool calls**: the MCP tool-call test passes on the
+  self-hosted runner — the model calls a real tool and its final answer is grounded in the
+  tool result (not hallucinated). This is the hard bar.
+- A **reviewed QA test doc** (qa-workflow) exists and drives the model-suite regression
+  (TC-MODELS-017), reviewed before the implementation is accepted.
+- lfm2.5 is covered by all three suites on the self-hosted K80 runner, with results
+  captured: the model suite (regression YAML), the throughput benchmark, and the MCP
+  tool-call probe.
+- Honesty note: throughput is whatever the K80 delivers for a 1B-active MoE — reported,
+  not held to a target. If K80 tool-calling needs iteration to land, that is surfaced in
+  the results, not hidden.
+
+## Open Questions
+
+- How much of upstream's lfm2 surface actually needs porting: are the parser and renderer
+  enough (they are required for tool-calling), or is `convert/convert_lfm2.go` also needed
+  — i.e. does pulling the prebuilt library GGUF avoid the import/convert path entirely?
+- Does the "thinking" variant matter for lfm2.5:8b-a1b, or is the non-thinking renderer/parser
+  enough? (Upstream registers both `lfm2` and `lfm2-thinking`.)
+- Does lfm2's short-convolution (LIV) path hit any K80 op that is missing or slow on
+  compute 3.7 (as happened with the gemma4 / DeltaNet ports), or does the already-vendored
+  compute graph just work?
+- For throughput and MCP, models are dispatch-time inputs, not YAML — should their default
+  model lists be updated to include lfm2.5, or is a documented manual dispatch enough?
+- VL and Audio: file the vision variant (lfm2.5-vl) as its own story if wanted; there is no
+  audio implementation upstream to port.
+
+## Status
+
+- Created: 2026-07-09
+- Issues: none

--- a/docs/tests/TS-04-models.md
+++ b/docs/tests/TS-04-models.md
@@ -14,7 +14,7 @@ The build/runtime/inference suites prove the *stack* works; this scenario proves
 GPU count, and no `CUBLAS_STATUS` / `CUDA error`, with the model unloaded afterwards to free VRAM
 for the next. It is the per-model regression half of [STORY-005](../stories/STORY-005.md). Each
 case is one model; `Script:` carries the real `TC-MODELS-*.yml` (the YAML ids skip `010` and run
-to `015`).
+to `017`).
 
 Every case runs the same four steps unless noted:
 
@@ -201,6 +201,18 @@ Every case runs the same four steps unless noted:
 | # | Action | Expected Result |
 |---|--------|-----------------|
 | 1 | Test inference | returns a `response`; no `unknown model architecture: 'gemma4'` fallback, no `CUBLAS_STATUS` / `CUDA error` |
+| 2 | Check GPU memory | reports non-zero `MiB` in use |
+| 3 | Check GPU count | `GPU_COUNT_OK` (not `GPU_COUNT_EXCEEDED`) |
+| 4 | Unload model | `Model unloaded` |
+
+### TC-16: lfm2.5:8b-a1b (Liquid LFM2 MoE)
+
+- **Objective:** lfm2.5:8b-a1b — the text LFM2 **MoE** (8B total / ~1B active, ~5.2 GB) — runs on K80 compute 3.7 (single GPU). The per-model regression half of [STORY-016](../stories/STORY-016.md): the fork already vendors the `lfm2`/`lfm2moe` llama.cpp arch, so this case gates that the GGUF loads and generates coherently once STORY-016's Go parser/renderer port lands — **red until then**. The inference step pins `"think": false` so the deterministic answer isn't buried inside a `<think>` span (lfm2.5 has a thinking mode). Run under the **dual** judge at least once so "coherent, not fluent garbage" is actually checked, not just non-empty `response`.
+- **Script:** cicd/tests/testcases/models/TC-MODELS-017.yml
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Test inference | returns a `response`; no `CUBLAS_STATUS` / `CUDA error` |
 | 2 | Check GPU memory | reports non-zero `MiB` in use |
 | 3 | Check GPU count | `GPU_COUNT_OK` (not `GPU_COUNT_EXCEEDED`) |
 | 4 | Unload model | `Model unloaded` |


### PR DESCRIPTION
## Summary

The study + paperwork for supporting [ollama.com/library/lfm2.5](https://ollama.com/library/lfm2.5) (the text LFM2 MoE, `lfm2.5:8b-a1b`) on the K80 and covering it in CI. **Docs only — no runnable code changes.**

- **`docs/stories/STORY-016.md`** — the need: run `lfm2.5:8b-a1b` coherently and make real, grounded tool calls on the K80, covered by the model / throughput / MCP suites on the self-hosted runner. Scope is text-only (VL is a separate model; no audio exists upstream). The vendored llama.cpp already carries the `lfm2`/`lfm2moe` arch; the gap is the Go parser/renderer — that's the MCP-must-pass bar deferred to the port.
- **`docs/tests/TS-04-models.md`** — new **TC-16** (`lfm2.5:8b-a1b`) per-model regression; bumps the intro YAML-id range to `017`.
- **`cicd/tests/testcases/models/TC-MODELS-017.yml`** — the bound executable (4 steps: inference / GPU memory / GPU count / unload). `think:false` pins a deterministic answer. **Red until the port lands** — same as gemma4's TC-15 was.

MCP + throughput coverage is parametric (dispatch-time model inputs), so lfm2.5 rides the existing TS-05 / TS-06 cases with no doc change here.

Part of STORY-016. No issue linkage — this is the story-creation step; the port issue comes next via `dw-plan`.

Gated locally through the qa-workflow (`qw-plan` → `qw-review-plan` → `qw-cases` → `qw-review-cases`) and `dw-review-implement` — all PASS.

## Test plan
- [ ] Docs render correctly (story + TS-04 TC-16 table)
- [ ] `TC-MODELS-017.yml` parses and its 4 steps match the TC-16 doc rows (binding invariant)
- [ ] Cross-references resolve (`STORY-016.md`, `TC-MODELS-017.yml`)
- [ ] The model test itself stays red until STORY-016's parser/renderer port lands (expected)

Generated with [Claude Code](https://claude.com/claude-code)