### PR TITLE
ci: experiment infrastructure for the FA path comparison

### DIFF
--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -34,8 +34,15 @@ Performance and capability experiments run via the runner's perf subcommands, se
 suite workflows:
 
 ```
-└── test-throughput.yml   # cli.ts bench-throughput — per-model tok/s + output check
+├── test-throughput.yml   # cli.ts bench-throughput — per-model tok/s + output check (short prompt)
+└── test-context.yml      # cli.ts bench-context — long-context prefill/decode tok/s + needle + judge
 ```
+
+`test-context.yml` is the flash-attention path comparison: it primes a realistic long prompt (so
+prefill and decode are in the regime where FA's cost/benefit shows) and is self-contained — it
+applies the experiment env (`flash_attention`/`kv_cache_type`) by recreating the container, then
+`always()` reverts to the stable baseline (FA off). `test-throughput.yml` stays the short-prompt K80
+model-regression tool.
 
 (`cli.ts test-mcp` — MCP tool-call capability — is a subcommand with no workflow yet.)
 `release-docker.yml` builds and publishes the image on a release.

--- a/.claude/skills/ci-run/SKILL.md
+++ b/.claude/skills/ci-run/SKILL.md
@@ -10,6 +10,7 @@ Execute test cases and evaluate results. The simple (deterministic) judge is the
 default verdict; the agent judge is an opt-in second opinion (`JUDGE_MODE=dual`),
 keyless on a Claude Code subscription.
 
+```
 $ARGUMENTS
 
 ## PURPOSE
@@ -23,8 +24,9 @@ Run YAML test cases by executing commands and evaluating results against pattern
 ### Step 1: Load Test Cases
 
 Input can be:
-- A test ID (e.g., `TC-RUNTIME-001`) — run that specific test
-- A suite name (`build`, `runtime`, `inference`, or `models`) — run all tests in that suite
+- A test ID (e.g., `TC-INT-001`) — run that specific test
+- A suite name (e.g., `integration`) — run all tests in that suite
+- A tag name (e.g., `auth`) — run all tests with that tag
 - Empty — run all tests
 
 Read YAML test case files from `cicd/tests/testcases/`.
@@ -66,12 +68,12 @@ Output a summary table:
 ```
 Test Results
 ============
-TC-RUNTIME-001   Container Startup     PASS  (12.4s)
-TC-RUNTIME-002   GPU Detection         FAIL  (step 4: expected "library=CUDA" not found)
-TC-INFERENCE-002 API Inference Test    PASS  (8.1s)
+TC-INT-001  Query resources            PASS  (1.2s)
+TC-INT-002  Create and verify          FAIL  (step 2: expected pattern "active" not found)
+TC-E2E-001  Full lifecycle             PASS  (5.8s)
 
 Summary: 2/3 passed
-Duration: 28.6s
+Duration: 8.2s
 ```
 
 If any test failed, show:
@@ -85,144 +87,18 @@ Instead of agent-based execution, use the built-in CLI:
 
 ```bash
 cd cicd/tests
-npm test                         # All tests (simple judge — fast, no model)
-npm test -- --suite runtime      # Specific suite (build|runtime|inference|models)
-npm test -- --id TC-RUNTIME-001  # Specific test
-npm test -- --dry-run            # Preview only
-JUDGE_MODE=dual npm test         # Opt in the agent judge (env, not a flag)
+npm test                        # All tests (simple judge — fast, no model)
+npm test -- --suite integration # Specific suite
+npm test -- --id TC-INT-001     # Specific test
+npm test -- --tag auth          # Tests tagged 'auth'
+npm test -- --dry-run           # Preview only
+JUDGE_MODE=dual npm test        # Opt in the agent judge (env, not a flag)
 ```
 
 **Environment variables for CI:**
 - `JUDGE_MODE` — `simple` (default) or `dual` (opt in the agent judge)
 - `JUDGE_AGENT` — Command for the ACP agent the judge drives; unset uses the bundled Claude ACP agent (keyless). Set it to swap model/vendor
 - `CLAUDE_CODE_OAUTH_TOKEN` — Authenticates the bundled Claude agent on a GitHub-hosted runner; unneeded on a self-hosted runner logged into Claude Code (`~/.claude`)
-
----
-
-## THE BUILD
-
-`test-build.yml` does not *wrap* a build — **`TC-BUILD-002` IS the build.** It runs
-`make build-runtime-local-no-cache`, a full no-cache compile.
-
-```
-   make build  =  build-builder  +  build-runtime
-                        │                 │
-   ensure-builder ──────┘                 │
-     builder image absent?                │
-       → builds it LOCALLY (~90 min,      │
-         CMake from source). It never     │
-         pulls. ~15 GB, then cached.      │
-                                          ▼
-                        ┌─────────────────────────────────┐
-                        │  runtime image, --no-cache,     │
-                        │  preset "CUDA 11 K80"           │
-                        │  native CUBIN sm_37…sm_86       │
-                        │  (no PTX ⇒ no first-run JIT)    │
-                        └───────────────┬─────────────────┘
-                                        ▼
-                             ollama37:latest  (LOCAL tag)
-                                        │
-                        docker/docker-compose.yml reads it
-```
-
-**Two Dockerfiles, same commit, different mechanism:**
-
-| Caller | Target | Dockerfile | Source |
-|---|---|---|---|
-| `TC-BUILD-002` (CI) | `build-runtime-local-no-cache` | `runtime/Dockerfile.local` | `COPY .` — the checkout |
-| `release-docker.yml` | `build-runtime-no-cache` | `runtime/Dockerfile` | `git clone` pinned to `GIT_COMMIT` |
-
-**The build needs no GPU** — nothing passes `--gpus`, and `nvcc` compiles without a device. It
-is host-independent. It stays on `sm37` because `ensure-builder` would otherwise reconstruct the
-15 GB builder from scratch on the other box.
-
----
-
-## WHICH TESTBED
-
-Two self-hosted runners. They are **independent hosts with no network between them**, so a
-Docker tag on one names nothing on the other. Select the host with `runner_label`; move the
-image through a registry, by digest.
-
-```
-                    ┌──────────────────────────────────────────────┐
-                    │  Docker Hub — public, pull needs no auth      │
-                    │  dogkeeper886/ollama37-ci:ci-<sha>            │
-                    │                      @sha256:<digest>        │
-                    └───────▲──────────────────────────┬───────────┘
-                    publish │                          │ fetch, by digest
-                   (sm37 only)                         │ (BOTH hosts)
-   ┌────────────────────────┴──────┐      ┌────────────▼──────────────────┐
-   │ sm37   rocky9-k80-cicd-1      │      │ sm75   rocky9-2060-cicd-1     │
-   │ 4× Tesla K80 · cc 3.7         │      │ RTX 2060 · cc 7.5             │
-   │ driver 470 · 11.4 GiB per die │      │ driver 580 · 5.1 GiB usable   │
-   │ GPU_TEMP_LIMIT=80             │      │ GPU_TEMP_LIMIT=85             │
-   │ THE REFERENCE TESTBED         │      │ the only tensor-core testbed  │
-   ├───────────────────────────────┤      ├───────────────────────────────┤
-   │ build      the build itself   │      │ build      no — hours, no cache│
-   │ runtime    yes                │      │ runtime    yes                │
-   │ inference  yes                │      │ inference  see note below     │
-   │ models     yes (16 cases)     │      │ models     never — VRAM       │
-   │ perf       yes                │      │ perf       models that fit    │
-   └───────────────────────────────┘      └───────────────────────────────┘
-
-   fetch on BOTH, including the host that built. Testing a local build on sm37
-   while sm75 tests a pulled image compares two artifacts, not one.
-```
-
-**Why a digest, never a tag.** A tag can be overwritten; a digest cannot. That is the only
-thing making "sm37 says no-harm" and "sm75 says fixed" statements about the same bits.
-
-**`runner_label`.** Today only `test-runtime.yml` takes it (`workflow_dispatch` and
-`workflow_call`, default `sm37`). Every other workflow is still pinned to `sm37`. Never use a
-bare `runs-on: self-hosted` — a K80 sweep landing on a small consumer card produces numbers
-that look valid and are not. See `.claude/rules/workflow-patterns.md`.
-
-```bash
-gh workflow run test-runtime.yml -f runner_label=sm75
-```
-
-**Per-host knobs live on the host.** `cicd/scripts/gpu-temp-guard.sh` reads `GPU_TEMP_LIMIT`
-from the environment; each runner sets it in `~/actions-runner/.env`. Don't change the script
-default, and don't add a workflow input for it.
-
-**What a suite actually runs.** `docker/docker-compose.yml` reads the local tag
-`ollama37:latest`. To test a specific build, pull it by digest and retag to that name — no
-compose change is needed. The publish and fetch steps belong in **testcases** (see
-`ci-testcase`), driven by these workflows with `--id`; they are not yet written.
-
-**`inference` on sm75 is currently blocked.** `TC-INFERENCE-001` pulls `gemma3:4b`, an
-architecture on ollama's flash-attention whitelist. On cc ≥ 7.5 the stock compose auto-enables
-FA and the runner panics — issue #385. Once that lands, `test-inference` on sm75 becomes its
-regression test.
-
-## VERIFYING A CODE CHANGE ACROSS BOTH TESTBEDS
-
-A change to the CUDA backend cannot be verified on one card. `sm37` proves nothing regressed;
-`sm75` proves the fix works on silicon `sm37` cannot reach.
-
-```
-  1  push a branch
-  2  test-build.yml            @ sm37   → compiles the branch → ollama37:latest (local)
-  3  publish                   @ sm37   → tag ci-<sha>, push, print the digest
-  4  fetch <digest>            @ sm37   ┐ BOTH hosts pull the same digest and retag
-     fetch <digest>            @ sm75   ┘ to ollama37:latest, which compose reads
-  5  runtime+inference+models  @ sm37   → the no-harm gate: the sweep must not move
-     runtime+<the regression>  @ sm75   → does the fix actually work on cc 7.5?
-  6  benchmark                 @ sm75   → keep the change only if it wins
-  7  (manual) release-docker   @ sm37   → rebuilds at the release tag, pushes :latest
-```
-
-**Both hosts fetch, including the one that built.** Testing a local build on `sm37` while
-`sm75` tests a pulled image compares two artifacts, not one.
-
-**Benchmark before you keep an optimization** (`docs/porting-k80.md` §2), at a realistic
-context — ≥ 6.8k tokens, not a one-line prompt (§3). A short prompt hid a 7.4× flash-attention
-regression on the K80 behind a 22% one.
-
-**Steps 3-4 are not implemented.** The publish/fetch testcases are not yet written, and a
-testcase cannot emit a workflow output — so handing the digest from the publishing run to the
-fetching run is an open problem. See `cicd/docs/PLAN.md`.
 
 ---
 

--- a/.claude/skills/ci-testcase/SKILL.md
+++ b/.claude/skills/ci-testcase/SKILL.md
@@ -8,6 +8,7 @@ user-invocable: true
 
 Generate a YAML test case file from requirements or acceptance criteria.
 
+```
 $ARGUMENTS
 
 ## PURPOSE
@@ -45,23 +46,16 @@ Create test case file(s) in `cicd/tests/testcases/<suite>/` using this format:
 ```yaml
 id: TC-[SUITE]-[NUMBER]
 name: Descriptive test name
-suite: build|runtime|inference|models
+suite: build|integration|e2e
+goal: One-line test objective for agent judge
 priority: 1-10 (lower = runs first)
 timeout: 30000
 dependencies: []
 tags: [feature-name]
 
-intent:                    # the design authority — why this test exists
-  user_story: |
-    What value this test delivers
-  acceptance:              # optional — observable criteria
-    - "..."
-  notes: |                 # optional — prerequisites, gotchas, acceptable warnings
-    ...
-
 steps:
   - name: Step description
-    command: <shell command>
+    command: <shell command or mcp-client.ts call>
     timeout: 5000              # Optional
     expectPatterns:
       - "regex pattern"
@@ -75,16 +69,18 @@ criteria: |
 ```
 
 **Suite guidelines:**
-- `build` — toolchain image, runtime image build, image sizes. **Also where the CI image is
-  published and fetched**: a testcase may have side effects (`TC-BUILD-002` runs
-  `make build-runtime-local-no-cache`). `sm37` only.
-- `runtime` — container startup, GPU detection, health, `/api/metrics`. Runs on either testbed.
-- `inference` — model pull + GPU inference smoke.
-- `models` — per-model regression. `sm37` only: the models exceed any other card's VRAM.
+- `build` — compilation, dependency checks, environment validation
+- `integration` — single tool/API calls, verify output format and correctness
+- `e2e` — multi-step workflows, verify end-to-end state
 
-**ID format:** `TC-BUILD-XXX`, `TC-RUNTIME-XXX`, `TC-INFERENCE-XXX`, `TC-MODELS-XXX`
+**ID format:** `TC-BUILD-XXX`, `TC-INT-XXX`, `TC-E2E-XXX`
 
-**Tags:** the `tags:` field is optional metadata; the runner selects by `--suite`/`--id` (there is no `--tag` filter).
+**Tags:** Use feature names or capability areas (e.g., `auth`, `api`, `build`). Tags enable per-feature CI workflows via `--tag`.
+
+**For MCP tool testing:**
+```yaml
+command: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '{"arg":"value"}'
+```
 
 **For shell command testing:**
 ```yaml
@@ -103,46 +99,6 @@ steps:
 ```
 
 Variables resolve from captured step output first, then fall back to `process.env`.
-
----
-
-### Writing for two testbeds
-
-The suites run on **`sm37`** (4× Tesla K80, cc 3.7, driver 470) and **`sm75`** (RTX 2060,
-cc 7.5, driver 580). A testcase is plain shell, executed on whichever runner the workflow
-selected. It cannot know which one — so don't let it assume.
-
-**Assert the property, not the device.** A test that names one testbed's hardware fails on
-the other while testing nothing more.
-
-```yaml
-# WRONG — TC-RUNTIME-002 does this today, and it fails on sm75
-expectPatterns:
-  - "Tesla K80"        # the device
-  - "470\\."           # its driver
-  - "compute=3\\.7"    # its compute capability
-
-# RIGHT — the intent is "a CUDA GPU was detected and is in use"
-expectPatterns:
-  - "library=CUDA"
-  - "compute=[0-9]+\\.[0-9]+"
-rejectPatterns:
-  - "library=cpu"
-```
-
-The exact card, driver and compute capability are already recorded per run by the
-`identify-host` action. A testcase does not need to restate them.
-
-**Host-specific values come from the environment, never a literal.** Variables fall back to
-`process.env`, so a workflow passes a CI image digest, a temperature limit, or a model name
-in — the YAML stays host-agnostic.
-
-**Size the test to the smallest testbed it may run on**, or scope it to one suite. `sm75` has
-~5.1 GiB of usable VRAM; the `models` suite exceeds that, which is why it is `sm37` only.
-
-**A testcase cannot emit a workflow output.** It prints to stdout and the results JSON. If a
-later workflow run needs a value it produced — an image digest, say — that handoff is the
-workflow's problem, not the testcase's.
 
 ### Step 4: Report
 

--- a/.claude/skills/ollama37-ci-apply/SKILL.md
+++ b/.claude/skills/ollama37-ci-apply/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: ollama37-ci-apply
+description: Apply a built ollama37 image onto a testbed through CI — recreate the container, never docker compose by hand
+user-invocable: true
+---
+
+# Apply the ollama37 image with CI
+
+Roll a freshly built image onto a testbed through the GitHub Actions runtime workflow on a self-hosted
+runner — never `docker compose up` or `docker exec` on a dev box. To *build* the image first, see
+`ollama37-ci-build`.
+
+$ARGUMENTS
+
+## Applying = running the runtime workflow
+
+**`test-runtime.yml` is how a built image is applied.** `TC-RUNTIME-001` runs `docker compose down`
+then `docker compose up -d`, which recreates the container from the current **`ollama37:latest`** — so
+it picks up whatever `ollama37-ci-build` last built. The `ollama-data` volume is `external`, so pulled
+models survive the recreate. The same run then exercises the runtime checks (startup, GPU detection,
+health).
+
+```bash
+gh workflow run test-runtime.yml --ref <branch> -f runner_label=<sm37|sm75>
+```
+
+- **`runner_label`** — which box: `sm37` (`rocky9-k80-cicd-1`, the reference K80 testbed) or `sm75`
+  (`rocky9-2060-cicd-1`, RTX 2060). Default `sm37`. Never a bare `runs-on: self-hosted` — a K80 sweep on
+  a consumer card produces numbers that look valid and are not.
+- **`--ref <branch>`** — check out that branch's `docker-compose.yml` and testcases. Omit for the
+  default branch.
+
+Never `docker compose up`/`down` yourself to apply an image — run the runtime workflow so the recreate
+is logged and reproducible.
+
+## Where apply fits
+
+`ollama37-ci-build` builds the image; this skill applies it; then the test suites
+(`test-models.yml`, etc.) exercise it. `test-pipeline.yml` chains `build → runtime → inference →
+models` for one `runner_label` if you want the whole flow in one run. For a CUDA change that must hold
+on both cards, apply the **same published digest** on both hosts before testing — see `ollama37-ci-build`.

--- a/.claude/skills/ollama37-ci-build/SKILL.md
+++ b/.claude/skills/ollama37-ci-build/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ollama37-ci-build
+description: Build (and publish) the ollama37 CI image on a self-hosted GPU runner — never with a local make
+user-invocable: true
+---
+
+# Build the ollama37 CI image with CI
+
+Build the fork's runtime image through the GitHub Actions build workflow on a self-hosted runner —
+`gh workflow run`, never `make build-runtime-local` on a dev box. To *apply* a built image to a
+testbed, see `ollama37-ci-apply`.
+
+$ARGUMENTS
+
+## Never build by hand — a local build is version-crippled
+
+A local `make` build defaults `OLLAMA_VERSION=0.0.0` (`docker/Makefile`), and the ollama registry
+rejects every gated model pull from an old version with `412: requires a newer version` — so the image
+*looks* fine and silently cannot pull modern models (qwen3.5, gemma3, ministral-3, …). The CI build
+injects `OLLAMA_VERSION` from the **repo variable** (check it: `gh variable list`), which is `>` any
+`0.x` minimum and clears the gate. Only the CI image can pull those models. It also leaves logs; a hand
+`make` leaves nothing.
+
+## The build
+
+**`TC-BUILD-002` IS the build** — `test-build.yml` runs `make build-runtime-local-no-cache`, a full
+no-cache compile (preset "CUDA 11 K80", native CUBIN sm_37…sm_86, no GPU needed). It produces the local
+tag **`ollama37:latest`** on the runner it ran on.
+
+```bash
+gh workflow run test-build.yml --ref <branch> -f runner_label=<sm37|sm75>
+gh run watch <run-id> --exit-status        # block until done; GitHub holds the logs
+```
+
+- **`runner_label`** — which box: `sm37` (`rocky9-k80-cicd-1`, 4× K80) or `sm75` (`rocky9-2060-cicd-1`,
+  RTX 2060). Default `sm37`. Never a bare `runs-on: self-hosted`.
+- **`--ref <branch>`** — which code. Omit to build the default branch.
+- The build normally runs on **`sm37`** (its ~15 GB builder image is cached there; on a fresh host
+  `ensure-builder` rebuilds it, ~90 min). It can run on `sm75` only if `ollama37-builder:latest` is
+  already present there.
+
+## The CI image, and moving it between testbeds
+
+`ollama37:latest` is a **local tag** on one runner's Docker daemon — `docker/docker-compose.yml` reads
+exactly this tag. The two runners are **independent hosts with no network between them**, so the tag on
+`sm37` names nothing on `sm75`. To test the *same bits* on both cards, publish to Docker Hub
+**`dogkeeper886/ollama37-ci:ci-<sha>`** and fetch **by digest** (`@sha256:…`, immutable — a tag can be
+overwritten, a digest cannot). `TC-BUILD-004` publishes; a fetch step retags the digest back to
+`ollama37:latest` so compose reads it. That published, digest-addressed artifact is "the CI image."
+
+Once built, hand off to `ollama37-ci-apply` to roll it onto the testbed.

--- a/.claude/skills/ollama37-ci-perf/SKILL.md
+++ b/.claude/skills/ollama37-ci-perf/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ollama37-ci-perf
+description: Run a decision-grade FA/CUDA performance experiment via CI — verified throughput, self-reverting testbed
+user-invocable: true
+---
+
+# Run an ollama37 performance experiment with CI
+
+Measure a CUDA / flash-attention change's real performance through `test-throughput.yml` on a
+self-hosted runner — tok/s that can actually decide whether to keep or drop the change. Build the
+variant under test with `ollama37-ci-build`; apply an image with `ollama37-ci-apply`.
+
+$ARGUMENTS
+
+## Decision-grade, or it doesn't count
+
+Raw tok/s from a hand `curl` loop is **not** evidence for an FA decision — it is single-run and never
+checks the answer is correct; a path that is faster but emits garbage is not a win. Decision-grade
+means all three:
+
+- **Verified response** — `judge_mode=dual` runs the keyless agent judge for *meaningfulness*, not
+  just "non-empty." Required for any keep/drop decision.
+- **Realistic context** — `context_size` ≥ ~6.8k, not a one-line prompt. A short prompt once hid a
+  7.4× flash-attention regression on the K80 behind a 22% one (`docs/porting-k80.md` §3).
+- **Consistent** — the workflow recreates the container per run, so the state is fixed; compare paths
+  on the same model + context.
+
+## A "path" is (build) × (runtime env)
+
+- **`--ref <branch>`** selects the *kernel routing* that got compiled — FA-off, all-VEC, decode-only,
+  MMA-on, … — i.e. `ollama37-ci-build`'s output.
+- **`flash_attention`** selects *FA vs the non-FA cuBLAS path* at runtime: `0` = cuBLAS baseline,
+  `1` = FA. `kv_cache_type` is the other runtime knob.
+
+## Run one
+
+```bash
+gh workflow run test-throughput.yml --ref <branch> \
+  -f runner_label=sm75 \
+  -f models=<model> \
+  -f flash_attention=<0|1> \
+  -f kv_cache_type='' \
+  -f context_size=8192 -f num_predict=128 \
+  -f judge_mode=dual
+gh run watch <run-id> --exit-status
+```
+
+Read the markdown table in the run summary: **Prompt tok/s** = prefill, **Gen tok/s** = decode,
+**Check** = PASS/FAIL (the judge's verdict). Collect one row per path and compare.
+
+## The testbed reverts itself — fail is data
+
+`test-throughput.yml` is self-contained: it applies the experiment env by recreating the container,
+benchmarks, and in an `always()` step **reverts to the stable baseline (`OLLAMA_FLASH_ATTENTION=0`)**.
+So a kernel that panics — e.g. tensor-core MMA on Turing under CUDA 11.4 — is a *recorded result*
+("unusable"), and the testbed is still left clean for the next run. Never chase a green result by
+dodging the crash; the crash is the finding.
+
+`models` is `sm37`-only for the large models; on `sm75` size to the ~5 GiB it has.

--- a/.claude/skills/ollama37-ci-perf/SKILL.md
+++ b/.claude/skills/ollama37-ci-perf/SKILL.md
@@ -19,7 +19,9 @@ checks the answer is correct; a path that is faster but emits garbage is not a w
 means all three:
 
 - **Verified response** — `judge_mode=dual` runs the keyless agent judge for *meaningfulness*, not
-  just "non-empty." Required for any keep/drop decision.
+  just "non-empty." Required for any keep/drop decision. **`dual` silently degrades to `simple` if the
+  runner has no agent-judge auth (`~/.claude`)** — so confirm a judge *verdict* actually appears in the
+  run; if it fell back to `simple`, the response is not verified and the number is not decision-grade.
 - **Realistic context** — `context_size` ≥ ~6.8k, not a one-line prompt. A short prompt once hid a
   7.4× flash-attention regression on the K80 behind a 22% one (`docs/porting-k80.md` §3).
 - **Consistent** — the workflow recreates the container per run, so the state is fixed; compare paths

--- a/.github/workflows/test-context.yml
+++ b/.github/workflows/test-context.yml
@@ -1,0 +1,148 @@
+name: Long-context Benchmark
+
+# Long-context FA path comparison: primes a realistic prompt + needle, measures
+# prefill/decode tok/s, verifies simple ∧ needle ∧ agent(dual). Self-contained —
+# applies the experiment env (flash_attention/kv_cache_type) by recreating the
+# container, benchmarks, and always() reverts to the stable baseline (FA off).
+# Keeps test-throughput.yml pure as the short-prompt K80 model-regression tool.
+
+on:
+  workflow_dispatch:
+    inputs:
+      models:
+        description: "Models to benchmark (space-separated)"
+        required: true
+        default: "qwen2.5:3b"
+        type: string
+      context:
+        description: "Target primed-prompt length in tokens (realistic ≥ ~6800)"
+        required: false
+        default: "8192"
+        type: string
+      num_predict:
+        description: "Max tokens to generate"
+        required: false
+        default: "128"
+        type: string
+      flash_attention:
+        description: "OLLAMA_FLASH_ATTENTION: 0 = off (cuBLAS baseline), 1 = on (FA)."
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
+      kv_cache_type:
+        description: "OLLAMA_KV_CACHE_TYPE (e.g. f16, q8_0). Empty = compose default (f16)."
+        required: false
+        default: ""
+        type: string
+      judge_mode:
+        description: "Output validation (simple = non-empty + needle; dual = also the keyless agent judge)"
+        required: false
+        default: "simple"
+        type: choice
+        options:
+          - "simple"
+          - "dual"
+      runner_label:
+        description: "Which GPU testbed. sm37 = Tesla K80. sm75 = RTX 2060 (~5.1 GiB)."
+        required: false
+        default: "sm75"
+        type: choice
+        options:
+          - "sm37"
+          - "sm75"
+
+env:
+  OLLAMA_HOST: http://localhost:11434
+
+jobs:
+  context:
+    name: Long-context Benchmark
+    runs-on: [self-hosted, "${{ inputs.runner_label || 'sm75' }}"]
+    environment: cicd-1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Identify host
+        uses: ./.github/actions/identify-host
+
+      - name: Validate inputs
+        env:
+          MODELS: ${{ inputs.models }}
+        run: |
+          if ! echo "$MODELS" | grep -qE '^[a-zA-Z0-9:._/ -]+$'; then
+            echo "ERROR: Invalid characters in model names: $MODELS" >&2
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install test runner dependencies
+        run: cd cicd/tests && npm ci
+
+      # Self-contained: apply the experiment env by recreating the container from the
+      # current ollama37:latest. The always() revert below restores the stable baseline
+      # (FA off) even if the benchmark panics — the testbed is never left experimental.
+      - name: Apply experiment environment
+        env:
+          FA: ${{ inputs.flash_attention || '0' }}
+          KV: ${{ inputs.kv_cache_type }}
+        run: |
+          cd docker
+          echo "Applying experiment env: OLLAMA_FLASH_ATTENTION=${FA} OLLAMA_KV_CACHE_TYPE='${KV}'"
+          OLLAMA_FLASH_ATTENTION="${FA}" OLLAMA_KV_CACHE_TYPE="${KV}" docker compose up -d --force-recreate
+          for i in $(seq 1 60); do curl -sf "${OLLAMA_HOST}/api/tags" >/dev/null 2>&1 && break; sleep 2; done
+          curl -sf "${OLLAMA_HOST}/api/tags" >/dev/null 2>&1 || { echo "server did not come up"; docker compose logs 2>&1 | tail -30; exit 1; }
+          docker compose logs 2>&1 | grep -i "flash_attn" | tail -2 || true
+
+      - name: Run long-context benchmark
+        env:
+          MODELS: ${{ inputs.models }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -o pipefail
+          cd cicd/tests
+          JUDGE_FLAG=""
+          if [ "${{ inputs.judge_mode || 'simple' }}" = "dual" ]; then
+            JUDGE_FLAG="--judge"
+          fi
+          echo "Judge mode: ${{ inputs.judge_mode || 'simple' }}"
+          # shellcheck disable=SC2086 -- intentional word splitting on models + flag
+          bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts bench-context $MODELS \
+            --num-predict "${{ inputs.num_predict || '128' }}" \
+            --context "${{ inputs.context || '8192' }}" \
+            --output /tmp/context-results.json \
+            $JUDGE_FLAG | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Unload models
+        if: always()
+        env:
+          MODELS: ${{ inputs.models }}
+        run: |
+          for MODEL in $MODELS; do
+            curl -s "${OLLAMA_HOST}/api/generate" -d "{\"model\":\"${MODEL}\",\"keep_alive\":0}" || true
+          done
+
+      # Guaranteed revert: restore the stable baseline (FA off) whatever happened above.
+      - name: Revert to stable baseline (FA off)
+        if: always()
+        run: |
+          cd docker
+          echo "Reverting testbed to stable baseline: OLLAMA_FLASH_ATTENTION=0"
+          OLLAMA_FLASH_ATTENTION=0 docker compose up -d --force-recreate
+          for i in $(seq 1 60); do curl -sf "${OLLAMA_HOST}/api/tags" >/dev/null 2>&1 && break; sleep 2; done
+          echo "Baseline restored (FA off)."
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: context-results
+          path: /tmp/context-results.json

--- a/.github/workflows/test-context.yml
+++ b/.github/workflows/test-context.yml
@@ -46,9 +46,9 @@ on:
           - "simple"
           - "dual"
       runner_label:
-        description: "Which GPU testbed. sm37 = Tesla K80. sm75 = RTX 2060 (~5.1 GiB)."
+        description: "Which GPU testbed. sm37 = Tesla K80 (reference). sm75 = RTX 2060 (~5.1 GiB) — pick this for the FA study."
         required: false
-        default: "sm75"
+        default: "sm37"
         type: choice
         options:
           - "sm37"
@@ -60,7 +60,7 @@ env:
 jobs:
   context:
     name: Long-context Benchmark
-    runs-on: [self-hosted, "${{ inputs.runner_label || 'sm75' }}"]
+    runs-on: [self-hosted, "${{ inputs.runner_label || 'sm37' }}"]
     environment: cicd-1
 
     steps:

--- a/.github/workflows/test-inference.yml
+++ b/.github/workflows/test-inference.yml
@@ -7,6 +7,11 @@ on:
         description: "Run a single test by ID (e.g. TC-INFERENCE-001)"
         required: false
         type: string
+      model:
+        description: "Model to pull and test (TEST_MODEL). Default gemma3:4b."
+        required: false
+        default: "gemma3:4b"
+        type: string
       judge_mode:
         description: "Test judge mode (simple = SimpleJudge only; dual = also run the keyless agent judge)"
         required: false
@@ -30,6 +35,11 @@ on:
           - "sm75"
   workflow_call:
     inputs:
+      model:
+        description: "Model to pull and test (TEST_MODEL)"
+        required: false
+        default: "gemma3:4b"
+        type: string
       judge_mode:
         description: "Test judge mode (simple, dual)"
         required: false
@@ -85,6 +95,8 @@ jobs:
           # dual mode runs the keyless agent judge; the runner reads JUDGE_MODE.
           JUDGE_MODE: ${{ inputs.judge_mode || 'simple' }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # inference testcases read TEST_MODEL (they default to gemma3:4b in-shell).
+          TEST_MODEL: ${{ inputs.model || 'gemma3:4b' }}
         run: |
           cd cicd/tests
           echo "Judge mode: ${JUDGE_MODE}"
@@ -114,9 +126,11 @@ jobs:
 
       - name: Unload test models from VRAM
         if: always()
+        env:
+          TEST_MODEL: ${{ inputs.model || 'gemma3:4b' }}
         run: |
           echo "Unloading test models from VRAM..."
-          curl -s http://localhost:11434/api/generate -d '{"model":"gemma3:4b","keep_alive":0}' || true
+          curl -s http://localhost:11434/api/generate -d "{\"model\":\"${TEST_MODEL}\",\"keep_alive\":0}" || true
           echo "Models unloaded"
 
       - name: Upload inference results

--- a/.github/workflows/test-throughput.yml
+++ b/.github/workflows/test-throughput.yml
@@ -34,6 +34,19 @@ on:
         options:
           - "sm37"
           - "sm75"
+      flash_attention:
+        description: "OLLAMA_FLASH_ATTENTION for this run: 0 = off (cuBLAS, the stable baseline), 1 = on (FA)."
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
+      kv_cache_type:
+        description: "OLLAMA_KV_CACHE_TYPE (e.g. f16, q8_0). Empty = compose default (f16)."
+        required: false
+        default: ""
+        type: string
 
 env:
   OLLAMA_HOST: http://localhost:11434
@@ -69,6 +82,23 @@ jobs:
       - name: Install test runner dependencies
         run: cd cicd/tests && npm ci
 
+      # Self-contained: apply the experiment env by recreating the container from the
+      # current ollama37:latest. The always() revert step below restores the stable
+      # baseline (FA off) even if the benchmark crashes — the testbed is never left in
+      # an experimental state. Models live in the external ollama-data volume, so they
+      # survive the recreate.
+      - name: Apply experiment environment
+        env:
+          FA: ${{ inputs.flash_attention || '0' }}
+          KV: ${{ inputs.kv_cache_type }}
+        run: |
+          cd docker
+          echo "Applying experiment env: OLLAMA_FLASH_ATTENTION=${FA} OLLAMA_KV_CACHE_TYPE='${KV}'"
+          OLLAMA_FLASH_ATTENTION="${FA}" OLLAMA_KV_CACHE_TYPE="${KV}" docker compose up -d --force-recreate
+          for i in $(seq 1 60); do curl -sf "${OLLAMA_HOST}/api/tags" >/dev/null 2>&1 && break; sleep 2; done
+          curl -sf "${OLLAMA_HOST}/api/tags" >/dev/null 2>&1 || { echo "server did not come up"; docker compose logs 2>&1 | tail -30; exit 1; }
+          docker compose logs 2>&1 | grep -i "flash_attn" | tail -2 || true
+
       - name: Run throughput benchmark
         env:
           MODELS: ${{ inputs.models }}
@@ -102,6 +132,17 @@ jobs:
           for MODEL in $MODELS; do
             curl -s "${OLLAMA_HOST}/api/generate" -d "{\"model\":\"${MODEL}\",\"keep_alive\":0}" || true
           done
+
+      # Guaranteed revert: restore the stable baseline (FA off) whatever happened above —
+      # a benchmark crash/panic still leaves the testbed in a known-good state.
+      - name: Revert to stable baseline (FA off)
+        if: always()
+        run: |
+          cd docker
+          echo "Reverting testbed to stable baseline: OLLAMA_FLASH_ATTENTION=0"
+          OLLAMA_FLASH_ATTENTION=0 docker compose up -d --force-recreate
+          for i in $(seq 1 60); do curl -sf "${OLLAMA_HOST}/api/tags" >/dev/null 2>&1 && break; sleep 2; done
+          echo "Baseline restored (FA off)."
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -18,6 +18,7 @@ import { JsonReporter, ConsoleReporter } from './reporter/index.js';
 import { RunConfig } from './types.js';
 import { CONFIG, pickEnv } from './config.js';
 import { runThroughput } from './perf/throughput.js';
+import { runContext } from './perf/context.js';
 import { runMcpTest } from './mcp/test-mcp.js';
 
 const program = new Command();
@@ -248,6 +249,36 @@ program
     });
     // Flush stdout before forcing exit — the markdown summary is piped to tee
     // in CI, and process.exit() can truncate buffered pipe output.
+    await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));
+    process.exit(code);
+  });
+
+/**
+ * bench-context — long-context throughput + correctness for the FA path comparison.
+ *
+ * Primes a long DETERMINISTIC prompt (so prefill is realistic and the KV cache is
+ * full before decode) with a buried needle, then measures prefill/decode tok/s and
+ * a per-model verdict of simple ∧ needle ∧ agent(dual). Unlike bench-throughput's
+ * short prompt, this is the regime where flash attention's cost/benefit shows.
+ */
+program
+  .command('bench-context')
+  .description('Long-context benchmark (prefill/decode tok/s) with a deterministic needle + output validation')
+  .argument('<models...>', 'One or more model names to benchmark')
+  .option('-n, --num-predict <n>', 'Max tokens to generate', '128')
+  .option('-c, --context <n>', 'Target primed-prompt length in tokens', '8192')
+  .option('--judge', 'Also run the agent judge on each response (dual mode)', false)
+  .option('-H, --host <url>', 'Ollama host', process.env.OLLAMA_HOST || 'http://localhost:11434')
+  .option('-o, --output <file>', 'Write the JSON report to this file')
+  .action(async (models: string[], options) => {
+    const code = await runContext({
+      models,
+      numPredict: Number(options.numPredict),
+      context: Number(options.context),
+      judge: options.judge,
+      host: options.host,
+      output: options.output,
+    });
     await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));
     process.exit(code);
   });

--- a/cicd/tests/src/perf/context.ts
+++ b/cicd/tests/src/perf/context.ts
@@ -1,0 +1,269 @@
+/**
+ * Long-context benchmark for the flash-attention path comparison.
+ *
+ * Unlike `bench-throughput` (a fast, short-prompt K80 model-regression tool), this
+ * primes a long DETERMINISTIC prompt so prefill is realistic and the KV cache is
+ * full before decode — the only regime where flash attention's decode benefit and
+ * prefill cost are visible (docs/porting-k80.md §3). A buried "needle" makes
+ * long-context correctness checkable *deterministically*: a broken FA path emits
+ * fluent-but-wrong output, which a coherence judge passes and the needle catches.
+ *
+ * Per (model, context): prime ~context tokens → generate → measure prefill/decode
+ * tok/s → verdict = simple ∧ needle ∧ agent(dual). Deterministic prompt ⇒ stable
+ * numbers run-to-run. Calibrate against the FA=0 (cuBLAS) baseline: a model that
+ * fails the needle under cuBLAS is just weak at retrieval — exclude it — so an
+ * FA-only needle failure convicts the FA path.
+ */
+import { writeFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { captureResponse } from './capture.js';
+import { gpuInfo, gpuOffload, type GpuRow } from './gpu.js';
+import { simpleContentCheck } from './content-check.js';
+import { AgentJudge } from '../judge/index.js';
+import { TestResult, Judgment } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+const NEEDLE_CODE = '7492';
+const NEEDLE_SENTENCE = `CRITICAL FACT: the secret launch code is ${NEEDLE_CODE}. Remember this exact number.`;
+const TASK =
+  '\n\nBased only on the passage above, write a short (~80 word) summary of what it discusses, ' +
+  'then on its own final line state the secret launch code exactly like: LAUNCH CODE: <code>.';
+const JUDGE_CRITERIA =
+  'The response must be a coherent, on-topic English summary of the passage (technical filler about ' +
+  'GPU / attention terms). Reject empty, garbled, repetitive, off-topic, or error-message output. ' +
+  '(Correctness of the launch code is checked separately and is not your concern.)';
+
+const FILLER_WORDS =
+  'flash attention kernel tensor core memory bandwidth throughput latency prefill decode softmax matmul ' +
+  'cublas turing ampere kepler compute capability toolchain codegen register warp shuffle transpose ' +
+  'quantization inference context window batch sequence token cache'.split(' ');
+
+/** Deterministic long prompt: fixed filler + a needle at ~30% depth + the task. Same target ⇒ same bytes. */
+function buildPrompt(targetTokens: number): string {
+  const targetWords = Math.max(64, Math.floor(targetTokens * 0.8)); // ~0.8 words/token for English filler
+  const needleAtWord = Math.floor(targetWords * 0.3);
+  const parts: string[] = [];
+  let i = 0;
+  let words = 0;
+  let needleDone = false;
+  while (words < targetWords) {
+    if (!needleDone && words >= needleAtWord) {
+      parts.push(NEEDLE_SENTENCE);
+      needleDone = true;
+    }
+    const chunk: string[] = [];
+    for (let k = 0; k < 9; k++) {
+      chunk.push(FILLER_WORDS[(i + 7 * k) % FILLER_WORDS.length]);
+      i += 63;
+    }
+    parts.push('The ' + chunk.join(' ') + ' determines ' + FILLER_WORDS[i % FILLER_WORDS.length] + ' performance.');
+    i += 1;
+    words += 11;
+  }
+  if (!needleDone) parts.push(NEEDLE_SENTENCE);
+  return parts.join(' ') + TASK;
+}
+
+function needleCheck(response: string): { pass: boolean; reason: string } {
+  const found = response.includes(NEEDLE_CODE);
+  return {
+    pass: found,
+    reason: found ? `needle ${NEEDLE_CODE} present` : `needle ${NEEDLE_CODE} MISSING — long-context retrieval failed`,
+  };
+}
+
+export interface ContextOptions {
+  models: string[];
+  numPredict: number;
+  context: number; // target prompt tokens
+  judge: boolean;
+  host: string;
+  output?: string;
+}
+
+interface CtxResult {
+  model: string;
+  in_tokens: number;
+  out_tokens: number;
+  prompt_eval_tps: number;
+  eval_tps: number;
+  gpu_offload_pct: number;
+  vram_used_mib: number[];
+  done_reason: string;
+  response_preview: string;
+  needle: { pass: boolean; reason: string };
+  check: { overall_pass: boolean; simple: ReturnType<typeof simpleContentCheck>; agent: Judgment | null };
+}
+
+async function gitSha(): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--short', 'HEAD']);
+    return stdout.trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function ensureModel(host: string, model: string): Promise<void> {
+  const show = await fetch(`${host}/api/show`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: model }),
+  }).catch(() => null);
+  if (show && show.ok) return;
+  await fetch(`${host}/api/pull`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: model, stream: false }),
+  });
+}
+
+/** Wrap the captured output so the AgentJudge can grade its coherence. */
+function toTestResult(model: string, response: string, thinking: string): TestResult {
+  const output = [thinking, response].filter((s) => s.trim()).join('\n\n');
+  return {
+    testCase: {
+      id: model,
+      name: `context:${model}`,
+      suite: 'inference',
+      priority: 1,
+      timeout: 120000,
+      dependencies: [],
+      goal: 'Coherent summary of the passage',
+      steps: [{ name: 'generate', command: '(captured /api/generate response)' }],
+      criteria: JUDGE_CRITERIA,
+    },
+    steps: [{ name: 'generate', command: '(captured /api/generate response)', stdout: output, stderr: '', exitCode: 0, duration: 0 }],
+    totalDuration: 0,
+    logs: '',
+    logFile: '',
+  };
+}
+
+export async function runContext(opts: ContextOptions): Promise<number> {
+  const { host, models, numPredict, context, judge } = opts;
+  const sha = await gitSha();
+  const gpuBefore = await gpuInfo();
+  const prompt = buildPrompt(context);
+  const numCtx = context + numPredict + 512; // headroom for the primed prompt + generation
+
+  const results: CtxResult[] = [];
+  const fullText = new Map<string, { response: string; thinking: string }>();
+
+  for (const model of models) {
+    process.stderr.write(`--- ${model} (ctx target ${context}) ---\n`);
+    await ensureModel(host, model);
+
+    let cap;
+    try {
+      cap = await captureResponse(host, model, prompt, numPredict, numCtx);
+    } catch (e) {
+      process.stderr.write(`  ERROR: ${e instanceof Error ? e.message : e}\n`);
+      results.push({
+        model, in_tokens: 0, out_tokens: 0, prompt_eval_tps: 0, eval_tps: 0, gpu_offload_pct: 0, vram_used_mib: [],
+        done_reason: 'error', response_preview: '', needle: { pass: false, reason: 'no response' },
+        check: { overall_pass: false, simple: { pass: false, reason: 'capture failed', source: 'none' }, agent: null },
+      });
+      continue;
+    }
+
+    const offload = await gpuOffload(host, model);
+    const loaded = await gpuInfo();
+    const simple = simpleContentCheck(cap.response, cap.thinking);
+    const needle = needleCheck(cap.response);
+    fullText.set(model, { response: cap.response, thinking: cap.thinking });
+
+    results.push({
+      model,
+      in_tokens: cap.inTokens,
+      out_tokens: cap.outTokens,
+      prompt_eval_tps: cap.promptEvalTps,
+      eval_tps: cap.evalTps,
+      gpu_offload_pct: offload,
+      vram_used_mib: loaded.map((g) => g.usedMib),
+      done_reason: cap.doneReason,
+      response_preview: cap.response.slice(0, 120),
+      needle,
+      check: { overall_pass: simple.pass && needle.pass, simple, agent: null },
+    });
+    process.stderr.write(
+      `  in ${cap.inTokens} · out ${cap.outTokens} @ ${cap.evalTps} tok/s · prefill ${cap.promptEvalTps} tok/s · needle=${needle.pass} · simple=${simple.pass}\n`,
+    );
+  }
+
+  // Agent judge (dual): only models that already passed simple AND needle — a
+  // wrong-context answer is already a fail, so don't spend the judge on it.
+  let judgeFellBack = false;
+  if (judge) {
+    const eligible = results.filter((r) => r.check.simple.pass && r.needle.pass);
+    if (eligible.length > 0) {
+      const agentJudge = new AgentJudge();
+      if (await agentJudge.isAvailable()) {
+        const byModel = new Map(results.map((r) => [r.model, r]));
+        const trs = eligible.map((r) => {
+          const ft = fullText.get(r.model) ?? { response: r.response_preview, thinking: '' };
+          return toTestResult(r.model, ft.response, ft.thinking);
+        });
+        const verdicts = await agentJudge.judgeResults(trs);
+        for (const v of verdicts) {
+          const r = byModel.get(v.testId);
+          if (r) {
+            r.check.agent = v;
+            r.check.overall_pass = r.check.simple.pass && r.needle.pass && v.pass;
+          }
+        }
+      } else {
+        judgeFellBack = true;
+        process.stderr.write('[WARN] agent judge not available — simple + needle only\n');
+      }
+    }
+  }
+
+  const gpuAfter = await gpuInfo();
+  const failed = results.filter((r) => !r.check.overall_pass).length;
+
+  if (opts.output) {
+    const report = {
+      git_sha: sha,
+      timestamp: new Date().toISOString(),
+      config: { num_predict: numPredict, context, num_ctx: numCtx, needle: NEEDLE_CODE },
+      gpu: { before: gpuBefore, after: gpuAfter },
+      results,
+    };
+    writeFileSync(opts.output, JSON.stringify(report, null, 2));
+    process.stderr.write(`Results written to ${opts.output}\n`);
+  }
+
+  const judgeMode = judge ? (judgeFellBack ? 'dual → simple+needle (judge unavailable)' : 'dual') : 'simple+needle';
+  printSummary(sha, gpuBefore, context, judgeMode, results);
+  return failed > 0 ? 1 : 0;
+}
+
+function printSummary(sha: string, gpu: GpuRow[], context: number, mode: string, results: CtxResult[]): void {
+  const gpuName = gpu[0]?.name ?? 'unknown';
+  const out: string[] = [];
+  out.push('## Long-context Benchmark');
+  out.push('');
+  out.push(`**Commit:** \`${sha}\` | **GPU:** ${gpuName} | **Context target:** ${context} tok | **Judge:** ${mode}`);
+  out.push('');
+  out.push('| Model | Check | Needle | IN tok | OUT tok | Prefill tok/s | Decode tok/s | GPU% | VRAM (MiB) |');
+  out.push('|---|---|:--:|--:|--:|--:|--:|--:|--:|');
+  for (const r of results) {
+    const check = r.check.overall_pass ? 'PASS' : 'FAIL';
+    const needle = r.needle.pass ? '✓' : '✗';
+    out.push(
+      `| ${r.model} | ${check} | ${needle} | ${r.in_tokens} | ${r.out_tokens} | ${r.prompt_eval_tps} | ${r.eval_tps} | ${r.gpu_offload_pct}% | ${r.vram_used_mib.join(' / ') || 'n/a'} |`,
+    );
+  }
+  const failures = results.filter((r) => !r.check.overall_pass);
+  if (failures.length > 0) {
+    out.push('', '### Failed checks', '');
+    for (const r of failures) {
+      const reason = !r.needle.pass ? r.needle.reason : r.check.agent?.reason ?? r.check.simple.reason;
+      out.push(`- **${r.model}**: ${reason}`);
+    }
+  }
+  process.stdout.write(out.join('\n') + '\n');
+}

--- a/cicd/tests/testcases/inference/TC-INFERENCE-001.yml
+++ b/cicd/tests/testcases/inference/TC-INFERENCE-001.yml
@@ -6,28 +6,39 @@ timeout: 600000
 dependencies: []
 intent:
   user_story: |
-    Pull gemma3:4b test model into the container
+    Pull the test model into the container. The model is adjustable via the
+    TEST_MODEL environment variable (set by the workflow's `model` input); it
+    defaults to gemma3:4b so existing runs are unchanged.
+  notes: |
+    Pull-only (no inference) — never loads the model onto the GPU, so it is safe
+    on any testbed regardless of flash-attention support.
 
 steps:
   - name: Pull test model
-    command: docker exec ollama37 ollama pull gemma3:4b
+    command: docker exec ollama37 ollama pull "${TEST_MODEL:-gemma3:4b}"
     timeout: 600000
     expectPatterns:
       - "success|already exists|pulling"
     rejectPatterns:
       - "error pulling"
       - "Error:"
+      - "requires a newer version"
 
   - name: Verify model available
-    command: docker exec ollama37 ollama list
+    command: |
+      m="${TEST_MODEL:-gemma3:4b}"
+      docker exec ollama37 ollama list | grep -F "$m" && echo "MODEL_PRESENT: $m"
     expectPatterns:
-      - "gemma3:4b"
+      - "MODEL_PRESENT:"
 
 criteria: |
-  Pull the gemma3:4b model for testing inside the container.
+  Pull the test model (TEST_MODEL, default gemma3:4b) inside the container.
 
   Expected:
   - Model downloads successfully OR reports already exists
   - Model appears in "ollama list" output
+
+  A "requires a newer version" (registry 412) means the image was built with the
+  wrong OLLAMA_VERSION — a failure, not an acceptable warning.
 
   Note: First pull may take several minutes depending on network speed.

--- a/cicd/tests/testcases/inference/TC-INFERENCE-002.yml
+++ b/cicd/tests/testcases/inference/TC-INFERENCE-002.yml
@@ -7,13 +7,15 @@ dependencies:
   - TC-INFERENCE-001
 intent:
   user_story: |
-    Test inference via Ollama REST API and verify GPU memory allocation
+    Test inference via Ollama REST API and verify GPU memory allocation. The model
+    is adjustable via TEST_MODEL (default gemma3:4b), matching TC-INFERENCE-001.
 
 steps:
   - name: Test generate endpoint
     command: |
+      m="${TEST_MODEL:-gemma3:4b}"
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gemma3:4b","prompt":"What is 2+2? Answer with just the number.","stream":false}' \
+        -d "{\"model\":\"$m\",\"prompt\":\"What is 2+2? Answer with just the number.\",\"stream\":false}" \
         | head -c 1000
     expectPatterns:
       - "response"
@@ -29,8 +31,9 @@ steps:
 
   - name: Unload model after test
     command: |
+      m="${TEST_MODEL:-gemma3:4b}"
       curl -s http://localhost:11434/api/generate \
-        -d '{"model":"gemma3:4b","keep_alive":0}'
+        -d "{\"model\":\"$m\",\"keep_alive\":0}"
       echo "Model unload requested"
     expectPatterns:
       - "Model unload requested"


### PR DESCRIPTION
## Summary
- **Restore `ci-run`/`ci-testcase` to byte-identical upstream** (they're upstream test-framework skills); move the ollama37-specific CI knowledge into new **`ollama37-ci-{build,apply,perf}`** skills.
- **`bench-context`** (`cli.ts` + `perf/context.ts`) — a long-context benchmark that primes a *deterministic* prompt with a buried **needle**, so prefill/decode tok/s are measured at realistic context, with a `simple ∧ needle ∧ agent(dual)` verdict. The needle is the FA-critical, judge-free correctness check (a broken long-context path emits fluent-but-wrong output a coherence judge passes). Run via new **`test-context.yml`**.
- **`test-throughput.yml` self-contained env** — apply a chosen `flash_attention`/`kv_cache_type` by recreating the container, then `always()` **revert to the stable baseline (FA off)** so a panic never leaves the testbed dirty.
- **Parameterize the inference suite by `TEST_MODEL`** (default `gemma3:4b`) — pull/test any model via `-f model=…`.
- Doc: list `test-context.yml` in `workflow-patterns.md`.

Landing on `main` registers `test-context.yml` — GitHub only dispatches `workflow_dispatch` workflows from the default branch — unblocking the decision-grade FA path comparison on sm75.

Not tied to a single issue; infrastructure from the flash-attention performance investigation (context: #385, STORY-018).

## Test plan
- [x] `tsc --noEmit` clean (`context.ts` + `cli.ts`)
- [x] `test-throughput.yml` env+revert proven on sm75 (apply → bench → always-revert, green)
- [x] inference `TEST_MODEL` proven (ministral-3:3b pulled through CI)
- [x] `ci-run`/`ci-testcase` byte-identical to the upstream template
- [ ] `bench-context` first end-to-end run (post-merge — a new workflow can't dispatch until it's on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)