### PR TITLE
test(models): red testcases for ornith:9b/35b + lfm2:24b + lfm2.5-thinking:1.2b

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -127,6 +127,10 @@ jobs:
           curl -s http://localhost:11434/api/generate -d '{"model":"gemma4:26b","keep_alive":0}' || true
           curl -s http://localhost:11434/api/generate -d '{"model":"functiongemma:270m","keep_alive":0}' || true
           curl -s http://localhost:11434/api/generate -d '{"model":"ministral-3:3b","keep_alive":0}' || true
+          curl -s http://localhost:11434/api/generate -d '{"model":"ornith:9b","keep_alive":0}' || true
+          curl -s http://localhost:11434/api/generate -d '{"model":"ornith:35b","keep_alive":0}' || true
+          curl -s http://localhost:11434/api/generate -d '{"model":"lfm2:24b","keep_alive":0}' || true
+          curl -s http://localhost:11434/api/generate -d '{"model":"lfm2.5-thinking:1.2b","keep_alive":0}' || true
           echo "Models unloaded"
 
       - name: Upload models results

--- a/cicd/specs/models.md
+++ b/cicd/specs/models.md
@@ -66,3 +66,51 @@ Validate deepseek-r1:14b (~14B params, ~10GB VRAM) runs on K80.
 - **VRAM Constraint:** K80 has 22GB total (2 x 11GB). Models tested one at a time with unloading.
 - **Acceptable warning:** "flash attention enabled but not supported by gpu" - K80 does not support flash attention
 - **No CUDA/CUBLAS errors** should appear in logs
+
+---
+
+## TC-MODELS-018: ornith:9b Inference
+
+**Importance:** High
+**Execution Type:** Automated
+**Status:** Red until the ornith renderer/parser port (#422) is in the deployed image.
+
+**Summary:**
+Validate ornith:9b (Qwen3.5-family, dense `qwen35`, thinking) runs on K80. Request pins
+`"think": false` so the answer isn't buried in a `<think>` span (ornith forces thinking, #422).
+
+---
+
+## TC-MODELS-019: ornith:35b Inference
+
+**Importance:** High
+**Execution Type:** Automated
+**Status:** Red until the ornith renderer/parser port (#422) is in the deployed image.
+
+**Summary:**
+Validate ornith:35b (Qwen3.5-family MoE, `qwen35moe`, thinking) runs on K80. Larger than one
+die, so it may span both K80 dies (`GPU_COUNT_OK` when it genuinely needs them).
+
+---
+
+## TC-MODELS-020: lfm2:24b Inference
+
+**Importance:** High
+**Execution Type:** Automated
+
+**Summary:**
+Validate lfm2:24b (Liquid LFM2 family, likely MoE) runs on K80; may span both K80 dies. If the
+model uses a thinking mode, switch the request to `/api/chat` with `"think": false`.
+
+---
+
+## TC-MODELS-021: lfm2.5-thinking:1.2b Inference
+
+**Importance:** High
+**Execution Type:** Automated
+**Status:** KNOWN RED — GGUF fails to load with `missing tensor 'token_embd_norm.weight'`;
+gates the vendored-llama.cpp LFM2 loader fix.
+
+**Summary:**
+Validate lfm2.5-thinking:1.2b (Liquid LFM2 thinking, ~0.7 GB) runs on K80, single die. Request
+pins `"think": false`.

--- a/cicd/tests/testcases/models/TC-MODELS-018.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-018.yml
@@ -1,0 +1,72 @@
+id: TC-MODELS-018
+name: "ornith:9b Inference"
+suite: models
+priority: 2
+timeout: 600000
+dependencies: []
+issue: ""
+intent:
+  user_story: |
+    Validate ornith:9b (Qwen3.5-family, thinking) runs on K80 compute 3.7 (single GPU).
+    Acceptance for STORY-020: red until the ornith renderer/parser port (#422) is in the
+    deployed image. "think": false is pinned so the answer isn't buried in a <think> span
+    (ornith forces thinking; see #422).
+  notes: |
+    Prerequisite: ornith:9b pre-pulled on the runner.
+    Acceptable warning (NOT an error): "flash attention enabled but not supported by gpu".
+
+steps:
+  - name: Test inference
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"ornith:9b","prompt":"What is 2+2? Answer briefly.","stream":false,"think":false,"options":{"num_predict":200}}' \
+        | head -c 2000
+    expectPatterns:
+      - "response"
+    rejectPatterns:
+      - "CUBLAS_STATUS"
+      - "CUDA error"
+
+  - name: Check GPU memory
+    command: docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    expectPatterns:
+      - "[0-9]+ MiB"
+
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
+  - name: Unload model
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"ornith:9b","keep_alive":0}'
+      echo "Model unloaded"
+    expectPatterns:
+      - "Model unloaded"
+
+criteria: |
+  Validate ornith:9b (Qwen3.5-family thinking model, dense qwen35) runs on K80 (compute 3.7).
+  Prerequisite: Model must be pre-pulled. Red until the ornith renderer/parser port (#422)
+  is in the deployed image.
+
+  Expected:
+  - API returns JSON with "response" field (coherent, no garbage)
+  - GPU memory allocated; fits a single K80 die
+  - No CUDA/CUBLAS errors; model unloads
+
+  Acceptable warning (NOT an error): "flash attention enabled but not supported by gpu".

--- a/cicd/tests/testcases/models/TC-MODELS-019.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-019.yml
@@ -1,0 +1,64 @@
+id: TC-MODELS-019
+name: "ornith:35b Inference"
+suite: models
+priority: 3
+timeout: 900000
+dependencies: []
+issue: ""
+intent:
+  user_story: |
+    Validate ornith:35b (Qwen3.5-family MoE, thinking) runs on K80 compute 3.7. Larger than a
+    single die, so it may span both K80 dies. Acceptance for STORY-020: red until the ornith
+    renderer/parser port (#422) is in the deployed image. "think": false pinned (see #422).
+  notes: |
+    Prerequisite: ornith:35b pre-pulled on the runner.
+    Acceptable warning (NOT an error): "flash attention enabled but not supported by gpu".
+
+steps:
+  - name: Test inference
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"ornith:35b","prompt":"What is 2+2? Answer briefly.","stream":false,"think":false,"options":{"num_predict":200}}' \
+        | head -c 2000
+    expectPatterns:
+      - "response"
+    rejectPatterns:
+      - "CUBLAS_STATUS"
+      - "CUDA error"
+
+  - name: Check GPU memory
+    command: docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    expectPatterns:
+      - "[0-9]+ MiB"
+
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
+  - name: Unload model
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"ornith:35b","keep_alive":0}'
+      echo "Model unloaded"
+    expectPatterns:
+      - "Model unloaded"
+
+criteria: |
+  Validate ornith:35b (Qwen3.5-family MoE, qwen35moe) runs on K80 (compute 3.7). May span both
+  K80 dies given its size — GPU_COUNT_OK if it genuinely needs the dies it uses. Prerequisite:
+  pre-pulled. Red until the ornith renderer/parser port (#422) is in the deployed image.

--- a/cicd/tests/testcases/models/TC-MODELS-020.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-020.yml
@@ -1,0 +1,64 @@
+id: TC-MODELS-020
+name: "lfm2:24b Inference"
+suite: models
+priority: 3
+timeout: 900000
+dependencies: []
+issue: ""
+intent:
+  user_story: |
+    Validate lfm2:24b (Liquid LFM2, likely MoE) runs on K80 compute 3.7. May span both K80
+    dies. Acceptance for STORY-019: the fork vendors the lfm2/lfm2moe llama.cpp arch, so this
+    gates that the GGUF loads and generates coherently.
+  notes: |
+    Prerequisite: lfm2:24b pre-pulled on the runner.
+    Acceptable warning (NOT an error): "flash attention enabled but not supported by gpu".
+
+steps:
+  - name: Test inference
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"lfm2:24b","prompt":"What is 2+2? Answer briefly.","stream":false,"options":{"num_predict":200}}' \
+        | head -c 2000
+    expectPatterns:
+      - "response"
+    rejectPatterns:
+      - "CUBLAS_STATUS"
+      - "CUDA error"
+
+  - name: Check GPU memory
+    command: docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    expectPatterns:
+      - "[0-9]+ MiB"
+
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
+  - name: Unload model
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"lfm2:24b","keep_alive":0}'
+      echo "Model unloaded"
+    expectPatterns:
+      - "Model unloaded"
+
+criteria: |
+  Validate lfm2:24b (Liquid LFM2 family) runs on K80 (compute 3.7). May span both K80 dies.
+  Prerequisite: Model must be pre-pulled. If the model uses a thinking mode, switch the request
+  to /api/chat with "think": false (per TC-MODELS-017).

--- a/cicd/tests/testcases/models/TC-MODELS-021.yml
+++ b/cicd/tests/testcases/models/TC-MODELS-021.yml
@@ -1,0 +1,66 @@
+id: TC-MODELS-021
+name: "lfm2.5-thinking:1.2b Inference"
+suite: models
+priority: 2
+timeout: 600000
+dependencies: []
+issue: ""
+intent:
+  user_story: |
+    Validate lfm2.5-thinking:1.2b (Liquid LFM2, thinking, ~0.7 GB) runs on K80 compute 3.7
+    (single GPU). Acceptance for STORY-019. KNOWN RED: on the current image the GGUF fails to
+    load with "missing tensor 'token_embd_norm.weight'" — this gates that vendored-llama.cpp
+    LFM2 fix. "think": false pinned so the answer isn't buried in a <think> span.
+  notes: |
+    Prerequisite: lfm2.5-thinking:1.2b pre-pulled on the runner.
+    Acceptable warning (NOT an error): "flash attention enabled but not supported by gpu".
+
+steps:
+  - name: Test inference
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"lfm2.5-thinking:1.2b","prompt":"What is 2+2? Answer briefly.","stream":false,"think":false,"options":{"num_predict":200}}' \
+        | head -c 2000
+    expectPatterns:
+      - "response"
+    rejectPatterns:
+      - "CUBLAS_STATUS"
+      - "CUDA error"
+      - "missing tensor"
+
+  - name: Check GPU memory
+    command: docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    expectPatterns:
+      - "[0-9]+ MiB"
+
+  - name: Check GPU count
+    command: |
+      output=$(docker exec ollama37 nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader)
+      echo "$output"
+      active=$(echo "$output" | grep -c 'MiB')
+      total=$(echo "$output" | grep -oP '[0-9]+(?= MiB)' | paste -sd+ | bc)
+      echo "Active GPUs: $active, Total VRAM: ${total} MiB"
+      if [ "$active" -le 1 ]; then
+        echo "GPU_COUNT_OK"
+      elif [ "$total" -le $(( (active - 1) * 11441 )) ]; then
+        echo "GPU_COUNT_EXCEEDED: total ${total} MiB fits in $((active - 1)) GPUs but using $active"
+      else
+        echo "GPU_COUNT_OK"
+      fi
+    expectPatterns:
+      - "GPU_COUNT_OK"
+    rejectPatterns:
+      - "GPU_COUNT_EXCEEDED"
+
+  - name: Unload model
+    command: |
+      curl -s http://localhost:11434/api/generate \
+        -d '{"model":"lfm2.5-thinking:1.2b","keep_alive":0}'
+      echo "Model unloaded"
+    expectPatterns:
+      - "Model unloaded"
+
+criteria: |
+  Validate lfm2.5-thinking:1.2b (Liquid LFM2 thinking, ~0.7 GB) runs on K80 (compute 3.7),
+  single die. Prerequisite: pre-pulled. KNOWN RED until the vendored-llama.cpp LFM2 loader
+  handles token_embd_norm.weight for this variant (observed load failure).


### PR DESCRIPTION
## Summary
Test-first model-suite coverage for the four target models — **intentionally red** until their implementations land (create test before implement):

| Testcase | Model | Why red now |
|---|---|---|
| TC-MODELS-018 | `ornith:9b` | needs the ornith renderer/parser port (#422) in the deployed image |
| TC-MODELS-019 | `ornith:35b` | same; MoE, may span both K80 dies |
| TC-MODELS-020 | `lfm2:24b` | gates that the vendored lfm2/lfm2moe arch loads + generates |
| TC-MODELS-021 | `lfm2.5-thinking:1.2b` | **KNOWN RED** — GGUF fails to load: `missing tensor 'token_embd_norm.weight'` (observed) |

- Thinking models pin `"think": false` (TC-MODELS-017 pattern).
- Adds VRAM-unload lines to `test-models.yml` and documents the four in `cicd/specs/models.md`.
- Suite auto-discovers the new `TC-MODELS-*.yml` (`--suite models`).

Part of STORY-019 (lfm2) and STORY-020 (ornith). Coverage only — no product code.

Generated with [Claude Code](https://claude.com/claude-code)
