### PR TITLE
CI: labelled host selection + identify-host, plus the issue-writing rule and sm_75 notes

### DIFF
--- a/.claude/rules/github-issue.md
+++ b/.claude/rules/github-issue.md
@@ -1,0 +1,73 @@
+# Writing a GitHub issue
+
+An issue is read by someone with **no memory of the conversation that produced it** — a
+teammate months later, or an agent with a fresh context window. Write for that reader.
+
+## Mirror the template
+
+`gh issue create --body-file` **bypasses** `.github/ISSUE_TEMPLATE/*.yml`. The template's
+sections are still required — reproduce them by hand, reading the fields from the template
+itself rather than from memory:
+
+| Kind | Template |
+|---|---|
+| Something is broken | `bug.yml` |
+| Change existing behaviour | `enhancement.yml` |
+| New capability | `feature.yml` |
+| Take something out | `removal.yml` |
+
+Don't restate a template's fields here — read the file. It is the source of truth.
+
+## Add, on top of the template
+
+**Goal.** One sentence: what "done" looks like. The outcome, not the fix.
+
+**Plain words first.** The opening paragraphs must land for a reader who doesn't know CUDA.
+Jargon and `file:line` belong further down, not in the first thing they read.
+
+**The path.** Name the **model**, the **hardware**, and the **config**, then trace the chain to
+the failure with `file:line` at each hop. A problem statement without a path is a rumour; a path
+can be fixed by anyone.
+
+```
+# example — the real one lives in #385
+Model: <tag> (arch <name>)   Hardware: <card>, cc <x.y>   Config: <what was set>
+  <entry point> → … → <dispatch> → <failing call> → <observed failure>
+```
+
+**Observed vs predicted.** Label every claim; never let them blur.
+- *Observed* — you ran it and read the output or the log.
+- *Predicted* — you read the source and reasoned. Say so, and say what would confirm it.
+
+**Blast radius.** Which cards, which architectures, which engine. Be exact — a compute-capability
+threshold is a number, not a vibe. State what is **untested** rather than implying it is safe.
+
+**Scope / Non-goals.** What this issue does *not* do. The recurring ones here:
+- Don't edit upstream gates (`fs/ggml/`, `ml/`) — the next re-sync overwrites them.
+- Vendored `llama/llama.cpp/**` changes are a **port** into the numbered patch series
+  (`llama/patches/`), never a cherry-pick or a vendor bump. See `docs/porting-k80.md` §1.
+- Don't adapt the toolchain to the code. The CUDA version is load-bearing: it is what keeps
+  sm_37 alive.
+
+**Acceptance criteria.** Checkboxes. Always include the **K80 no-harm gate** — the K80 is the only
+hardware-validated target, so any change must leave its sweep unmoved. Use the tolerance and
+methodology recorded in `docs/reports/k80-vram-by-family-*.md`; don't invent a number here. If a
+change *should* be a no-op there, say so and make it a criterion.
+
+**Unverified.** An honest list of what you did not prove. An issue that claims more certainty than
+it earned is worse than one that admits a gap.
+
+**Links.** Parent issue, the comment holding the evidence, any plan or research doc.
+
+## The two failures this prevents
+
+1. **A confident wrong claim.** Benchmark before asserting an optimization helps
+   (`docs/porting-k80.md` §2). Label a hunch as a hunch. Flash attention on the K80 was assumed a
+   win and measured a large loss — see #337, #346.
+2. **A rumour with no path.** "FA is broken on Turing" is unactionable. The same claim with a
+   model, a card, and a call chain is a fix waiting to happen.
+
+## Right-size it
+
+A typo or a dead link does not need this. Use judgment. A crash, a silent wrong answer, or anything
+someone will act on months from now does.

--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - ".github/workflows/**/*.yml"
+  - ".github/actions/**/*.yml"
 ---
 
 # CI Workflow Patterns
@@ -67,8 +68,13 @@ testbed rather than to "self-hosted":
 ```
 
 It writes the runner name and every GPU's name / compute capability / VRAM / driver to the step
-summary and the log, and exposes `compute_cap` + `gpu_name` as outputs for a job that needs to
-branch on the hardware.
+summary **and** the log — a run that dies before the summary renders is still attributable. If
+`nvidia-smi` is installed but unqueryable, the step **fails** rather than reporting "none
+detected": a broken host is not a CPU host, and an unattributable result is worse than a red job.
+
+It deliberately exposes no outputs. Add them when a job actually needs to branch on the hardware,
+and when you do, decide what a multi-GPU or mixed-architecture host should report — the first
+device's compute capability is not the host's.
 
 **Per-host knobs don't travel.** `cicd/scripts/gpu-temp-guard.sh` defaults to an 80 °C abort,
 which is tuned for the K80. Another card with a different thermal envelope needs its own

--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -6,7 +6,8 @@ paths:
 # CI Workflow Patterns
 
 ollama37's CI is organized by **test suite**, with a pipeline workflow that chains the suites,
-plus separate perf/experiment workflows. All run on the self-hosted Tesla K80 runner.
+plus separate perf/experiment workflows. All run on a labelled self-hosted GPU runner — see
+[Host selection](#host-selection).
 
 ## Suite workflows + the pipeline
 
@@ -38,7 +39,47 @@ suite workflows:
 (`cli.ts test-mcp` — MCP tool-call capability — is a subcommand with no workflow yet.)
 `release-docker.yml` builds and publishes the image on a release.
 
+## Host selection
+
+There is more than one possible GPU testbed, so **never use a bare `runs-on: self-hosted`.**
+It matches any runner, and a K80 sweep landing on a small consumer card produces numbers that
+look valid and are not.
+
+Select the host by the compute capability it provides:
+
+```yaml
+runs-on: [self-hosted, sm37]      # Tesla K80 — the only hardware-validated target
+```
+
+| Label | Host | Notes |
+|---|---|---|
+| `sm37` | Tesla K80 box (`rocky9-k80-cicd-1`) | 4 dies, ~11.4 GiB each. The reference testbed. |
+
+**Order of operations when adding a runner:** add the label to the runner *first*, then pin
+workflows to it. Pinning to a label no runner carries makes every job queue forever.
+
+**Identify the host** as the first step after checkout, so a result is attributable to a
+testbed rather than to "self-hosted":
+
+```yaml
+- name: Identify host
+  uses: ./.github/actions/identify-host
+```
+
+It writes the runner name and every GPU's name / compute capability / VRAM / driver to the step
+summary and the log, and exposes `compute_cap` + `gpu_name` as outputs for a job that needs to
+branch on the hardware.
+
+**Per-host knobs don't travel.** `cicd/scripts/gpu-temp-guard.sh` defaults to an 80 °C abort,
+which is tuned for the K80. Another card with a different thermal envelope needs its own
+`GPU_TEMP_LIMIT`, set where that host's jobs are defined — not by changing the default.
+
 ## Key Design Decisions
+
+**Manual triggers only:** every workflow is `workflow_dispatch` and, where they compose,
+`workflow_call`. **No workflow triggers on `push` or `pull_request`.** That is deliberate: the
+runners are self-hosted on a public repository, so a PR-triggered workflow would let a fork
+execute arbitrary code on them. Adding such a trigger is a security decision, not a convenience.
 
 **Dual triggers:** workflows support `workflow_dispatch` (manual) and, where they compose,
 `workflow_call` (the pipeline calls the suites). Run a suite alone or as part of the pipeline.

--- a/.github/actions/identify-host/action.yml
+++ b/.github/actions/identify-host/action.yml
@@ -12,22 +12,34 @@ runs:
         set -u
 
         if command -v nvidia-smi >/dev/null 2>&1; then
+          # `compute_cap` is not a valid query field on older nvidia-smi — notably the 470
+          # branch that drives the K80, which is the reference testbed. Probe for it and
+          # drop it rather than failing the job on every workflow.
+          fields="name,compute_cap,memory.total,driver_version"
+          if ! nvidia-smi --query-gpu=compute_cap --format=csv,noheader >/dev/null 2>&1; then
+            fields="name,memory.total,driver_version"
+          fi
+
           # A host with the driver installed that cannot be queried is a broken host, not
           # a CPU host. Reporting "none detected" there would silently strip attribution
           # from the result — the same reason gpu-temp-guard.sh aborts on unreadable polls.
           # stderr goes to a file, never into the parsed output: a benign nvidia-smi
           # warning must not be mistaken for a GPU row.
           err="$(mktemp)"
-          if ! smi="$(nvidia-smi --query-gpu=name,compute_cap,memory.total,driver_version \
-                                 --format=csv,noheader 2>"$err")" || [ -z "${smi}" ]; then
-            echo "identify-host: nvidia-smi is installed but returned no usable output." >&2
-            cat "$err" >&2
+          if ! smi="$(nvidia-smi --query-gpu="${fields}" --format=csv,noheader 2>"$err")" \
+             || [ -z "${smi:-}" ]; then
+            # nvidia-smi reports an unusable query on stdout, not stderr. Print both, or
+            # the reason for the failure is invisible.
+            echo "identify-host: nvidia-smi returned no usable output for '${fields}'." >&2
+            echo "--- stdout ---" >&2; printf '%s\n' "${smi:-}" >&2
+            echo "--- stderr ---" >&2; cat "$err" >&2
             rm -f "$err"
             exit 1
           fi
           rm -f "$err"
           mapfile -t gpus <<< "${smi}"
         else
+          fields=""
           gpus=()
         fi
 
@@ -50,6 +62,8 @@ runs:
         if [ "${#gpus[@]}" -eq 0 ]; then
           emit "| GPU | none detected |"
         else
+          # The field list varies by driver, so name it — otherwise the row is unreadable.
+          emit "| GPU fields | \`${fields}\` |"
           i=0
           for g in "${gpus[@]}"; do
             # Escape pipes so an exotic device name cannot mangle the table row.

--- a/.github/actions/identify-host/action.yml
+++ b/.github/actions/identify-host/action.yml
@@ -1,54 +1,59 @@
 name: Identify host
 description: >
-  Record which self-hosted runner and which GPU a job actually ran on, into the step
-  summary. Makes every result attributable to a specific testbed instead of "self-hosted".
-
-outputs:
-  compute_cap:
-    description: Compute capability of GPU 0 (e.g. 3.7, 7.5). Empty when no NVIDIA GPU.
-    value: ${{ steps.probe.outputs.compute_cap }}
-  gpu_name:
-    description: Name of GPU 0. Empty when no NVIDIA GPU.
-    value: ${{ steps.probe.outputs.gpu_name }}
+  Record which self-hosted runner and which GPUs a job actually ran on, into the step
+  summary and the log. Makes every result attributable to a specific testbed instead of
+  "self-hosted".
 
 runs:
   using: composite
   steps:
-    - id: probe
-      shell: bash
+    - shell: bash
       run: |
         set -u
 
         if command -v nvidia-smi >/dev/null 2>&1; then
-          mapfile -t gpus < <(nvidia-smi --query-gpu=name,compute_cap,memory.total,driver_version \
-                                         --format=csv,noheader 2>/dev/null)
+          # A host with the driver installed that cannot be queried is a broken host, not
+          # a CPU host. Reporting "none detected" there would silently strip attribution
+          # from the result — the same reason gpu-temp-guard.sh aborts on unreadable polls.
+          # stderr goes to a file, never into the parsed output: a benign nvidia-smi
+          # warning must not be mistaken for a GPU row.
+          err="$(mktemp)"
+          if ! smi="$(nvidia-smi --query-gpu=name,compute_cap,memory.total,driver_version \
+                                 --format=csv,noheader 2>"$err")" || [ -z "${smi}" ]; then
+            echo "identify-host: nvidia-smi is installed but returned no usable output." >&2
+            cat "$err" >&2
+            rm -f "$err"
+            exit 1
+          fi
+          rm -f "$err"
+          mapfile -t gpus <<< "${smi}"
         else
           gpus=()
         fi
 
-        gpu_name="$(printf '%s' "${gpus[0]:-}" | cut -d, -f1 | sed 's/^ *//')"
-        compute_cap="$(printf '%s' "${gpus[0]:-}" | cut -d, -f2 | sed 's/^ *//')"
-
-        echo "gpu_name=${gpu_name}"       >> "$GITHUB_OUTPUT"
-        echo "compute_cap=${compute_cap}" >> "$GITHUB_OUTPUT"
-
-        {
-          echo "### Host"
-          echo
-          echo "| | |"
-          echo "|---|---|"
-          echo "| Runner | \`${RUNNER_NAME:-?}\` |"
-          echo "| OS / arch | \`${RUNNER_OS:-?} ${RUNNER_ARCH:-?}\` · \`$(uname -sr)\` |"
-          if [ "${#gpus[@]}" -eq 0 ]; then
-            echo "| GPU | none detected |"
-          else
-            i=0
-            for g in "${gpus[@]}"; do
-              echo "| GPU $i | \`${g}\` |"
-              i=$((i + 1))
-            done
+        # Emit to the log as well as the summary: a run that dies before the summary
+        # renders is still attributable.
+        emit() {
+          printf '%s\n' "$1"
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
           fi
-        } >> "$GITHUB_STEP_SUMMARY"
+        }
 
-        # Also to the log: a run that dies before the summary renders is still attributable.
-        echo "host: runner=${RUNNER_NAME:-?} gpu=${gpu_name:-none} cc=${compute_cap:-none}"
+        emit "### Host"
+        emit ""
+        emit "| | |"
+        emit "|---|---|"
+        emit "| Runner | \`${RUNNER_NAME:-?}\` |"
+        emit "| OS / arch | \`${RUNNER_OS:-?} ${RUNNER_ARCH:-?}\` · \`$(uname -sr)\` |"
+
+        if [ "${#gpus[@]}" -eq 0 ]; then
+          emit "| GPU | none detected |"
+        else
+          i=0
+          for g in "${gpus[@]}"; do
+            # Escape pipes so an exotic device name cannot mangle the table row.
+            emit "| GPU $i | \`${g//|/\\|}\` |"
+            i=$((i + 1))
+          done
+        fi

--- a/.github/actions/identify-host/action.yml
+++ b/.github/actions/identify-host/action.yml
@@ -1,0 +1,54 @@
+name: Identify host
+description: >
+  Record which self-hosted runner and which GPU a job actually ran on, into the step
+  summary. Makes every result attributable to a specific testbed instead of "self-hosted".
+
+outputs:
+  compute_cap:
+    description: Compute capability of GPU 0 (e.g. 3.7, 7.5). Empty when no NVIDIA GPU.
+    value: ${{ steps.probe.outputs.compute_cap }}
+  gpu_name:
+    description: Name of GPU 0. Empty when no NVIDIA GPU.
+    value: ${{ steps.probe.outputs.gpu_name }}
+
+runs:
+  using: composite
+  steps:
+    - id: probe
+      shell: bash
+      run: |
+        set -u
+
+        if command -v nvidia-smi >/dev/null 2>&1; then
+          mapfile -t gpus < <(nvidia-smi --query-gpu=name,compute_cap,memory.total,driver_version \
+                                         --format=csv,noheader 2>/dev/null)
+        else
+          gpus=()
+        fi
+
+        gpu_name="$(printf '%s' "${gpus[0]:-}" | cut -d, -f1 | sed 's/^ *//')"
+        compute_cap="$(printf '%s' "${gpus[0]:-}" | cut -d, -f2 | sed 's/^ *//')"
+
+        echo "gpu_name=${gpu_name}"       >> "$GITHUB_OUTPUT"
+        echo "compute_cap=${compute_cap}" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Host"
+          echo
+          echo "| | |"
+          echo "|---|---|"
+          echo "| Runner | \`${RUNNER_NAME:-?}\` |"
+          echo "| OS / arch | \`${RUNNER_OS:-?} ${RUNNER_ARCH:-?}\` · \`$(uname -sr)\` |"
+          if [ "${#gpus[@]}" -eq 0 ]; then
+            echo "| GPU | none detected |"
+          else
+            i=0
+            for g in "${gpus[@]}"; do
+              echo "| GPU $i | \`${g}\` |"
+              i=$((i + 1))
+            done
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        # Also to the log: a run that dies before the summary renders is still attributable.
+        echo "host: runner=${RUNNER_NAME:-?} gpu=${gpu_name:-none} cc=${compute_cap:-none}"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -39,7 +39,11 @@ jobs:
         with:
           ref: ${{ steps.version.outputs.tag }}
 
+      # Guarded: this job checks out an arbitrary release tag, and tags cut before the
+      # action existed have no .github/actions/identify-host to resolve. Without the
+      # guard, republishing any older release fails at this step.
       - name: Identify host
+        if: hashFiles('.github/actions/identify-host/action.yml') != ''
         uses: ./.github/actions/identify-host
 
       - name: Build Docker image

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   publish:
     name: Build & Push Docker Image
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     env:
       OLLAMA_VERSION: ${{ vars.OLLAMA_VERSION || '0.0.0' }}
@@ -38,6 +38,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.version.outputs.tag }}
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   build:
     name: Build Verification
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     env:
       OLLAMA_VERSION: ${{ vars.OLLAMA_VERSION || '0.0.0' }}
@@ -38,6 +38,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-inference.yml
+++ b/.github/workflows/test-inference.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   inference:
     name: Inference Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     env:
       OLLAMA37_ROOT: ${{ github.workspace }}
@@ -54,6 +54,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -69,12 +69,15 @@ env:
 jobs:
   test-mcp:
     name: MCP Tool-Call Test
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Validate inputs
         env:

--- a/.github/workflows/test-mlx-smoke.yml
+++ b/.github/workflows/test-mlx-smoke.yml
@@ -37,13 +37,16 @@ on:
 jobs:
   mlx-smoke:
     name: Build + run qwen_smoke
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Regression check — production GGML path still serves
         # Safety net for the MLX rapid-merge cadence. Our changes only

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   models:
     name: Models Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     env:
       OLLAMA37_ROOT: ${{ github.workspace }}
@@ -51,6 +51,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-report-sweep.yml
+++ b/.github/workflows/test-report-sweep.yml
@@ -53,13 +53,16 @@ env:
 jobs:
   sweep:
     name: Report Sweep
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     timeout-minutes: 660 # ~11h: a full 13-model x (4 ctx tp + 4 mcp) sweep is long
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Validate model inputs
         env:

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   runtime:
     name: Container & Runtime Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
     env:
       OLLAMA37_ROOT: ${{ github.workspace }}
@@ -43,6 +43,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-throughput.yml
+++ b/.github/workflows/test-throughput.yml
@@ -33,12 +33,15 @@ env:
 jobs:
   throughput:
     name: Throughput Benchmark
-    runs-on: self-hosted
+    runs-on: [self-hosted, sm37]
     environment: cicd-1
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
 
       - name: Validate inputs
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,11 @@ use judgment; branch + PR + merge is enough. The three review passes overlap:
 logic or risk, `/review` is the PR summary. Running all three on a trivial diff is
 ritual, not rigor.
 
+**Filing an issue** — whether through `dw-story`/`dw-tasks` or by hand with `gh issue
+create` — follows `.claude/rules/github-issue.md`. `gh` bypasses the templates in
+`.github/ISSUE_TEMPLATE/`, so their sections have to be reproduced deliberately. That
+rule can't be path-scoped (an issue is not a file), which is why it is named here.
+
 ## 6. Artifact & doc review discipline
 
 Match the reviewer to **who reads** the file you changed:

--- a/docs/research/sm75-fa-validation-plan.md
+++ b/docs/research/sm75-fa-validation-plan.md
@@ -1,0 +1,208 @@
+# sm_75 (RTX 2060) validation — flash-attention plan
+
+Working plan for the non-K80 hardware validation in **#342** (plan **#340**, cards **#358**).
+Also serves the *Done When* item "a runnable smoke-test procedure is documented".
+
+**Status:** T1, T3, T4, T5, T6 executed. T2 blocked (model unsupported). See *Results*.
+**Last updated:** 2026-07-10.
+**Thread:** <https://github.com/dogkeeper886/ollama37/issues/342#issuecomment-4934285756>
+
+## Results (2026-07-10)
+
+| # | Config | Engine | FA | Observed | Verdict |
+|--:|---|---|---|---|---|
+| T1 | `deepseek-r1:1.5b`, defaults | llama.cpp | off | 153.9 tok/s, `"Paris"`, `done=stop` | **PASS** |
+| T2 | `lfm2.5-thinking:1.2b`, defaults | llama.cpp | — | `error loading model: missing tensor 'token_embd_norm.weight'`, `print_info: arch = lfm2` | **BLOCKED** |
+| T3 | `qwen3.5:0.8b`, **no `.env`** | **Go** | **true (auto)** | `architecture=qwen35`, 25/25 on GPU, then `panic: failed to sample token` (`ollamarunner/runner.go:737`) | **CRASH** |
+| T4 | `qwen3.5:0.8b`, `FA=0` | Go | false | 125.4 tok/s, coherent reasoning to "Paris", 0 panics | **PASS** |
+| T5 | `deepseek-r1:1.5b`, `FA=1` | llama.cpp | true | `Assertion 'found' failed` + `SIGABRT` | **CRASH** |
+| T6 | `deepseek-r1:1.5b`, `FA=1`, `CUDA_VISIBLE_DEVICES=-1` | llama.cpp | true (`"enabling flash attention"`) | `library=cpu`, 4.77 tok/s, 0 aborts | **PASS** |
+
+**What this establishes.**
+
+1. **The default config is broken on cc>=7.0.** T3 set no environment variable at all and the
+   load request still carried `FlashAttention:true`. The §2 whitelist is confirmed empirically,
+   not just by reading source.
+2. **The break is not engine- or arch-specific.** Two different samplers fail on the same kernel:
+   llama.cpp's C++ `llama_sampler_dist_apply` aborts (T5, arch `qwen2`), and the Go engine's
+   sampler panics (T3, arch `qwen35`). Different code, same cause.
+3. **The fault is in the CUDA FA path.** T6 was designed to refute that: same model, same
+   `FA=1`, no GPU. It passed. FA on CPU is fine. The `MMA_F16` / `movmatrix` attribution
+   survived its falsification test.
+4. **FA is the only variable.** T3 vs T4 hold model, engine and host constant; only FA differs.
+
+**Still not proven:** that the `movmatrix` fallback is the *specific* defect. T6 narrows the
+fault to the CUDA FA path; it does not single out `get_transposed` within it. Confirming that
+still needs the builder-image probe or a CUDA 11.8 sm_75 build.
+
+**New, unrelated finding (T2).** `lfm2.5-thinking:1.2b` is `arch = lfm2` (dense) and fails to
+load: `missing tensor 'token_embd_norm.weight'`. Only `lfm2moe` (the 8b) was merged in #383.
+This is a load-time architecture gap, not sm_75-specific — it would fail on the K80 too.
+Deserves its own issue.
+
+---
+
+## The finding in one paragraph
+
+The published image runs correctly on the RTX 2060 (sm_75) with flash attention **off**:
+29/29 layers on GPU, correct output, 153.9 tok/s vs the K80's 34.1 on `deepseek-r1:1.5b`.
+With FA **on** it aborts deterministically (2/2) in `llama_sampler_dist_apply` — the signature
+of NaN logits. And **FA turns on by itself** for nine architectures, so the *default* config is
+unsafe on any cc>=7.0 card, not just when a user follows `.env.example`.
+
+## What is proven vs. suspected
+
+**Proven** (source-traced + observed):
+
+| Claim | Evidence |
+|---|---|
+| Env unset ⇒ FA falls back to a per-arch whitelist | `envconfig/config.go:152-163` (`BoolWithDefault`), `llm/server.go:244` |
+| The whitelist | `fs/ggml/ggml.go:904` — gemma3, gptoss/gpt-oss, qwen3, qwen3moe, qwen35, qwen35moe, qwen3next, qwen3vl, qwen3vlmoe |
+| cc>=7 passes the GPU gate | `ml/device.go:436` |
+| `qwen35` bypasses the model gate | `fs/ggml/ggml.go:889` returns true unconditionally |
+| Both engines hit the same CUDA op | llama.cpp via `llamarunner`; Go via `ml/backend/ggml/ggml.go:1798` → `C.ggml_flash_attn_ext` |
+| sm_75 selects the tensor-core kernel | `fattn.cu:195` → `turing_mma_available(750)` true, VEC needs cc>=890 → `BEST_FATTN_KERNEL_MMA_F16` (`fattn.cu:295`) |
+| CUDA 11.4 compiles the fallback `movmatrix` | `mma.cuh:22` gates on `CUDART_VERSION >= 11080`; image bundles `libcudart.so.11.4.148` (11040) |
+| That fallback is reachable only via FA | `ggml_cuda_movmatrix` → `get_transposed` (`mma.cuh:213`) → called only at `fattn-mma-f16.cuh:696,1142` |
+| K80 never executes it | `turing_mma_available(370)` is false |
+| FA=1 aborts, FA=0 clean | 2/2 each, this host |
+
+**Suspected — do not state as fact:**
+
+- That the `movmatrix` fallback is *numerically wrong*. It is upstream code. The fault may lie
+  elsewhere in `fattn-mma-f16` under nvcc 11.4. **T6 is the test that can refute this.**
+- That `__CUDA_ARCH_LIST__` (`common.cuh:133`) is CUDA 11.5+. If undefined on 11.4,
+  `ggml_cuda_highest_compiled_arch` degrades to `return arch` (`common.cuh:167`) and
+  `turing_mma_available()` cannot detect a missing cubin. Confirm inside the builder.
+- All arch strings in the matrix below. Confirm from `general.architecture` at load.
+
+## Host + current state
+
+| | |
+|---|---|
+| GPU | RTX 2060 (TU106), cc **7.5**, 6144 MiB, ~5.1 GiB free (display attached) |
+| Driver | 580.159.03 (CUDA 13.0) — **not** the 470 target |
+| OS / Docker | Rocky 9.8 · Docker 29.6.1 · Compose v5.3.1 |
+| Image | `dogkeeper886/ollama37:latest` `sha256:32010cd3…`, self-reports `2.1.0`, retagged `ollama37:latest` |
+
+Already done, do not redo:
+
+- `nvidia-container-toolkit` installed; Docker `nvidia` runtime registered.
+- `docker volume create ollama-data` (compose declares it `external: true`).
+- Models in the volume: `deepseek-r1:1.5b`, `qwen3:4b` (**unwanted** — pulled by an aborted
+  command; remove with `docker exec ollama37 ollama rm qwen3:4b`).
+- `docker/.env` exists with `OLLAMA_FLASH_ATTENTION=0` (gitignored). **T2 and T3 require it
+  deleted, not edited** — compose maps unset → empty string → `BoolWithDefault` default path.
+
+## Model → path map on sm_75
+
+Sizes are published tags; `available` on this host is 5.1 GiB.
+
+| Model | Size | arch (expected) | Engine | FA, no env | Kernel | Fits | Expected |
+|---|--:|---|---|---|---|:--:|---|
+| `deepseek-r1:1.5b` | 1.1 GB | `qwen2` | llama.cpp | off | — | yes | PASS (observed) |
+| `lfm2.5-thinking:1.2b` | 731 MB | `lfm2`/`lfm2moe` | llama.cpp | off | — | yes | PASS |
+| `lfm2.5:8b` | 5.2 GB | `lfm2moe` | llama.cpp | off | — | **no** (K80 d0 6358 MiB) | untestable |
+| `qwen3.5:0.8b` | 1.0 GB | `qwen35` | **Go** | **ON** | `MMA_F16` | yes | **CRASH** |
+| `qwen3.5:2b` | 2.7 GB | `qwen35` | **Go** | **ON** | `MMA_F16` | yes | **CRASH** |
+| `qwen3.5:4b` | 3.4 GB | `qwen35` | **Go** | **ON** | `MMA_F16` | yes | **CRASH** |
+| `qwen3.5:latest` | 6.6 GB | `qwen35moe` | **Go** | **ON** | `MMA_F16` | **no** | untestable |
+
+VRAM ceiling is from `docs/reports/k80-vram-by-family-2026-07-10-d83061de.md` (per-die `d0`).
+`qwen35` is hybrid: `FullAttention` layers use FA (`attention.go:91`), `GatedDeltaNet` layers
+bypass it (`deltanet.go`). `model/models/qwen35/` has **no vision tower**, yet the published
+`qwen3.5:*` tags advertise Image — separate gap, needs its own issue.
+
+## The matrix
+
+| # | Model | Env | Isolates | Expect | Done |
+|--:|---|---|---|---|:--:|
+| T1 | `deepseek-r1:1.5b` | defaults | sm_75 cubin runs at all | PASS | ✅ |
+| T2 | `lfm2.5-thinking:1.2b` | **no `.env`** | 2nd arch on the no-FA path | PASS | ☐ |
+| T3 | `qwen3.5:0.8b` | **no `.env`** | **default config is broken** | CRASH | ☐ |
+| T4 | `qwen3.5:0.8b` | `FA=0` | controls engine; isolates FA | PASS | ☐ |
+| T5 | `lfm2.5-thinking:1.2b` | `FA=1` | FA break is engine/arch-independent | CRASH | ☐ |
+| T6 | `deepseek-r1:1.5b` | `FA=1`, CPU only | **refutes the CUDA attribution** | PASS | ☐ |
+
+T3 is the headline — no configuration at all. T6 is the falsifier: if CPU also aborts, the
+`movmatrix` trace is wrong and the whole mechanism section must be retracted.
+
+Optional: **T7** = T3 + `OLLAMA_KV_CACHE_TYPE=q8_0` (quantized K ⇒ decode takes `VEC`, prefill
+stays `MMA_F16` — the only way to separate the two kernels without a rebuild).
+**T8** = image prompt to `qwen3.5:4b`, documents the missing vision tower.
+
+## Procedure
+
+Pull first (~1.8 GB total): `docker exec ollama37 ollama pull qwen3.5:0.8b` and
+`... pull lfm2.5-thinking:1.2b`.
+
+**No-`.env` runs (T2, T3):**
+
+```bash
+cd docker && mv .env .env.bak && docker compose up -d --force-recreate && sleep 6
+docker logs ollama37 2>&1 | grep -o "OLLAMA_FLASH_ATTENTION:[a-z]*" | tail -1   # expect: false (empty env)
+```
+
+**`.env` runs (T4, T5):** set `OLLAMA_FLASH_ATTENTION=0` or `=1`, then
+`docker compose up -d --force-recreate`.
+
+**T6 (CPU control):**
+
+```bash
+docker run -d --rm --name ollama37-cpu -e OLLAMA_FLASH_ATTENTION=1 \
+  -e CUDA_VISIBLE_DEVICES=-1 -e OLLAMA_HOST=0.0.0.0:11434 \
+  -p 11435:11434 -v ollama-data:/root/.ollama ollama37:latest
+# ... then curl :11435 ; docker stop ollama37-cpu when done
+```
+
+**Drive one model** (mirrors the K80 sweep methodology: `num_predict=16`, 4k ctx):
+
+```bash
+curl -s --max-time 240 http://localhost:11434/api/generate -d '{
+  "model":"<MODEL>","prompt":"In one sentence, what is the capital of France?",
+  "stream":false,"options":{"num_predict":16,"num_ctx":4096,"seed":42}}' > out.json
+python3 -c 'import json;d=json.load(open("out.json"));ec,ed=d.get("eval_count"),d.get("eval_duration");print("eval:",ec,"| tok/s:", round(ec/(ed/1e9),2) if ec and ed else None, "| error:",d.get("error","none"))'
+```
+
+**Record per run** — an empty `eval_count` plus a 500 means the runner died:
+
+1. `general.architecture` — `docker logs ollama37 2>&1 | grep -i "general.architecture\|architecture "`
+2. FA in effect — `grep -o "OLLAMA_FLASH_ATTENTION:[a-z]*"`, and `FlashAttention:true|false` in the load request
+3. Engine — `llama_model_load_from_file_impl` (llama.cpp) vs the Go runner's load lines
+4. GPU placement — `layers.offload=N` and `available=`
+5. tok/s, output text, `done_reason`
+6. On crash — `grep -c "Assertion \`found' failed"` and the `SIGABRT` block
+
+Known limitation: **the selected FA kernel is not logged.** MMA-vs-VEC is inferred from
+`fattn.cu:195`, not observed. T7 is the only cheap discriminator.
+
+## Cleanup / restore
+
+```bash
+cd docker && cp .env.bak .env 2>/dev/null || printf 'OLLAMA_FLASH_ATTENTION=0\n' > .env
+docker compose up -d --force-recreate
+docker stop ollama37-cpu 2>/dev/null
+docker exec ollama37 ollama rm qwen3:4b     # unwanted
+```
+
+Leave the box at `FA=0` — the default config crashes for whitelisted archs.
+
+## Decisions pending
+
+- **Doc/gate fix — needs no further testing.** The default auto-enables FA on every cc>=7.0
+  card for nine archs. Either hard-gate FA off in this build, or fix `docker-compose.yml:22-23`
+  (which claims "we don't auto-enable it on the experimental cc>=7.0 cards" — false) and
+  `.env.example:17-20`. Amends **#340 step 2**, which plans to leave the gate untouched on the
+  belief the path is "pure-upstream and already correct" for every card in the sweep.
+- **Deferred, expensive:** `get_transposed` probe in the builder (~15 GB image); an sm_75-only
+  CUDA 11.8 build. Both buy root cause for a feature the K80 does not want. Revisit only if a
+  Pascal card or the #223 reporter appears.
+- **New issue:** `qwen3.5:*` advertise Image but `model/models/qwen35/` has no vision tower.
+- `docs/research/470-arch-support-map.md` is referenced by #340 and #342 but was deleted in
+  `17678ce4`. This file is the "or a sibling" it points to.
+
+## Out of scope, by construction
+
+Pascal gate crossings (sm_60 fast-FP16, sm_61 dp4a), the #223 mixed-arch box, driver 470,
+and any model above 5.1 GiB. This host is one Turing card on a modern driver — a weak
+best-effort sanity check, exactly as #342 frames it.

--- a/docs/research/sm75-fa-validation-plan.md
+++ b/docs/research/sm75-fa-validation-plan.md
@@ -115,17 +115,25 @@ bypass it (`deltanet.go`). `model/models/qwen35/` has **no vision tower**, yet t
 
 ## The matrix
 
+As **executed** — this table is the plan as it actually ran, not as first drafted. See *Results*
+above for the observed outcome of each row.
+
 | # | Model | Env | Isolates | Expect | Done |
 |--:|---|---|---|---|:--:|
 | T1 | `deepseek-r1:1.5b` | defaults | sm_75 cubin runs at all | PASS | ✅ |
-| T2 | `lfm2.5-thinking:1.2b` | **no `.env`** | 2nd arch on the no-FA path | PASS | ☐ |
-| T3 | `qwen3.5:0.8b` | **no `.env`** | **default config is broken** | CRASH | ☐ |
-| T4 | `qwen3.5:0.8b` | `FA=0` | controls engine; isolates FA | PASS | ☐ |
-| T5 | `lfm2.5-thinking:1.2b` | `FA=1` | FA break is engine/arch-independent | CRASH | ☐ |
-| T6 | `deepseek-r1:1.5b` | `FA=1`, CPU only | **refutes the CUDA attribution** | PASS | ☐ |
+| T2 | `lfm2.5-thinking:1.2b` | **no `.env`** | 2nd arch on the no-FA path | PASS | ⛔ blocked — model will not load ([#386](https://github.com/dogkeeper886/ollama37/issues/386)) |
+| T3 | `qwen3.5:0.8b` | **no `.env`** | **default config is broken** | CRASH | ✅ |
+| T4 | `qwen3.5:0.8b` | `FA=0` | controls engine; isolates FA | PASS | ✅ |
+| T5 | `deepseek-r1:1.5b` | `FA=1` | FA break is engine/arch-independent | CRASH | ✅ |
+| T6 | `deepseek-r1:1.5b` | `FA=1`, CPU only | **refutes the CUDA attribution** | PASS | ✅ |
+
+**T5 substituted its model.** It was planned as `lfm2.5-thinking:1.2b` + `FA=1`, to reach the
+llama.cpp FA path with a non-whitelisted arch. That model cannot load at all (T2), so `deepseek-r1:1.5b`
+(`arch = qwen2`, also non-whitelisted, also llama.cpp) was used instead. The purpose — showing the FA
+break is not specific to one engine or architecture — is unchanged.
 
 T3 is the headline — no configuration at all. T6 is the falsifier: if CPU also aborts, the
-`movmatrix` trace is wrong and the whole mechanism section must be retracted.
+`movmatrix` trace is wrong and the whole mechanism section must be retracted. It did not abort.
 
 Optional: **T7** = T3 + `OLLAMA_KV_CACHE_TYPE=q8_0` (quantized K ⇒ decode takes `VEC`, prefill
 stays `MMA_F16` — the only way to separate the two kernels without a rebuild).


### PR DESCRIPTION
Closes #390. Prerequisite for the sm_75 testbed in #358.

Two commits, two concerns. Bundled on request — happy to split if you'd rather review them apart.

---

## 1. `c0ed83f0` — CI host selection *(the substance)*

All nine jobs used a bare `runs-on: self-hosted`, and `rocky9-k80-cicd-1` carried no custom label. Registering a second GPU runner would have let K80 sweeps schedule onto a 6 GB RTX 2060 — producing throughput and VRAM numbers that look valid and are meaningless. `deepseek-r1:32b` would not have loaded at all. Nothing recorded which host produced a result.

- **Select:** K80 runner labelled `sm37`; all nine jobs pinned to `[self-hosted, sm37]`.
- **Identify:** new `.github/actions/identify-host` composite action, run after checkout in every job. Writes runner name + each GPU's name / compute capability / VRAM / driver to the step summary and the log; exposes `compute_cap` and `gpu_name` as outputs.
- **Record:** conventions in `.claude/rules/workflow-patterns.md`.

Shared action rather than nine copies — same reasoning as the STORY-013 temperature guard.

### Ordering

**The label was added to the runner before this branch existed.** Pinning workflows to a label no runner carries makes every job **queue forever** — it does not degrade. The reverse is safe: a bare `self-hosted` job still matches a runner with extra labels. So both halves are independently safe and this merges in either order.

### Notes

- `runner.labels` is **not** a valid GitHub context — `runner` exposes only `name`, `os`, `arch`. The action reads `RUNNER_NAME`/`RUNNER_OS`/`RUNNER_ARCH` and probes `nvidia-smi`. Caught before it shipped.
- The action is local, so it must run **after** `actions/checkout`. `release-docker.yml` checks out mid-job; the step follows checkout there too.
- Also documented: no workflow triggers on `push`/`pull_request`, and that this is a deliberate security property on a public repo with self-hosted runners — not an oversight.

---

## 2. `b7d49935` — the issue-writing rule, and the notes it came from

**`.claude/rules/github-issue.md`.** `gh issue create --body-file` bypasses `.github/ISSUE_TEMPLATE/*.yml`, so #385–389 were filed without the sections those templates require. The rule says to mirror whichever template applies, and adds what this project needs on top: name the model, the hardware and the config, then trace the path with `file:line`; label every claim *observed* or *predicted*; state the blast radius exactly; always include the K80 no-harm gate; list what you did not prove.

It **cannot be path-scoped** like the other rules — an issue is not a file — so `CLAUDE.md` names it directly. Without that pointer the rule would never load, which is precisely the drift it exists to prevent.

**`docs/research/sm75-fa-validation-plan.md`.** The procedure, host state, and executed T1–T6 matrix behind #385/#388/#389. #342's *Done When* asks for a runnable smoke-test procedure in `docs/research/470-arch-support-map.md` "or a sibling"; that file was removed in `17678ce4`, so this is the sibling.

Both went through a `reviewing-artifacts` pass. Findings fixed: the rule was orphaned (nothing loaded it), restated the template's fields verbatim, hardcoded `file:line` refs that will rot, and invented a no-harm tolerance that already lives in `docs/reports/`.

---

## Verification

- All 10 workflow files and the composite action parse as valid YAML.
- No bare `runs-on: self-hosted` remains.
- `sm37` is live on `rocky9-k80-cicd-1` (`self-hosted, Linux, X64, sm37`).
- **The action has never actually run.** Its first real execution will be the next dispatched workflow — that's the thing to watch on merge.

CI plumbing and docs only: no container, model, or kernel behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)