### PR TITLE
Fix #385: restrict CUDA flash attention to Volta on this build (no working kernel for Turing/Ampere under CUDA 11.4)

### DIFF
--- a/cicd/tests/testcases/build/TC-BUILD-004.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-004.yml
@@ -1,0 +1,48 @@
+id: TC-BUILD-004
+name: Publish CI image to Docker Hub
+suite: build
+priority: 4
+timeout: 600000
+dependencies: []
+intent:
+  user_story: |
+    Publish the runtime image already built on this runner to the CI image repo, so a
+    second testbed (e.g. sm75) can pull the exact same artifact by digest.
+  notes: |
+    Runs against the `ollama37:latest` already on this host's Docker daemon — it does NOT
+    rebuild (no dependency on TC-BUILD-002). Publishes to a dedicated public repo so
+    half-tested ci-<sha> tags never touch the tag list users pull `:latest` from. Pushes
+    from the sm37 daemon's existing credential; no docker login step. The digest it prints
+    is what the other testbed pulls (a tag can be overwritten; a digest cannot).
+
+steps:
+  - name: Tag and push CI image
+    command: |
+      SHA=$(echo "${GITHUB_SHA:-local}" | cut -c1-12)
+      REF="dogkeeper886/ollama37-ci:ci-${SHA}"
+      echo "Publishing ollama37:latest as ${REF}"
+      docker tag ollama37:latest "${REF}"
+      docker push "${REF}"
+    expectPatterns:
+      - "digest: sha256:"
+    rejectPatterns:
+      - "denied"
+      - "no such image"
+      - "no basic auth credentials"
+
+  - name: Print the fully-qualified digest
+    command: |
+      SHA=$(echo "${GITHUB_SHA:-local}" | cut -c1-12)
+      docker image inspect "dogkeeper886/ollama37-ci:ci-${SHA}" --format '{{index .RepoDigests 0}}'
+    expectPatterns:
+      - "ollama37-ci@sha256:"
+
+criteria: |
+  Publish the local ollama37:latest to dogkeeper886/ollama37-ci:ci-<sha> and report its
+  digest.
+
+  Expected:
+  - docker push succeeds ("digest: sha256:..." in the output)
+  - the fully-qualified digest (dogkeeper886/ollama37-ci@sha256:...) is printed for the
+    fetching testbed to pull by digest
+  - no "denied" (would mean the runner's credential can't push to this repo)

--- a/ml/backend/ggml/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -3,6 +3,20 @@
 #include "mma.cuh"
 #include "fattn-common.cuh"
 
+// The MMA_F16 flash-attention kernel reaches ggml_cuda_movmatrix (mma.cuh), whose
+// movmatrix.sync.aligned PTX requires PTX ISA 7.8 / CUDA 11.8. Below that (this fork is
+// pinned to CUDA 11.4 to keep sm_37 alive), mma.cuh substitutes a software fallback that
+// produces wrong results, so the kernel must not be selected. Mirrors the availability
+// predicate idiom of ggml_cuda_should_use_wmma_fattn (fattn-wmma-f16.cuh).
+static bool ggml_cuda_should_use_mma_fattn(const int cc) {
+#if CUDART_VERSION < 11080
+    GGML_UNUSED(cc);
+    return false;
+#else
+    return turing_mma_available(cc);
+#endif // CUDART_VERSION < 11080
+}
+
 using namespace ggml_cuda_mma;
 
 typedef tile<16,  8, half2> tile_A;

--- a/ml/backend/ggml/ggml/src/ggml-cuda/fattn.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/fattn.cu
@@ -270,7 +270,11 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && K->ne[1] % FATTN_KQ_STRIDE == 0;
 
     // If Turing tensor cores available, use them:
-    if (turing_mma_available(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40) {
+    // Uses ggml_cuda_should_use_mma_fattn (not turing_mma_available directly): the MMA_F16
+    // kernel needs CUDA 11.8 for movmatrix.sync.aligned; on this CUDA 11.4 build it is never
+    // selected, so cc>=7.5 falls through to the WMMA/tile path (#385). On the K80 this is a
+    // no-op (turing_mma_available(370) is already false).
+    if (ggml_cuda_should_use_mma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40) {
         if (can_use_vector_kernel) {
             if (K->type == GGML_TYPE_F16 && V->type == GGML_TYPE_F16) {
                 if (cc >= GGML_CUDA_CC_ADA_LOVELACE && Q->ne[1] == 1 && Q->ne[3] == 1 && !(gqa_ratio > 4 && K->ne[1] >= 8192)) {

--- a/ml/backend/ggml/ggml/src/ggml-cuda/fattn.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/fattn.cu
@@ -271,9 +271,12 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
     // If Turing tensor cores available, use them:
     // Uses ggml_cuda_should_use_mma_fattn (not turing_mma_available directly): the MMA_F16
-    // kernel needs CUDA 11.8 for movmatrix.sync.aligned; on this CUDA 11.4 build it is never
-    // selected, so cc>=7.5 falls through to the WMMA/tile path (#385). On the K80 this is a
-    // no-op (turing_mma_available(370) is already false).
+    // kernel needs CUDA 11.8 for movmatrix.sync.aligned, so on this CUDA 11.4 build it is
+    // never selected. This only stops MMA — it is NOT a safe landing on its own: cc>=7.5
+    // then falls to WMMA (no Turing device code) or tile (compiled out for Turing+GQA,
+    // NO_DEVICE_CODE). The Volta-only gate in ml/device.go FlashAttentionSupported is the
+    // primary guard that keeps FA off the selector on Turing/Ampere. On the K80 this is a
+    // no-op (turing_mma_available(370) is already false). See #385.
     if (ggml_cuda_should_use_mma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40) {
         if (can_use_vector_kernel) {
             if (K->type == GGML_TYPE_F16 && V->type == GGML_TYPE_F16) {

--- a/ml/device.go
+++ b/ml/device.go
@@ -435,15 +435,16 @@ func (a DeviceInfo) IsBetter(b DeviceInfo) bool {
 // For each GPU, check if it does NOT support flash attention
 func FlashAttentionSupported(l []DeviceInfo) bool {
 	for _, gpu := range l {
-		// CUDA: this fork builds with CUDA 11.4 (to keep sm_37 alive), where the only
-		// flash-attention kernel with compiled device code is WMMA — and WMMA's device
-		// code is Volta-only (cc 7.0). Turing/Ampere (cc >= 7.5) select MMA_F16, which
-		// needs CUDA 11.8 (movmatrix.sync.aligned); its fallbacks have no sm_75+ device
-		// code (WMMA is == Volta, tile is compiled out for >= Volta), so FA crashes the
-		// runner there. Restrict CUDA FA to Volta (cc 7.0). Upstream allows cc >= 7 (it
-		// builds with CUDA >= 11.8 where MMA works); this is the fork's toolchain
-		// adaptation. The ggml_cuda_should_use_mma_fattn predicate (fattn-mma-f16.cuh) is
-		// the paired CUDA-layer guard. See #385.
+		// CUDA: this fork builds with CUDA 11.4 (to keep sm_37 alive). On Turing/Ampere
+		// (cc >= 7.5) the selector routes the dominant attention shapes to MMA_F16, which
+		// needs CUDA 11.8 (movmatrix.sync.aligned) and emits NaN under 11.4 — so FA crashes
+		// the runner there. The VEC kernel does have working sm_75+ device code, but FA is
+		// all-or-nothing per graph (ggml.go), so VEC cannot cover prefill; WMMA is
+		// Volta-only and tile is compiled out for >= Volta. Volta (cc 7.0) is the only cc
+		// whose selected FA path fully works (WMMA), so restrict CUDA FA to it. Upstream
+		// allows cc >= 7 (it builds with CUDA >= 11.8 where MMA works); this is the fork's
+		// toolchain adaptation. The ggml_cuda_should_use_mma_fattn predicate
+		// (fattn-mma-f16.cuh) is the paired CUDA-layer guard. See #385.
 		supportsFA := gpu.Library == "cpu" ||
 			gpu.Name == "Metal" || gpu.Library == "Metal" ||
 			(gpu.Library == "CUDA" && gpu.ComputeMajor == 7 && gpu.ComputeMinor == 0) ||

--- a/ml/device.go
+++ b/ml/device.go
@@ -435,9 +435,18 @@ func (a DeviceInfo) IsBetter(b DeviceInfo) bool {
 // For each GPU, check if it does NOT support flash attention
 func FlashAttentionSupported(l []DeviceInfo) bool {
 	for _, gpu := range l {
+		// CUDA: this fork builds with CUDA 11.4 (to keep sm_37 alive), where the only
+		// flash-attention kernel with compiled device code is WMMA — and WMMA's device
+		// code is Volta-only (cc 7.0). Turing/Ampere (cc >= 7.5) select MMA_F16, which
+		// needs CUDA 11.8 (movmatrix.sync.aligned); its fallbacks have no sm_75+ device
+		// code (WMMA is == Volta, tile is compiled out for >= Volta), so FA crashes the
+		// runner there. Restrict CUDA FA to Volta (cc 7.0). Upstream allows cc >= 7 (it
+		// builds with CUDA >= 11.8 where MMA works); this is the fork's toolchain
+		// adaptation. The ggml_cuda_should_use_mma_fattn predicate (fattn-mma-f16.cuh) is
+		// the paired CUDA-layer guard. See #385.
 		supportsFA := gpu.Library == "cpu" ||
 			gpu.Name == "Metal" || gpu.Library == "Metal" ||
-			(gpu.Library == "CUDA" && gpu.ComputeMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
+			(gpu.Library == "CUDA" && gpu.ComputeMajor == 7 && gpu.ComputeMinor == 0) ||
 			gpu.Library == "ROCm"
 
 		if !supportsFA {


### PR DESCRIPTION
Closes #385.

## The bug

On the default config, flash attention **auto-enables and crashes the runner** on every cc≥7.5 NVIDIA card — no user action needed. Reproduced on an RTX 2060: `qwen3.5:0.8b` (or any whitelisted arch) panics on the first token.

## Root cause (traced across sm_37→sm_86, both our ggml and upstream)

The selector picks `MMA_F16` for cc≥7.5, but that kernel needs `movmatrix.sync.aligned` PTX = **CUDA 11.8**. This fork is pinned to **CUDA 11.4** (to keep sm_37 alive). Under 11.4, no FA kernel has usable sm_75+ device code:

| Kernel | sm_75 device code? |
|---|---|
| MMA_F16 | compiled, but `movmatrix` needs 11.8 → wrong results |
| WMMA | **no** — `== VOLTA` (sm_70 only); upstream removed CUDA-WMMA entirely |
| TILE | **no** — compiled out for `≥ VOLTA` |
| VEC | yes, but decode-only (no prefill) |

**Scope:** the crash is **cc 7.5 / 8.0 / 8.6** (Turing, Ampere). **cc 7.0 (Volta) is fine** — it uses WMMA, whose device code *is* compiled for sm_70. cc < 7.0 is safe (FA vetoed at the Go gate). Full table in #385.

## The fix — two guards, following ggml/ollama's existing two-layer design

Confirmed via codebase-memory that this mirrors how the codebase already separates concerns:

- **Layer 1 — Go support gate** (`ml/device.go` `FlashAttentionSupported`): restrict CUDA FA to Volta (`ComputeMajor == 7 && ComputeMinor == 0`). Turing/Ampere never turn FA on → no `flash_attn_ext` op → **GPU non-FA attention** (fast, correct), on every run path, crash-proof even if `OLLAMA_FLASH_ATTENTION=1`.
- **Layer 2 — CUDA kernel predicate** (`fattn-mma-f16.cuh` + `fattn.cu`): `ggml_cuda_should_use_mma_fattn` — don't select MMA_F16 under `CUDART_VERSION < 11080`. A direct sibling of upstream's `ggml_cuda_should_use_wmma_fattn`.

Does **not** raise the CUDA version (that drops sm_37 — the fork's reason to exist; `docs/porting-k80.md` §1). The Go gate edits a function that already carried fork FA logic (#340).

## Verification (real hardware, both testbeds)

Built on sm37 → published to `dogkeeper886/ollama37-ci` by digest → pulled on sm75 (same bits).

- **Compiles** (Go + CUDA, 9-arch) on sm37 ✅
- **No-harm** on sm37 (K80): runtime + inference green, byte-identical (K80 never matched the CUDA FA clause) ✅
- **sm75 (RTX 2060):** `qwen3.5:0.8b` default config → **103.7 tok/s, coherent, 0 crashes** (was: panic → then no-device-code) ✅
- **Crash-proof:** `OLLAMA_FLASH_ATTENTION=1` forced → gate keeps `FlashAttention:false`, no crash ✅

## Not proven

cc 7.0 (Volta) and cc 8.0/8.6 (Ampere) — no hardware. Both follow the same trace: Volta keeps working FA via WMMA; Ampere is fixed like Turing by the same gate.

## Note on the extra testcase

`cicd/tests/testcases/build/TC-BUILD-004.yml` (publish CI image by digest) is the transport mechanism used to carry the built image sm37→sm75 for this verification — the publish half of the two-testbed flow (`cicd/docs/PLAN.md`). Included here because it's how the fix was proven; can be split out if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)