### PR TITLE
Pin flash attention off: it auto-enabled on cc>=7.5 and crashed the runner

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -14,16 +14,27 @@ OLLAMA_VERSION=2.2.1
 # Defaults are tuned for K80 hardware. Override here only if you know what
 # you're doing.
 
-# Flash attention. Left unset by default — ollama's hardware gate forces it OFF on
-# the K80 (sm_37) regardless (a net loss there, ~7x slower at long context; see #346).
-# On cc>=7.0 cards (the widened build, experimental) set =1 to enable FA.
+# Flash attention. Pinned OFF in docker-compose.yml. Do not turn it on.
+#
+# Leaving this variable empty does NOT mean "off" — ollama then falls back to a
+# per-architecture whitelist (gemma3, gpt-oss, qwen3*, qwen35*, qwen3vl*) and those
+# models enable FA by themselves. That is why compose pins the value rather than
+# passing an empty string through.
+#
+# On the K80 (sm_37) the hardware gate vetoes FA regardless; it is a ~7x loss there at
+# long context anyway (#346). On cc>=7.5 (Turing/Ampere) FA reaches a tensor-core kernel
+# that this CUDA 11.4 build miscompiles, and the runner aborts on the first token —
+# reproduced on an RTX 2060, both engines (#385, #388). sm_70 (Volta) takes a different
+# kernel and is untested.
+#
+# Left overridable only so the fix in #388 can be tested. It will crash a cc>=7.5 card.
 # OLLAMA_FLASH_ATTENTION=1
 
-# KV cache element type. Default "f16" on K80, because FA is off there and
-# V-cache quantization (q8_0) requires FA — so q8_0 won't load on the K80.
+# KV cache element type. Default "f16" everywhere, because q8_0/q4_0 V-cache
+# quantization requires flash attention — and FA is off on every card we ship for:
+# vetoed by hardware on the K80, and pinned off elsewhere until #388 is resolved.
 # f16 costs ~2x the KV memory of q8_0; if a large model + long context doesn't
-# fit on a 12GB die, reduce num_ctx. q8_0/q4_0 are only usable on FA-capable
-# (cc>=7.0) cards.
+# fit on a 12GB die, reduce num_ctx.
 # OLLAMA_KV_CACHE_TYPE=f16
 
 # Verbose server logging.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,11 +18,18 @@ services:
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_DEBUG=${OLLAMA_DEBUG:-}
       # K80 perf defaults — see docker/.env.example to override.
-      # Flash attention is left unset (not pinned): ollama's hardware gate forces it
-      # off on the K80 (sm_37) anyway — it's a net loss there (see #346) — and we don't
-      # auto-enable it on the experimental cc>=7.0 cards. Set OLLAMA_FLASH_ATTENTION=1
-      # to turn it on where supported. With FA off, q8_0 KV needs FA, so cache is f16.
-      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-}
+      #
+      # Flash attention is pinned OFF. Leaving it unset does NOT mean "off": ollama
+      # falls back to a per-architecture whitelist (gemma3, gpt-oss, qwen3*, qwen35*,
+      # qwen3vl*), so those models switch FA on by themselves. On the K80 (sm_37) the
+      # hardware gate vetoes it regardless — it is a net loss there anyway (#346). On
+      # cc>=7.5 (Turing/Ampere) FA reaches a kernel this CUDA 11.4 build miscompiles and
+      # the runner aborts on the first token (#385, #388).
+      #
+      # Setting OLLAMA_FLASH_ATTENTION=1 currently CRASHES any cc>=7.5 card. It is left
+      # overridable only so the fix in #388 can be tested. With FA off, q8_0 KV needs FA,
+      # so the cache stays f16.
+      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-0}
       - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}
       # Compute-buffer safety margin (#352). The built-in default 2.5 keeps large
       # models (deepseek-r1:32b) on the K80's small dies instead of offloading to CPU.


### PR DESCRIPTION
Closes #385.

## What was wrong

Leaving `OLLAMA_FLASH_ATTENTION` unset **does not mean "off."** `envconfig.FlashAttention` is `BoolWithDefault`, so an empty value falls back to the caller's default — and `llm/server.go:244` passes the *model's own* preference, a hardcoded architecture whitelist:

```
gemma3 · gpt-oss · qwen3 · qwen3moe · qwen35 · qwen35moe · qwen3next · qwen3vl · qwen3vlmoe
```

Those models switched flash attention on **with no user action**. Pull `qwen3.5` or `gemma3` onto a Turing or Ampere card, run the published image with the stock compose file, set nothing — and the runner panics on the first token.

Two comments in our own config asserted the opposite, and one instructed users to enable it.

## The path

`Model: qwen3.5:0.8b (arch qwen35)` · `Hardware: RTX 2060, cc 7.5` · `Config: no .env`

```
envconfig/config.go:153   Var("OLLAMA_FLASH_ATTENTION") == ""   → fall back to default
llm/server.go:244         fa = envconfig.FlashAttention(f.FlashAttention())
fs/ggml/ggml.go:904         "qwen35" ∈ whitelist                → TRUE
ml/device.go:436            cc 7.5 >= 7                         → TRUE
llm/server.go:262         loadRequest.FlashAttention = true
ggml-cuda/fattn.cu:295    → BEST_FATTN_KERNEL_MMA_F16
mma.cuh:22                #if CUDART_VERSION >= 11080 → 11040, FALSE
mma.cuh:39                → software movmatrix fallback
                          ↓ NaN logits
runner/ollamarunner/runner.go:737   panic: failed to sample token
```

CUDA 11.4 is not incidental — it is what keeps sm_37 alive. The card that forces the old toolchain is not the card it breaks.

## The change

Compose passes an explicit `0` instead of an empty string, so the whitelist is never consulted. Comments in `docker-compose.yml` and `.env.example` rewritten to describe what the code actually does.

**No code changed.** `fs/ggml/ggml.go` and `ml/device.go` are upstream gates; the next re-sync would overwrite them, and #340's guiding principle is to rely on upstream's gating rather than fork it. Pinning the env var gets the same outcome with nothing to re-merge.

Left overridable (`${OLLAMA_FLASH_ATTENTION:-0}` rather than a hard `=0`) so #388 can be tested. **This is a deliberate deviation from the issue text**, which asked for a hard pin — a hard pin would make the #388 investigation and the #358 validation matrix require editing compose.

## Blast radius

`GGML_CUDA_CC_TURING` is 750, so the boundary is **cc >= 7.5, not 7.0**.

| Card | cc | Kernel | Affected |
|---|--:|---|---|
| K80 | 3.7 | FA vetoed by hardware gate | no |
| V100 | 7.0 | WMMA (`== VOLTA`) | **likely not — untested** |
| T4 / RTX 20xx | 7.5 | `MMA_F16` | **yes — observed** |
| A100 / RTX 30xx | 8.0 / 8.6 | `MMA_F16` | **yes — predicted** |

## Verification

**Observed, RTX 2060, stock compose, no `.env`:**

- `qwen3.5:0.8b` (whitelisted) now loads with `FlashAttention:false`, 25/25 layers on GPU, answers coherently at **122.6 tok/s**, zero panics. It panicked on the first token before.
- `deepseek-r1:1.5b` (not whitelisted) unchanged: **155.8 tok/s** vs a 153.9 baseline.

**Observed, K80 (`rocky9-k80-cicd-1`):** `test-runtime` dispatched on this branch — container starts from the changed compose file, `inference compute … compute=3.7 … Tesla K80`, all steps green. [Run](https://github.com/dogkeeper886/ollama37/actions/runs/29093120172)

**K80 no-harm, by construction:** GPU placement comes from `estimateGPULayers(gpus, …)` (`llm/memory.go:299`), where `ml.FlashAttentionSupported()` already vetoed FA on sm_37 before this change. The only path that differs is `verifyCPUFit`'s `gpus=nil` estimate for whitelisted archs — and that only asks whether a model fits in system RAM for CPU inference. No sweep row touches it.

## Not proven

- That the `movmatrix` fallback is the *specific* defect. The CPU-only control (FA=1, no GPU, clean) localized the fault to the CUDA FA path, not to that line. Tracked in #388.
- sm_70 and sm_80/86 behaviour. Neither was run.

## Links

Evidence and the T1–T6 matrix: https://github.com/dogkeeper886/ollama37/issues/342#issuecomment-4934523329 · Procedure: `docs/research/sm75-fa-validation-plan.md` · Constraint: #388 · Amends #340 step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)