### PR TITLE
bench-context: fit the 2060 model set + loosen judge to coherence-only

### DIFF
--- a/.github/workflows/test-context.yml
+++ b/.github/workflows/test-context.yml
@@ -12,7 +12,7 @@ on:
       models:
         description: "Models to benchmark (space-separated)"
         required: true
-        default: "qwen2.5:3b"
+        default: "gemma3:4b ministral-3:3b qwen3.5:2b deepseek-r1:1.5b"
         type: string
       context:
         description: "Target primed-prompt length in tokens"

--- a/cicd/tests/src/perf/context.ts
+++ b/cicd/tests/src/perf/context.ts
@@ -33,10 +33,11 @@ const TASK =
   'Then on its own final line write the secret launch code from the passage exactly like: ' +
   'LAUNCH CODE: <code>.';
 const JUDGE_CRITERIA =
-  'The response must be a coherent, on-topic English explanation of flash attention — a real GPU/ML ' +
-  'technique (streaming the KV cache, tiling, avoiding materializing the full attention matrix, etc.). ' +
-  'Reject empty, garbled, repetitive, off-topic, or error-message output. (The launch-code line is ' +
-  'checked separately and is not your concern.)';
+  'This check catches CORRUPTED generation (e.g. NaN output from a broken FA path), not weak answers. ' +
+  'PASS any response that is coherent, fluent English and on-topic (flash attention / GPU inference). ' +
+  'Reject ONLY output that is empty, garbled, stuck in repetition, truncated mid-word, or an error ' +
+  'message. Do NOT grade technical accuracy or completeness — a vague, partial, or imperfect ' +
+  'explanation still PASSES. (The launch-code line is checked separately and is not your concern.)';
 
 const FILLER_WORDS =
   'flash attention kernel tensor core memory bandwidth throughput latency prefill decode softmax matmul ' +
@@ -138,7 +139,7 @@ function toTestResult(model: string, response: string, thinking: string): TestRe
       priority: 1,
       timeout: 120000,
       dependencies: [],
-      goal: 'Coherent explanation of flash attention',
+      goal: 'Coherent, on-topic response about flash attention (not corrupted output)',
       steps: [{ name: 'generate', command: '(captured /api/generate response)' }],
       criteria: JUDGE_CRITERIA,
     },


### PR DESCRIPTION
## Summary
- `test-context.yml` default model set now uses `qwen3.5:2b` instead of `qwen3.5:4b` — the 4b needs 5.4 GiB but the display-attached 2060 exposes only 5.3 GiB available, so it ran ~30% on CPU (PARTIAL). The 2b clears the budget.
- `JUDGE_CRITERIA` loosened back to **coherence-only**, realigning it with the file's own design (`context.ts:9`): pass any coherent, on-topic response; reject only empty/garbled/repetitive/error output. Removes the "must explain the real technique" over-reach that false-FAILed deepseek-r1:1.5b. The needle stays the hard correctness gate, so FA-corruption detection is intact.

Fixes #411

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Re-run the cuBLAS baseline on sm75 — expect qwen3.5:2b PASS (fits) and deepseek-r1:1.5b PASS (coherent), giving a clean 4-model baseline