### PR TITLE
docs/reports: K80 sweep on d83061de — no-harm check after lfm2.5 merge

### DIFF
--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -21,12 +21,14 @@ place or mixed across builds; the pre-versioning (mixed-build) reports live in g
 
 | Snapshot | Build | Swept | Notes |
 |---|---|---|---|
+| [`…-2026-07-10-d83061de.md`](./k80-vram-by-family-2026-07-10-d83061de.md) | `d83061de` | 2026-07-10 | **Latest.** 14 models (+`lfm2.5:8b`, new `lfm2` family, ~33 tok/s). No-harm vs `c282ba37`: 49/51 rows within ±3 %. gemma4:26b @8k+ now spreads to 4 dies (−9 %) — gemma4/KV-graph effect, not lfm2. |
 | [`…-2026-06-29-c282ba37.md`](./k80-vram-by-family-2026-06-29-c282ba37.md) | `c282ba37` | 2026-06-29 | First clean single-build sweep (all 13 models). gemma4:12b now on GPU; `swa_full` windowed cache reclaims its 16k VRAM. e4b@2k cold-load artifact published + flagged. |
 
 ### Capability axis — MCP tool-call
 
 | Snapshot | Build | Swept | Notes |
 |---|---|---|---|
+| [`…-2026-07-10-d83061de.md`](./k80-mcp-by-family-2026-07-10-d83061de.md) | `d83061de` | 2026-07-10 | **Latest — T1 @8k only** (16k thermal-aborted at 81 °C, twice). 14 models (+`lfm2.5:8b`). 0 verdict regressions vs `c282ba37`; `deepseek-r1:8b-tools` ❌→✅; `lfm2.5:8b` ✅; 9/14 PASS. |
 | [`…-2026-06-29-c282ba37.md`](./k80-mcp-by-family-2026-06-29-c282ba37.md) | `c282ba37` | 2026-06-29 | **T1 only.** gemma4:12b: fails-to-load (main) → loads + 16k T1 ✅ (8k over-explores the menu). 0 verdict changes vs main; 15/26 PASS. |
 | [`k80-mcp-by-family.md`](./k80-mcp-by-family.md) | pre-versioning (mixed) | 2026-06-23 era | The older T1+**T2** report (gemma4:12b shown as fails-to-load). Kept for T2 until a clean T1+T2 re-sweep produces a versioned snapshot. |
 

--- a/docs/reports/k80-mcp-by-family-2026-07-10-d83061de.md
+++ b/docs/reports/k80-mcp-by-family-2026-07-10-d83061de.md
@@ -1,0 +1,94 @@
+# K80 MCP tool-call capability by family — T1 @8k
+
+Can each model drive a **real** MCP server (testlink-mcp) for the T1 task — `List the projects.` —
+under **verify-live** (the model must call `list_projects` *and* its answer must match live data),
+with a playwright distractor server raising the tool-menu difficulty. Companion to the VRAM/throughput report.
+
+## Setup
+
+| | |
+|---|---|
+| Build | ollama `d83061de` · branch `main` — lfm2 (LFM2 MoE) support merged (#383, STORY-016) |
+| Swept | 2026-07-10 — T1 only, **8k only** (see thermal note), 14 models (13 baseline + lfm2.5:8b) |
+| Version caveat | binary self-reports `2.1.0`; commit recovered from the deploy pipeline (build does not yet embed its git SHA) |
+| T1 | `List the projects.` · verify-live allow `list_projects` |
+| Server | testlink-mcp (docker) + playwright distractor menu |
+| Context | 8k only |
+| Verdict | ✅ pass · ❌ fail (called wrong/extra tools, or answer ≠ live data) · 🚫 no tool support |
+
+> **16k not measured — thermal.** The 16k T1 sweep hit the GPU temperature guard (peak **81 °C** >
+> 80 °C limit) and was killed early, twice, even from a cold start — ambient is ~1 °C hotter than the
+> `c282ba37` sweep (which peaked at exactly 80 °C). This snapshot is **T1 @8k only**; a clean 8k+16k
+> re-sweep awaits cooler conditions or a per-model cooldown.
+>
+> **peak°C omitted** — the aggregate does not capture per-model peak temperature (the guard logs only
+> the run-level peak); the column is elided rather than filled with placeholders.
+
+> **No-harm vs `c282ba37` (8k):** **0 verdict regressions.** One *improvement* — `deepseek-r1:8b-tools`
+> ❌→✅ — and the new `lfm2.5:8b` passes. All 11 other 8k verdicts are unchanged.
+
+---
+
+## deepseek-r1
+
+| Model | ctx | T1 | tool calls | prompt_tok | time_s | tok/s |
+|---|---|:--:|---|--:|--:|--:|
+| `deepseek-r1:1.5b-tools` | 8k | ❌ | - | 5375 | 47.16 | 15.84 |
+| `deepseek-r1:7b-tools`   | 8k | ❌ | - | 5375 | 176.06 | 6.02 |
+| `deepseek-r1:8b-tools`   | 8k | ✅ | list_projects | 5971 | 305.22 | 4.9 |
+| `deepseek-r1:14b-tools`  | 8k | ❌ | - | 5375 | 202.83 | 2.92 |
+| `deepseek-r1:32b-tools`  | 8k | ✅ | list_projects | 5983 | 576.88 | 1.62 |
+
+> `deepseek-r1:8b-tools` — ❌ on `c282ba37` (over-looped `list_projects`), now **✅** at 8k: a single
+> clean call. The 1.5b/7b/14b-tools variants still fail (14b over-calls, 1.5b/7b emit no valid call).
+
+---
+
+## gemma4
+
+| Model | ctx | T1 | tool calls | prompt_tok | time_s | tok/s |
+|---|---|:--:|---|--:|--:|--:|
+| `gemma4:e2b` | 8k | ❌ | list_projects | 6801 | 62.23 | 15.95 |
+| `gemma4:e4b` | 8k | ✅ | list_projects | 6801 | 159.01 | 10.31 |
+| `gemma4:12b` | 8k | ❌ | - | 0 | 0 | 0 |
+| `gemma4:26b` | 8k | ✅ | list_projects | 6801 | 165.21 | 9.07 |
+| `gemma4:31b` | 8k | ✅ | list_projects | 6801 | 423.69 | 1.97 |
+
+> `gemma4:12b` @8k — zero-row (no tokens produced / run did not complete). On `c282ba37` it also
+> failed 8k (over-explored the menu) but passed 16k; the 16k re-check is blocked by the thermal cap
+> above. The split-vision gemma4:12b remains the fleet's most fragile model at 8k.
+
+---
+
+## qwen3.6
+
+| Model | ctx | T1 | tool calls | prompt_tok | time_s | tok/s |
+|---|---|:--:|---|--:|--:|--:|
+| `qwen3.6:27b` | 8k | ✅ | list_projects | 7592 | 675.83 | 2.19 |
+| `qwen3.6:35b` | 8k | ✅ | list_projects | 7592 | 332.98 | 6.86 |
+
+---
+
+## gpt-oss
+
+| Model | ctx | T1 | tool calls | prompt_tok | time_s | tok/s |
+|---|---|:--:|---|--:|--:|--:|
+| `gpt-oss:20b` | 8k | ✅ | list_projects | 3838 | 103.27 | 10.26 |
+
+---
+
+## lfm2
+
+| Model | ctx | T1 | tool calls | prompt_tok | time_s | tok/s |
+|---|---|:--:|---|--:|--:|--:|
+| `lfm2.5:8b` | 8k | ✅ | list_projects | 7132 | 114.74 | 20.15 |
+
+> `lfm2.5:8b` (new, #383) — clean single `list_projects` call, answer grounded against live testlink
+> data, at 20 tok/s (the fastest tool-caller in the fleet). **Caveat:** lfm2.5 tool-calling works for
+> no-argument tools like T1; **typed-argument** tools (T2's `list_test_suites(project_id=…)`) are
+> blocked by the pre-existing, model-agnostic server bug **#382**, so T2 is out of scope here.
+
+---
+
+**Tally:** 9/14 PASS at 8k. **vs `c282ba37`:** 0 verdict regressions; `deepseek-r1:8b-tools` newly
+passes (❌→✅); `lfm2.5:8b` new ✅. 16k deferred (thermal).

--- a/docs/reports/k80-vram-by-family-2026-07-10-d83061de.md
+++ b/docs/reports/k80-vram-by-family-2026-07-10-d83061de.md
@@ -1,0 +1,139 @@
+# K80 VRAM & Throughput by Model Family
+
+How models across families place on the Tesla K80 — per-die VRAM, GPU vs CPU
+placement, and throughput — swept over context length. Run with the #352 fix live
+(`graphSafetyMultiplier` default 2.5). For tool-call capability see the companion
+report `k80-mcp-by-family.md`.
+
+## Setup
+
+| | |
+|---|---|
+| Hardware | 4 × Tesla K80 · 11441 MiB/die (~45.8 GB pooled) |
+| Engine | per-model (legacy llama.cpp or new ollama engine) |
+| Flash attention | off (sm_37) |
+| KV cache | f16 |
+| `graphSafetyMultiplier` | 2.5 (default, #352) |
+| Throughput | `num_predict=16` |
+| Context sweep | 2k / 4k / 8k / 16k |
+| Build | ollama `d83061de` · branch `main` — lfm2 (LFM2 MoE) support merged (#383, STORY-016) |
+| Swept | 2026-07-10 — full 14-model re-sweep (13 baseline + lfm2.5:8b), one model per run |
+| Version caveat | the binary self-reports `2.1.0`; the commit is recovered from the deploy pipeline (the build does not yet embed its git SHA — tracked follow-up) |
+
+## Reading the metrics
+
+- **GPU%** — layers on GPU (100% = fully on GPU; lower = CPU offload).
+- **d0–d3** — per-die VRAM used (MiB). Shows the layer distribution across the four dies.
+- **tok/s** — generation throughput.
+- **Context (2k→16k)** — footprint = weights + KV(∝ctx) + graph(∝ctx)×2.5. The sweep maps
+  each model's **fit cliff** (the context where it tips from full GPU to CPU offload). Cross-read
+  with `k80-mcp-by-family.md`: an MCP fail there at high ctx while GPU% here is 100% is a
+  capability/truncation result, **not** a speed/offload artifact — this column disambiguates.
+
+> **No-harm vs `c282ba37`:** 49/51 shared (model × ctx) rows are within ±3 % on tok/s — the
+> `lfm2` merge did not regress the other families. The two exceptions are **gemma4:26b** @8k
+> (−8.8 %) and @16k (−3.2 %): on this build it now spreads across **all four dies** (was two),
+> so cross-die traffic costs ~9 % — a gemma4-family placement shift from the gemma4/KV-graph
+> changes merged since `c282ba37`, **not** lfm2 (which touches no GPU layer distribution).
+
+---
+
+## gemma4
+
+| Model | ctx | GPU% | d0 | d1 | d2 | d3 | tok/s |
+|---|---|---|--:|--:|--:|--:|--:|
+| `gemma4:e2b`       | 2k  | 100% | 7352 | 7 | 7 | 7 | 24.85 |
+|                    | 4k  | 100% | 7388 | 7 | 7 | 7 | 24.71 |
+|                    | 8k  | 100% | 7418 | 7 | 7 | 7 | 25.15 |
+|                    | 16k | 100% | 7495 | 7 | 7 | 7 | 25.03 |
+| `gemma4:e4b`       | 2k  | 100% | 9796 | 7 | 7 | 7 | 15.02 |
+|                    | 4k  | 100% | 9908 | 7 | 7 | 7 | 15.09 |
+|                    | 8k  | 100% | 9992 | 7 | 7 | 7 | 15.09 |
+|                    | 16k | 100% | 10155 | 7 | 7 | 7 | 15.04 |
+| `gemma4:12b`       | 2k  | 100% | 4575 | 8735 | 7 | 7 | 6.45 |
+|                    | 4k  | 100% | 4693 | 8791 | 7 | 7 | 6.29 |
+|                    | 8k  | 100% | 4935 | 8903 | 7 | 7 | 6.23 |
+|                    | 16k | 100% | 4155 | 3662 | 7983 | 7 | 6.42 |
+| `gemma4:26b`       | 2k  | 100% | 9295 | 9288 | 7 | 7 | 14.37 |
+|                    | 4k  | 100% | 9625 | 9472 | 7 | 7 | 14.19 |
+|                    | 8k  | 100% | 5229 | 4919 | 5021 | 5422 | 13.24 ⚠️ |
+|                    | 16k | 100% | 5416 | 5255 | 5325 | 5726 | 13.81 ⚠️ |
+| `gemma4:31b`       | 2k  | 100% | 7657 | 7769 | 7922 | 7 | 3.04 |
+|                    | 4k  | 100% | 8449 | 8577 | 8354 | 7 | 3.03 |
+|                    | 8k  | 100% | 8962 | 8793 | 9058 | 7 | 3.07 |
+|                    | 16k | 100% | 9682 | 9577 | 9776 | 7 | 3.08 |
+
+> ⚠️ `gemma4:26b` @8k/16k now spreads across **all four dies** (was two dies on `c282ba37`) and
+> drops from ~14.5 to ~13.2–13.8 tok/s (−9 % / −3 %). Cross-die traffic on the K80's slow links is
+> the cost. Attributable to gemma4/KV-graph changes merged since `c282ba37`, not lfm2 — flagged for
+> a follow-up.
+
+---
+
+## qwen3.6
+
+| Model | ctx | GPU% | d0 | d1 | d2 | d3 | tok/s |
+|---|---|---|--:|--:|--:|--:|--:|
+| `qwen3.6:27b`      | 2k  | 100% | 10634 | 10514 | 7 | 7 | 2.94 |
+|                    | 4k  | 100% | 10798 | 10678 | 7 | 7 | 2.94 |
+|                    | 8k  | 100% | 11126 | 11004 | 7 | 7 | 2.95 |
+|                    | 16k | 100% | 8344 | 8251 | 8222 | 7 | 3.02 |
+| `qwen3.6:35b`      | 2k  | 100% | 8156 | 8720 | 8308 | 7 | 10.59 |
+|                    | 4k  | 100% | 8236 | 8804 | 8390 | 7 | 10.71 |
+|                    | 8k  | 100% | 8968 | 8404 | 8550 | 7 | 10.55 |
+|                    | 16k | 100% | 9288 | 8740 | 8868 | 7 | 10.75 |
+
+---
+
+## deepseek-r1
+
+| Model | ctx | GPU% | d0 | d1 | d2 | d3 | tok/s |
+|---|---|---|--:|--:|--:|--:|--:|
+| `deepseek-r1:1.5b` | 2k  | 100% | 2350 | 7 | 7 | 7 | 34.38 |
+|                    | 4k  | 100% | 2406 | 7 | 7 | 7 | 34.07 |
+|                    | 8k  | 100% | 2518 | 7 | 7 | 7 | 34.16 |
+|                    | 16k | 100% | 2871 | 7 | 7 | 7 | 34.29 |
+| `deepseek-r1:7b`   | 2k  | 100% | 6831 | 7 | 7 | 7 | 11.38 |
+|                    | 4k  | 100% | 6943 | 7 | 7 | 7 | 11.11 |
+|                    | 8k  | 100% | 7358 | 7 | 7 | 7 | 11.15 |
+|                    | 16k | 100% | 8270 | 7 | 7 | 7 | 11.12 |
+| `deepseek-r1:8b`   | 2k  | 100% | 5459 | 7 | 7 | 7 | 11.3 |
+|                    | 4k  | 100% | 5879 | 7 | 7 | 7 | 11.12 |
+|                    | 8k  | 100% | 6719 | 7 | 7 | 7 | 11.11 |
+|                    | 16k | 100% | 8399 | 7 | 7 | 7 | 11.15 |
+| `deepseek-r1:14b`  | 2k  | 100% | 4829 | 7974 | 7 | 7 | 5.86 |
+|                    | 4k  | 100% | 5205 | 8227 | 7 | 7 | 5.87 |
+|                    | 8k  | 100% | 5957 | 8947 | 7 | 7 | 5.76 |
+|                    | 16k | 100% | 7461 | 10387 | 7 | 7 | 5.78 |
+| `deepseek-r1:32b`  | 2k  | 100% | 7346 | 7242 | 9993 | 7 | 2.85 |
+|                    | 4k  | 100% | 7698 | 7594 | 10222 | 7 | 2.84 |
+|                    | 8k  | 100% | 8402 | 8298 | 10894 | 7 | 2.85 |
+|                    | 16k | 100% | 8146 | 7644 | 7644 | 10574 | 2.76 |
+
+---
+
+## gpt-oss
+
+| Model | ctx | GPU% | d0 | d1 | d2 | d3 | tok/s |
+|---|---|---|--:|--:|--:|--:|--:|
+| `gpt-oss:20b`      | 2k  | 100% | 7382 | 7556 | 7 | 7 | 16.69 |
+|                    | 4k  | 100% | 7382 | 7556 | 7 | 7 | 16.72 |
+|                    | 8k  | 100% | 7382 | 7556 | 7 | 7 | 16.52 |
+|                    | 16k | 100% | 8520 | 8694 | 7 | 7 | 16.51 |
+
+---
+
+## lfm2
+
+| Model | ctx | GPU% | d0 | d1 | d2 | d3 | tok/s |
+|---|---|---|--:|--:|--:|--:|--:|
+| `lfm2.5:8b`        | 2k  | 100% | 6358 | 7 | 7 | 7 | 33.02 |
+|                    | 4k  | 100% | 6406 | 7 | 7 | 7 | 33.14 |
+|                    | 8k  | 100% | 6722 | 7 | 7 | 7 | 32.96 |
+|                    | 16k | 100% | 7346 | 7 | 7 | 7 | 32.97 |
+
+> `lfm2.5:8b` (LFM2 MoE, 8B total / ~1B active) — new in this build (#383). Fully on a single die
+> (~6.4 GB), flat ~33 tok/s across contexts — the fastest dense-feeling model in the fleet after the
+> deepseek-r1:1.5b (34 tok/s), and ~5× gemma4:12b at similar footprint.
+
+---


### PR DESCRIPTION
## Summary

New versioned K80 report snapshots on the current `main` build (`d83061de`, lfm2.5 merged in #383), produced by the full `test-report-sweep.yml` sweep + the `test-pipeline.yml` regression gate. Adds an **`lfm2` family**; matches the existing `c282ba37` format.

**This is the "did lfm2.5 harm the other models?" regression check** — the report versioning exists exactly so two snapshots of the same axis can be diffed to isolate a code effect from measurement drift.

### Result: no harm.
- **Throughput** (`k80-vram-by-family-2026-07-10-d83061de.md`, all 4 contexts, 14 models): **49/51 shared rows within ±3 %** of `c282ba37`. `lfm2.5:8b` ~33 tok/s, single die. The one outlier — **gemma4:26b −9 % @8k+** — is a **placement shift (2→4 dies) from the gemma4/KV-graph changes, not lfm2** (lfm2 touches no GPU layer distribution). Flagged for a follow-up.
- **MCP T1 @8k** (`k80-mcp-by-family-2026-07-10-d83061de.md`, 14 models): **0 verdict regressions**; one *improvement* (`deepseek-r1:8b-tools` ❌→✅); `lfm2.5:8b` ✅ (grounded `list_projects`, 20 tok/s).

### Honest caveats (in the snapshots)
- **MCP 16k not measured** — the 16k sweep hit the GPU thermal guard (peak **81 °C** > 80 °C) and was killed early, twice, even from a cold start (ambient ~1 °C hotter than the `c282ba37` sweep, which peaked at exactly 80 °C). Snapshot is **T1 @8k only**.
- **peak°C omitted** — not captured by the aggregate (guard logs only the run-level peak).
- `gemma4:12b` @8k is a zero-row (crashed — the known-fragile split-vision model).
- lfm2.5 **typed-argument** tool calls (T2) are blocked by the pre-existing, model-agnostic server bug **#382** — T1 (no-arg) works.

### Pipeline regression gate
`test-pipeline.yml` on `d83061de`: build/runtime/inference ✅, models **15/16** (only gemma4:e4b tripped the GPU-count criterion on a 93 MiB cold-load sliver — a documented artifact; **lfm2.5 passed clean**).

Release is out of scope here (deferred).

Generated with [Claude Code](https://claude.com/claude-code)