### PR TITLE
ci(release): derive OLLAMA_VERSION from the git tag (#413)

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -26,8 +26,6 @@ jobs:
     name: Build & Push Docker Image
     runs-on: [self-hosted, "${{ inputs.runner_label || 'sm37' }}"]
     environment: cicd-1
-    env:
-      OLLAMA_VERSION: ${{ vars.OLLAMA_VERSION || '0.0.0' }}
 
     steps:
       - name: Determine version tag
@@ -38,9 +36,15 @@ jobs:
           else
             TAG="${{ inputs.tag }}"
           fi
+          # Derive the binary version from the tag so the image tag and the baked
+          # version can never drift. (OLLAMA_VERSION used to be read from a variable,
+          # which the cicd-1 environment silently shadowed — see #413.) Tag-less CI
+          # builds still source the version from the repo variable; only the release
+          # path derives it from the tag here.
+          VERSION="${TAG#v}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${OLLAMA_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Building version: ${OLLAMA_VERSION} (tag: ${TAG})"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building version: ${VERSION} (tag: ${TAG})"
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The release image tag came from the git tag but the baked binary version came from the `OLLAMA_VERSION` variable — which the `cicd-1` environment silently shadowed, so v2.2.2 first shipped a binary reporting 2.1.0.
- The `Determine version tag` step now derives `VERSION="${TAG#v}"`, so the image tag and the baked version are the same string by construction. Removed the now-unused `env.OLLAMA_VERSION` block.
- Scoped to the release path only; tag-less CI builds (`test-build`/`test-pipeline`) still source the version from the repo variable.

Fixes #413

## Test plan
- [x] `yaml.safe_load` parses the workflow
- [x] Strip logic verified: `v2.2.2→2.2.2`, `v2.02→2.02` (outlier), `v1.10→1.10`, `v2.0.3→2.0.3`; non-`v` tag is a safe no-op
- [x] No orphaned `${OLLAMA_VERSION}` env reference (only the `make` line using the derived step output)
- [ ] End-to-end at the next real release: build log shows `version.Version=<tag minus v>` and the published binary reports it (cannot run without publishing)

Generated with [Claude Code](https://claude.com/claude-code)