### PR TITLE
docs(stories): add STORY-019 (LFM2) and STORY-020 (ornith) model-support stories

### DIFF
--- a/docs/stories/STORY-019.md
+++ b/docs/stories/STORY-019.md
@@ -1,0 +1,71 @@
+# STORY-019: Support lfm2:24b and lfm2.5-thinking:1.2b, with CI coverage on K80 + RTX 2060
+
+## User Story
+
+As a maintainer running models on the Tesla K80 and the RTX 2060 testbed,
+I want lfm2:24b and lfm2.5-thinking:1.2b to run coherently on both cards and to be
+exercised by the model-suite CI on each self-hosted runner,
+So that the fork gains two more Liquid LFM2-family models — a larger MoE and a small
+thinking model — regression-guarded like every other supported model.
+
+## The Need
+
+Two more models from Liquid AI's LFM2 family: **lfm2:24b** (a larger LFM2, MoE or dense
+to be confirmed) and **lfm2.5-thinking:1.2b** (a small reasoning variant with a thinking
+mode). Both are text models with tool-calling and thinking.
+
+The hard architecture work is already done. STORY-016 landed the LFM2/LFM2MOE support the
+fork was missing: the vendored llama.cpp carries the arch, and the Go-side glue — the
+`LFM2Renderer`/`LFM2Parser` (both `lfm2` and `lfm2-thinking`) and the converter — was ported
+(#379–#381). So these two models are not a port; they build on support that already exists.
+
+What's missing is proof and coverage. Neither model runs in CI. Every supported model earns
+a model-suite regression, and — new for this story — the user wants that regression to run on
+**both** self-hosted runners: the K80 (sm37, the reference target) and the RTX 2060 (sm75).
+LFM2 is not in the flash-attention allowlist, so FA stays off on both cards; there is no
+Turing FA hazard here (unlike the qwen35-family models). The remaining risk is size and
+fit, not correctness of the engine.
+
+Size is the open edge. lfm2.5-thinking:1.2b is tiny and fits anywhere. lfm2:24b is large:
+it may need both K80 dies or spill to host, and on the 6 GB RTX 2060 it will largely offload
+to CPU — runnable but slow. Whether sm75 coverage of the 24B model is worth its wall-clock
+is a question for the plan, not an assumption here.
+
+Scope is the two text models above. Vision and audio LFM2 variants are out of scope.
+
+## Success Looks Like
+
+- `ollama run lfm2.5-thinking:1.2b` and `ollama run lfm2:24b` produce coherent output on the
+  K80 — no CUDA/CUBLAS errors, no garbage — each fitting within the K80's available VRAM
+  (single die where it fits, both dies where it must, without exceeding the GPU count it needs).
+- Both models are covered by the **model suite** on **both** self-hosted runners (sm37 and
+  sm75), with results captured. Where a model is too large to sit in the RTX 2060's 6 GB, that
+  is reported as an observed offload/throughput fact, not treated as a failure of correctness.
+- A **reviewed QA test doc** drives the new model-suite regressions, reviewed before the
+  implementation is accepted (consistent with how STORY-016 was handled).
+- Honesty note: throughput is whatever each card delivers — reported, not held to a target.
+  The thinking model's coherence is proven the way STORY-016 proved lfm2.5's (via `/api/chat`
+  / `think:false`, since a thinking model's leaked chain-of-thought trips the throughput
+  coherence judge).
+
+## Open Questions
+
+- **lfm2:24b — MoE or dense?** Which GGUF `general.architecture` does it carry (`lfm2` vs
+  `lfm2moe`)? The converter auto-detects, but confirm from the real config/GGUF, since it
+  drives the VRAM footprint.
+- **lfm2:24b fit.** Does it fit one K80 die (~11.4 GB), need both dies, or spill to host? On
+  the 6 GB RTX 2060 it will mostly offload to CPU — is sm75 coverage of the 24B model still
+  wanted given the wall-clock, or is the 1.2b model the meaningful sm75 target?
+- **Thinking-mode coherence judge.** Does lfm2.5-thinking:1.2b trip the throughput
+  `/api/generate` coherence judge the way lfm2.5:8b did (leaked CoT), so the regression must
+  use `/api/chat` with `think:false`?
+- **Image currency.** Is the STORY-016 LFM2 renderer/parser work merged to `main` and present
+  in the image the runners will test, or is a fresh `ollama37-ci-build` needed first?
+- **Availability.** Are `lfm2:24b` and `lfm2.5-thinking:1.2b` pullable tags (do the weights
+  exist in the registry the runners pull from)?
+
+## Status
+
+- Created: 2026-07-12
+- Plan: #415
+- Issues: #417 (arch/availability/image), #418 (CI coverage), #419 (K80 verify), #420 (sm75 verify)

--- a/docs/stories/STORY-020.md
+++ b/docs/stories/STORY-020.md
@@ -1,0 +1,81 @@
+# STORY-020: Support ornith:9b and ornith:35b, with CI coverage on K80 + RTX 2060
+
+## User Story
+
+As a maintainer running models on the Tesla K80 and the RTX 2060 testbed,
+I want ornith:9b and ornith:35b to render and parse correctly and run coherently on both
+cards, exercised by the model-suite CI on each self-hosted runner,
+So that the fork gains the ornith models — a thinking-mode Qwen3.5 family — with their
+chat template and tool-calling behaving as upstream intends, regression-guarded like every
+other supported model.
+
+## The Need
+
+`ornith` (9b and 35b) is a thinking-oriented model family. Tracing upstream ollama shows it
+is **not a new architecture**: it is a Qwen3.5-family model with its own chat template — the
+underlying weights load on the `qwen35` (dense) / `qwen35moe` (MoE) architecture the fork
+already runs natively. What ornith adds is a distinct **renderer and parser** (thinking
+forced on, empty think-block handling) that upstream carries but this fork does not yet — it
+landed upstream after the fork's last sync.
+
+Without that renderer/parser, an ornith model would fall back to a generic template: it can
+emit text, but its thinking blocks and tool calls won't be shaped the way the model was
+trained to expect, so it can't be trusted for the agentic / thinking workloads it's meant
+for. Porting the ornith renderer/parser — adapted to the fork's own qwen3.5 rendering, which
+has deliberately diverged from upstream — closes that gap.
+
+The models also aren't in CI. Every supported model earns a model-suite regression, and — as
+with the LFM2 story — the user wants that regression to run on **both** self-hosted runners:
+the K80 (sm37, reference) and the RTX 2060 (sm75).
+
+There is one hardware hazard specific to this family. Because the ornith models run on the
+qwen35 architecture, they **enable flash attention**. On the K80 that is harmless (FA is
+hard-gated off below Volta). On the RTX 2060 (Turing) it is not: FA on Turing under this
+fork's CUDA toolchain produces NaN and crashes the runner unless the tested image carries the
+Volta-only FA gate (the fix from the earlier qwen3.5 crash work). So the sm75 validation is
+only meaningful on an image that includes that gate.
+
+Scope is the two text ornith models. Any vision or audio variant is out of scope.
+
+## Success Looks Like
+
+- `ollama run ornith:9b` and `ollama run ornith:35b` produce coherent output on the K80 — no
+  CUDA/CUBLAS errors, no garbage — each within the VRAM / GPU-count it needs.
+- ornith's chat template and thinking behaviour match upstream's intent: the ported
+  renderer/parser reproduce upstream's expected rendered output (its golden-output tests pass
+  on CPU), and thinking blocks render as the model expects.
+- Both models run coherently on the RTX 2060 (sm75) **without the flash-attention NaN crash** —
+  i.e. on an image that carries the Volta-only FA gate.
+- Both models are covered by the **model suite** on **both** runners (sm37 and sm75), driven
+  by a **reviewed** QA test doc, with results captured. Where a model is too large for the
+  2060's 6 GB, the offload/throughput is reported as an observed fact, not a correctness fail.
+- Honesty note: throughput is whatever each card delivers — reported, not held to a target.
+
+## Open Questions
+
+- **ornith:9b / ornith:35b arch confirmation.** Is 9b dense `qwen35` and 35b `qwen35moe`, as
+  the naming and the fork's existing qwen3.6:35b-MoE testcase suggest? Confirm from the real
+  GGUF `general.architecture`.
+- **Renderer/parser adaptation.** Upstream's `OrnithRenderer` embeds a `Qwen35Renderer` type
+  the fork doesn't have (the fork routes qwen3.5 through `Qwen3VLRenderer`). How much of
+  ornith's think-block behaviour (`alwaysRenderAssistantThinkBlock`, `emitEmptyThinkOnNoThink`)
+  reconstructs cleanly on the fork's renderer, and do upstream's golden-output tests port as-is
+  as the acceptance bar?
+- **Renderer/parser selection.** Does an ornith model get its renderer/parser via explicit
+  Modelfile config, or does the server auto-resolve it — and does that resolution path need an
+  `ornith` entry in the fork?
+- **sm75 FA-gate precondition.** Which built image will the sm75 runs use, and does it carry
+  the #385/#395 Volta-only FA gate? (Ornith on a pre-gate image crashes on Turing.)
+- **Image rebuild.** The renderer/parser port is new code, so a fresh build is needed before
+  the models run correctly — via CI build, not a local `make`.
+- **ornith:35b fit.** Does the MoE fit one K80 die, need both, or spill? On the 6 GB 2060 it
+  will offload heavily to CPU — is sm75 coverage of the 35b worth the wall-clock, or is 9b the
+  meaningful sm75 target?
+- **Availability.** Are `ornith:9b` and `ornith:35b` pullable tags in the registry the runners
+  pull from?
+
+## Status
+
+- Created: 2026-07-12
+- Plan: #416
+- Issues: #421 (prereq confirm), #422 (renderer/parser port), #423 (CI coverage), #424 (K80 build+verify), #425 (sm75 verify)


### PR DESCRIPTION
## Summary

Adds the two model-support user stories produced by the dev-workflow, split by readiness.

- **STORY-019 — LFM2** (`lfm2:24b`, `lfm2.5-thinking:1.2b`): arch already landed via STORY-016, so this is verify + CI coverage on the K80 (sm37) and RTX 2060 (sm75). Plan #415 · tasks #417–#420.
- **STORY-020 — ornith** (`ornith:9b`, `ornith:35b`): a Qwen3.5-family model needing the upstream `ornith` renderer/parser ported (adapted to the fork's `Qwen3VLRenderer`), with the #385/#395 flash-attention gate as an sm75 precondition. Plan #416 · tasks #421–#425.

Docs-only (two new story files). Numbered 019/020 because `[STORY-017]`/`[STORY-018]` GitHub tags were already taken by the closed CUDA-FA work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
