### PR TITLE
docs(docker): note compose pulls the published image, not a local build

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,6 +52,8 @@ This will:
 docker compose up -d
 ```
 
+**Note:** the shipped `docker-compose.yml` pulls the published image `dogkeeper886/ollama37:latest`. To run an image you just built with `make build` (tagged `ollama37:latest`), edit the `image:` line in `docker-compose.yml`, or use the **Run Manually** step below.
+
 Check logs:
 ```bash
 docker compose logs -f


### PR DESCRIPTION
## What

Adds one note to `docker/README.md` §2 (Run with Docker Compose): the shipped `docker-compose.yml` references the published image `dogkeeper886/ollama37:latest`, so `docker compose up -d` after a local `make build` (which tags `ollama37:latest`) pulls the published image instead of the freshly-built one. The note points readers to edit the `image:` line or use the manual `docker run` step.

## Why

A companion change updates `docker/docker-compose.yml` from the local `ollama37:latest` tag to the published `dogkeeper886/ollama37:latest`. That is correct for end users who pull, but it silently diverges from the build-system doc's "make build → docker compose up" flow. This documents the divergence and the override.

## Scope

- Docs only. The local `ollama37:latest` tags in §2/§3 are left as-is — they are correct for `make build` output.
- Note becomes fully accurate on `main` once the compose image change lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)