### PR TITLE
fix(docker): point compose at the published image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ollama:
-    image: ollama37:latest
+    image: dogkeeper886/ollama37:latest
     container_name: ollama37
     runtime: nvidia
     deploy:


### PR DESCRIPTION
## What

Change `docker/docker-compose.yml` from the local build tag `ollama37:latest` to the published image `dogkeeper886/ollama37:latest`.

## Why

`ollama37:latest` is only produced by a local `make build`. A fresh clone running `docker compose up -d` has no such image, so the command fails. The published `dogkeeper886/ollama37:latest` is what every user-facing doc (top-level README, dockerhub-readme) already points at.

Pairs with the `docker/README.md` Quick Start note (#427), which documents this and the local-build override. Together they put both halves of the change on `main`, consistent with each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)