### PR TITLE
Port ornith (Qwen3.5-family) renderer + parser

### DIFF
--- a/model/parsers/ornith_test.go
+++ b/model/parsers/ornith_test.go
@@ -1,0 +1,90 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+// ornith reuses Qwen35Parser (thinking extraction + XML tool-call delegation to
+// Qwen3CoderParser). These cover the always-thinking behaviour the fork's
+// 2-arg Init produces for the "ornith" parser name.
+
+func TestOrnithParserThinkingWithExplicitOpeningTag(t *testing.T) {
+	parser := ParserForName("ornith")
+	if parser == nil {
+		t.Fatal("expected ornith parser")
+	}
+
+	parser.Init(nil, nil)
+	content, thinking, calls, err := parser.Add("<think>\nLet me think...</think>Answer.", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if thinking != "Let me think..." {
+		t.Fatalf("expected thinking %q, got %q", "Let me think...", thinking)
+	}
+	if content != "Answer." {
+		t.Fatalf("expected content %q, got %q", "Answer.", content)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+}
+
+func TestOrnithParserAssistantPrefillStartsInContent(t *testing.T) {
+	parser := ParserForName("ornith")
+	if parser == nil {
+		t.Fatal("expected ornith parser")
+	}
+
+	last := &api.Message{Role: "assistant", Content: "Prefilled response start"}
+	parser.Init(nil, last)
+
+	content, thinking, calls, err := parser.Add(" and continued", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if thinking != "" {
+		t.Fatalf("expected no thinking for assistant prefill continuation, got %q", thinking)
+	}
+	if content != " and continued" {
+		t.Fatalf("expected content %q, got %q", " and continued", content)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+}
+
+func TestOrnithParserXMLToolCallEmittedInThinkingIsParsed(t *testing.T) {
+	parser := ParserForName("ornith")
+	if parser == nil {
+		t.Fatal("expected ornith parser")
+	}
+
+	tools := []api.Tool{tool("get_weather", map[string]api.ToolProperty{
+		"location": {Type: api.PropertyType{"string"}},
+	})}
+
+	parser.Init(tools, nil)
+	input := "Need weather lookup<tool_call><function=get_weather><parameter=location>\nSF\n</parameter></function></tool_call>"
+	content, thinking, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if content != "" {
+		t.Fatalf("expected empty content, got %q", content)
+	}
+	if thinking != "Need weather lookup" {
+		t.Fatalf("expected thinking %q, got %q", "Need weather lookup", thinking)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Fatalf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+	if loc := calls[0].Function.Arguments["location"]; loc != "SF" {
+		t.Fatalf("expected location %q, got %v", "SF", loc)
+	}
+}

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -61,6 +61,8 @@ func ParserForName(name string) Parser {
 		return &LFM2Parser{hasThinkingSupport: false}
 	case "lfm2-thinking":
 		return &LFM2Parser{hasThinkingSupport: true}
+	case "ornith":
+		return &Qwen35Parser{}
 	case "passthrough":
 		return &PassthroughParser{}
 	case "harmony":

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -1,0 +1,259 @@
+package parsers
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"unicode"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/logutil"
+)
+
+type qwen35ParserState int
+
+const (
+	qwen35ParserStateCollectingThinking qwen35ParserState = iota
+	qwen35ParserStateThinkingDoneEatingWhitespace
+	qwen35ParserStateCollectingContent
+)
+
+const (
+	qwen35ThinkingOpenTag  = "<think>"
+	qwen35ThinkingCloseTag = "</think>"
+	qwen35ToolCallOpenTag  = "<tool_call>"
+)
+
+// Qwen35Parser handles qwen3.5 reasoning extraction and delegates post-thinking
+// content (including XML tool calls) to Qwen3CoderParser.
+type Qwen35Parser struct {
+	toolParser Qwen3CoderParser
+
+	state  qwen35ParserState
+	buffer strings.Builder
+	// Some checkpoints may emit an explicit leading <think> even when the
+	// prompt already opened thinking. Strip at most one such tag.
+	allowLeadingThinkOpenTag bool
+}
+
+func (p *Qwen35Parser) HasToolSupport() bool {
+	return true
+}
+
+func (p *Qwen35Parser) HasThinkingSupport() bool {
+	return true
+}
+
+func (p *Qwen35Parser) Init(tools []api.Tool, lastMessage *api.Message) []api.Tool {
+	p.buffer.Reset()
+	p.toolParser = Qwen3CoderParser{}
+	p.toolParser.Init(tools, nil)
+
+	// The fork's Parser interface carries no per-request think flag, so thinking
+	// follows HasThinkingSupport() (ornith is always a thinking model), matching
+	// how the fork's other thinking parsers (e.g. LFM2Parser) initialize.
+	thinkingEnabled := p.HasThinkingSupport()
+
+	assistantPrefill := lastMessage != nil && lastMessage.Role == "assistant" && lastMessage.Content != ""
+	if thinkingEnabled && !assistantPrefill {
+		p.state = qwen35ParserStateCollectingThinking
+		p.allowLeadingThinkOpenTag = true
+	} else {
+		p.state = qwen35ParserStateCollectingContent
+		p.allowLeadingThinkOpenTag = false
+	}
+
+	return tools
+}
+
+type qwen35Event interface {
+	isQwen35Event()
+}
+
+type qwen35EventContent struct {
+	content string
+}
+
+func (qwen35EventContent) isQwen35Event() {}
+
+type qwen35EventThinkingContent struct {
+	content string
+}
+
+func (qwen35EventThinkingContent) isQwen35Event() {}
+
+func (p *Qwen35Parser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
+	p.buffer.WriteString(s)
+	events := p.parseEvents()
+
+	var contentSb strings.Builder
+	var thinkingSb strings.Builder
+	for _, event := range events {
+		switch event := event.(type) {
+		case qwen35EventContent:
+			parsedContent, _, parsedCalls, err := p.toolParser.Add(event.content, done)
+			if err != nil {
+				slog.Warn("qwen3.5 tool call parsing failed", "error", err)
+				return "", "", nil, err
+			}
+			contentSb.WriteString(parsedContent)
+			calls = append(calls, parsedCalls...)
+		case qwen35EventThinkingContent:
+			thinkingSb.WriteString(event.content)
+		}
+	}
+
+	return contentSb.String(), thinkingSb.String(), calls, nil
+}
+
+func (p *Qwen35Parser) parseEvents() []qwen35Event {
+	var all []qwen35Event
+
+	keepLooping := true
+	for keepLooping {
+		var events []qwen35Event
+		events, keepLooping = p.eat()
+		if len(events) > 0 {
+			all = append(all, events...)
+		}
+	}
+
+	if len(all) > 0 {
+		slog.Log(context.TODO(), logutil.LevelTrace, "qwen3.5 events parsed", "events", all, "state", p.state, "buffer", p.buffer.String())
+	}
+
+	return all
+}
+
+// splitAtTag splits p.buffer at the first occurrence of tag. The fork's
+// package-level splitAtTag is bound to *Qwen3VLParser, so this operates on the
+// parser's own buffer directly (same semantics: trim before-right, optionally
+// trim after-left, keep the remainder in the buffer).
+func (p *Qwen35Parser) splitAtTag(tag string, trimAfter bool) (string, string) {
+	split := strings.SplitN(p.buffer.String(), tag, 2)
+	before := strings.TrimRightFunc(split[0], unicode.IsSpace)
+	after := split[1]
+	if trimAfter {
+		after = strings.TrimLeftFunc(after, unicode.IsSpace)
+	}
+	p.buffer.Reset()
+	p.buffer.WriteString(after)
+	return before, after
+}
+
+func (p *Qwen35Parser) eatLeadingWhitespaceAndTransitionTo(nextState qwen35ParserState) ([]qwen35Event, bool) {
+	trimmed := strings.TrimLeftFunc(p.buffer.String(), unicode.IsSpace)
+	p.buffer.Reset()
+	if trimmed == "" {
+		return nil, false
+	}
+	p.state = nextState
+	p.buffer.WriteString(trimmed)
+	return nil, true
+}
+
+// maybeConsumeLeadingThinkOpenTag handles a single optional leading <think> tag.
+// Returns (handled, shouldContinueParsingNow).
+func (p *Qwen35Parser) maybeConsumeLeadingThinkOpenTag(acc string) (bool, bool) {
+	if !p.allowLeadingThinkOpenTag {
+		return false, false
+	}
+
+	trimmed := strings.TrimLeftFunc(acc, unicode.IsSpace)
+	if strings.HasPrefix(trimmed, qwen35ThinkingOpenTag) {
+		after := strings.TrimPrefix(trimmed, qwen35ThinkingOpenTag)
+		after = strings.TrimLeftFunc(after, unicode.IsSpace)
+		p.buffer.Reset()
+		p.buffer.WriteString(after)
+		if after == "" {
+			return true, false
+		}
+		p.allowLeadingThinkOpenTag = false
+		return true, true
+	}
+
+	if strings.HasPrefix(qwen35ThinkingOpenTag, trimmed) {
+		return true, false
+	}
+
+	p.allowLeadingThinkOpenTag = false
+	return false, false
+}
+
+func (p *Qwen35Parser) eat() ([]qwen35Event, bool) {
+	var events []qwen35Event
+
+	switch p.state {
+	case qwen35ParserStateCollectingThinking:
+		acc := p.buffer.String()
+
+		if handled, continueNow := p.maybeConsumeLeadingThinkOpenTag(acc); handled {
+			return events, continueNow
+		}
+
+		if strings.Contains(acc, qwen35ThinkingCloseTag) {
+			thinking, remaining := p.splitAtTag(qwen35ThinkingCloseTag, true)
+			if len(thinking) > 0 {
+				events = append(events, qwen35EventThinkingContent{content: thinking})
+			}
+			if remaining == "" {
+				p.state = qwen35ParserStateThinkingDoneEatingWhitespace
+			} else {
+				p.state = qwen35ParserStateCollectingContent
+			}
+			return events, true
+		} else if overlapLen := max(overlap(acc, qwen35ThinkingCloseTag), overlap(acc, qwen35ToolCallOpenTag)); overlapLen > 0 {
+			beforePartialTag := acc[:len(acc)-overlapLen]
+			trailingWsLen := trailingWhitespaceLen(beforePartialTag)
+			ambiguousStart := len(beforePartialTag) - trailingWsLen
+
+			unambiguous := acc[:ambiguousStart]
+			ambiguous := acc[ambiguousStart:]
+			p.buffer.Reset()
+			p.buffer.WriteString(ambiguous)
+			if len(unambiguous) > 0 {
+				events = append(events, qwen35EventThinkingContent{content: unambiguous})
+			}
+			return events, false
+		} else if strings.Contains(acc, qwen35ToolCallOpenTag) {
+			// qwen3.5:9b model forgets sometimes to use </think> tag before the <tool_call> block starts
+			// this condition ends the Think block and continues with the <tool_call> when the tag
+			// is found
+			thinking, tooling := p.splitAtTag(qwen35ToolCallOpenTag, true)
+			p.buffer.Reset()
+			p.buffer.WriteString(thinking + qwen35ThinkingCloseTag + qwen35ToolCallOpenTag + tooling)
+			return events, true
+		}
+
+		whitespaceLen := trailingWhitespaceLen(acc)
+		ambiguousStart := len(acc) - whitespaceLen
+		unambiguous := acc[:ambiguousStart]
+		ambiguous := acc[ambiguousStart:]
+		p.buffer.Reset()
+		p.buffer.WriteString(ambiguous)
+		if len(unambiguous) > 0 {
+			events = append(events, qwen35EventThinkingContent{content: unambiguous})
+		}
+		return events, false
+
+	case qwen35ParserStateThinkingDoneEatingWhitespace:
+		return p.eatLeadingWhitespaceAndTransitionTo(qwen35ParserStateCollectingContent)
+
+	case qwen35ParserStateCollectingContent:
+		if p.buffer.Len() == 0 {
+			return events, false
+		}
+
+		content := p.buffer.String()
+		p.buffer.Reset()
+		if len(content) > 0 {
+			events = append(events, qwen35EventContent{content: content})
+		}
+		return events, false
+
+	default:
+		slog.Warn("qwen3.5 parser entered unknown state; resetting to content mode", "state", p.state)
+		p.state = qwen35ParserStateCollectingContent
+		return events, false
+	}
+}

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -131,6 +131,11 @@ func (p *Qwen35Parser) parseEvents() []qwen35Event {
 // trim after-left, keep the remainder in the buffer).
 func (p *Qwen35Parser) splitAtTag(tag string, trimAfter bool) (string, string) {
 	split := strings.SplitN(p.buffer.String(), tag, 2)
+	if len(split) == 1 {
+		// tag absent — mirror upstream's guard instead of indexing split[1].
+		p.buffer.Reset()
+		return split[0], ""
+	}
 	before := strings.TrimRightFunc(split[0], unicode.IsSpace)
 	after := split[1]
 	if trimAfter {

--- a/model/renderers/ornith.go
+++ b/model/renderers/ornith.go
@@ -1,0 +1,16 @@
+package renderers
+
+type OrnithRenderer struct {
+	Qwen35Renderer
+}
+
+func newOrnithRenderer() Renderer {
+	return &OrnithRenderer{
+		Qwen35Renderer: Qwen35Renderer{
+			isThinking:                      true,
+			alwaysRenderAssistantThinkBlock: true,
+			emitEmptyThinkOnNoThink:         true,
+			useImgTags:                      RenderImgTags,
+		},
+	}
+}

--- a/model/renderers/ornith.go
+++ b/model/renderers/ornith.go
@@ -1,5 +1,7 @@
 package renderers
 
+import "github.com/ollama/ollama/api"
+
 type OrnithRenderer struct {
 	Qwen35Renderer
 }
@@ -9,8 +11,17 @@ func newOrnithRenderer() Renderer {
 		Qwen35Renderer: Qwen35Renderer{
 			isThinking:                      true,
 			alwaysRenderAssistantThinkBlock: true,
-			emitEmptyThinkOnNoThink:         true,
 			useImgTags:                      RenderImgTags,
 		},
 	}
+}
+
+// Render forces thinking on. ornith is a thinking model, and the fork's Parser
+// interface cannot be told think:false per request — Qwen35Parser always collects
+// a <think>…</think> span. Keeping the renderer always-thinking matches the parser
+// (and the fork's other thinking models, e.g. qwen3.5); otherwise a think:false
+// request would emit a closed empty <think></think> in the prompt and the model's
+// answer would be misrouted to the thinking channel, leaving content empty.
+func (r *OrnithRenderer) Render(messages []api.Message, tools []api.Tool, _ *api.ThinkValue) (string, error) {
+	return r.Qwen35Renderer.Render(messages, tools, &api.ThinkValue{Value: true})
 }

--- a/model/renderers/ornith_test.go
+++ b/model/renderers/ornith_test.go
@@ -1,0 +1,74 @@
+package renderers
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestOrnithRendererMatchesAssistantHistoryThinkBlocks(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "user", Content: "Say hello."},
+		{Role: "assistant", Content: "Hello."},
+		{Role: "user", Content: "Now say bye."},
+	}
+
+	got, err := RenderWithRenderer("ornith", msgs, nil, nil)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	want := `<|im_start|>user
+Say hello.<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+Hello.<|im_end|>
+<|im_start|>user
+Now say bye.<|im_end|>
+<|im_start|>assistant
+<think>
+`
+	if got != want {
+		t.Fatalf("unexpected Ornith render\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+}
+
+func TestOrnithRendererKeepsAssistantThinkBlocksWhenThinkingDisabled(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "user", Content: "Say hello."},
+		{
+			Role:     "assistant",
+			Thinking: "Keep it short.",
+			Content:  "Hello.",
+		},
+		{Role: "user", Content: "Now say bye."},
+	}
+
+	got, err := RenderWithRenderer("ornith", msgs, nil, &api.ThinkValue{Value: false})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	want := `<|im_start|>user
+Say hello.<|im_end|>
+<|im_start|>assistant
+<think>
+Keep it short.
+</think>
+
+Hello.<|im_end|>
+<|im_start|>user
+Now say bye.<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+`
+	if got != want {
+		t.Fatalf("unexpected Ornith render with thinking disabled\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+}

--- a/model/renderers/ornith_test.go
+++ b/model/renderers/ornith_test.go
@@ -36,7 +36,11 @@ Now say bye.<|im_end|>
 	}
 }
 
-func TestOrnithRendererKeepsAssistantThinkBlocksWhenThinkingDisabled(t *testing.T) {
+// ornith forces thinking on even when the request sets think:false, because the
+// fork's parser cannot be told think:false and always collects a <think> span.
+// So a think:false request renders identically to a thinking request (an open
+// <think> prefill), never a closed empty block — keeping renderer and parser in sync.
+func TestOrnithRendererForcesThinkingWhenDisabled(t *testing.T) {
 	msgs := []api.Message{
 		{Role: "user", Content: "Say hello."},
 		{
@@ -64,11 +68,8 @@ Hello.<|im_end|>
 Now say bye.<|im_end|>
 <|im_start|>assistant
 <think>
-
-</think>
-
 `
 	if got != want {
-		t.Fatalf("unexpected Ornith render with thinking disabled\n--- got ---\n%q\n--- want ---\n%q", got, want)
+		t.Fatalf("unexpected Ornith render with think:false\n--- got ---\n%q\n--- want ---\n%q", got, want)
 	}
 }

--- a/model/renderers/qwen35.go
+++ b/model/renderers/qwen35.go
@@ -1,0 +1,198 @@
+package renderers
+
+import (
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+const (
+	qwen35ThinkOpenTag  = "<think>"
+	qwen35ThinkCloseTag = "</think>"
+	qwen35ToolPostamble = `
+</tools>
+
+If you choose to call a function ONLY reply in the following format with NO suffix:
+
+<tool_call>
+<function=example_function_name>
+<parameter=example_parameter_1>
+value_1
+</parameter>
+<parameter=example_parameter_2>
+This is the value for the second parameter
+that can span
+multiple lines
+</parameter>
+</function>
+</tool_call>
+
+<IMPORTANT>
+Reminder:
+- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags
+- Required parameters MUST be specified
+- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after
+- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls
+</IMPORTANT>`
+)
+
+type Qwen35Renderer struct {
+	isThinking bool
+
+	alwaysRenderAssistantThinkBlock bool
+	emitEmptyThinkOnNoThink         bool
+	useImgTags                      bool
+}
+
+func (r *Qwen35Renderer) LeadingBOS() string {
+	return ""
+}
+
+func (r *Qwen35Renderer) renderContent(content api.Message, imageOffset int) (string, int) {
+	if r.useImgTags {
+		return renderContentWithImageTags(content.Content, len(content.Images), imageOffset)
+	}
+
+	// This assumes all images are at the front of the message - same assumption as ollama/ollama/runner.go
+	var subSb strings.Builder
+	for range content.Images {
+		subSb.WriteString("<|vision_start|><|image_pad|><|vision_end|>")
+	}
+	// TODO: support videos
+
+	subSb.WriteString(content.Content)
+	return subSb.String(), imageOffset
+}
+
+func splitQwen35ReasoningContent(content, messageThinking string, isThinking bool) (reasoning string, remaining string) {
+	if isThinking && messageThinking != "" {
+		return strings.TrimSpace(messageThinking), content
+	}
+
+	if idx := strings.Index(content, qwen35ThinkCloseTag); idx != -1 {
+		before := content[:idx]
+		if open := strings.LastIndex(before, qwen35ThinkOpenTag); open != -1 {
+			reasoning = before[open+len(qwen35ThinkOpenTag):]
+		} else {
+			reasoning = before
+		}
+		content = strings.TrimLeft(content[idx+len(qwen35ThinkCloseTag):], "\n")
+	}
+
+	return strings.TrimSpace(reasoning), content
+}
+
+func (r *Qwen35Renderer) Render(messages []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error) {
+	var sb strings.Builder
+
+	isThinking := r.isThinking
+	if think != nil {
+		isThinking = think.Bool()
+	}
+
+	if len(tools) > 0 {
+		sb.WriteString(imStartTag + "system\n")
+		sb.WriteString("# Tools\n\nYou have access to the following functions:\n\n<tools>")
+		for _, tool := range tools {
+			sb.WriteString("\n")
+			if b, err := marshalWithSpaces(tool); err == nil {
+				sb.Write(b)
+			}
+		}
+		sb.WriteString(qwen35ToolPostamble)
+		if len(messages) > 0 && messages[0].Role == "system" {
+			systemContent, _ := r.renderContent(messages[0], 0)
+			systemContent = strings.TrimSpace(systemContent)
+			if systemContent != "" {
+				sb.WriteString("\n\n")
+				sb.WriteString(systemContent)
+			}
+		}
+		sb.WriteString(imEndTag + "\n")
+	} else if len(messages) > 0 && messages[0].Role == "system" {
+		systemContent, _ := r.renderContent(messages[0], 0)
+		sb.WriteString(imStartTag + "system\n" + strings.TrimSpace(systemContent) + imEndTag + "\n")
+	}
+
+	multiStepTool := true
+	lastQueryIndex := len(messages) - 1 // so this is the last user message
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		message := messages[i]
+		if multiStepTool && message.Role == "user" {
+			content, _ := r.renderContent(message, 0)
+			content = strings.TrimSpace(content)
+			if !(strings.HasPrefix(content, "<tool_response>") && strings.HasSuffix(content, "</tool_response>")) {
+				multiStepTool = false
+				lastQueryIndex = i
+			}
+		}
+	}
+
+	imageOffset := 0
+	for i, message := range messages {
+		content, nextImageOffset := r.renderContent(message, imageOffset)
+		imageOffset = nextImageOffset
+		content = strings.TrimSpace(content)
+
+		lastMessage := i == len(messages)-1
+		prefill := lastMessage && message.Role == "assistant"
+
+		if message.Role == "user" || (message.Role == "system" && i != 0) {
+			sb.WriteString(imStartTag + message.Role + "\n" + content + imEndTag + "\n")
+		} else if message.Role == "assistant" {
+			renderAssistantThinkBlock := r.alwaysRenderAssistantThinkBlock || (isThinking && i > lastQueryIndex)
+			contentReasoning, content := splitQwen35ReasoningContent(content, message.Thinking, renderAssistantThinkBlock)
+
+			if renderAssistantThinkBlock {
+				sb.WriteString(imStartTag + message.Role + "\n<think>\n" + contentReasoning + "\n</think>\n\n" + content)
+			} else {
+				sb.WriteString(imStartTag + message.Role + "\n" + content)
+			}
+
+			if len(message.ToolCalls) > 0 {
+				for j, toolCall := range message.ToolCalls {
+					if j == 0 {
+						if strings.TrimSpace(content) != "" {
+							sb.WriteString("\n\n")
+						}
+					} else {
+						sb.WriteString("\n")
+					}
+
+					sb.WriteString("<tool_call>\n<function=" + toolCall.Function.Name + ">\n")
+					for name, value := range toolCall.Function.Arguments {
+						sb.WriteString("<parameter=" + name + ">\n")
+						sb.WriteString(formatToolCallArgument(value))
+						sb.WriteString("\n</parameter>\n")
+					}
+					sb.WriteString("</function>\n</tool_call>")
+				}
+			}
+
+			if !prefill {
+				sb.WriteString(imEndTag + "\n")
+			}
+		} else if message.Role == "tool" {
+			if i == 0 || messages[i-1].Role != "tool" {
+				sb.WriteString(imStartTag + "user")
+			}
+			sb.WriteString("\n<tool_response>\n" + content + "\n</tool_response>")
+			if i == len(messages)-1 || messages[i+1].Role != "tool" {
+				sb.WriteString(imEndTag + "\n")
+			}
+		}
+
+		// prefill at the end
+		if lastMessage && !prefill {
+			sb.WriteString(imStartTag + "assistant\n")
+			if isThinking {
+				sb.WriteString("<think>\n")
+			} else if r.emitEmptyThinkOnNoThink {
+				sb.WriteString("<think>\n\n</think>\n\n")
+			}
+		}
+	}
+
+	return sb.String(), nil
+}

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -69,6 +69,8 @@ func rendererForName(name string) Renderer {
 		return &LFM2Renderer{IsThinking: false, useImgTags: RenderImgTags}
 	case "lfm2-thinking":
 		return &LFM2Renderer{IsThinking: true, useImgTags: RenderImgTags}
+	case "ornith":
+		return newOrnithRenderer()
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary
Port the **ornith** renderer + parser into the fork so ornith models (Qwen3.5-family, native `qwen35`/`qwen35moe`) render and parse as trained. Rebased onto current main (includes #429/#430/#432/#433).

- Ports upstream's dedicated `Qwen35Renderer` + `Qwen35Parser`, adapted to the fork's interfaces (the fork's qwen3.5 path uses a different JSON tool format + lacks ornith's think flags, so building on `Qwen3VLRenderer` was not viable).
- Code-review fixes: `OrnithRenderer.Render` forces thinking on (the fork parser can't be told `think:false`, so this keeps renderer + parser in sync); `splitAtTag` guard restored.
- No change to `fs/ggml/` FA lists or `ml/device.go`.

## Verification
- `go test ./model/renderers/ ./model/parsers/` — green (ported ornith golden tests + parser tests).
- **Real K80 runs (this session):** `ornith:9b` ✅ pull+generate; `ornith:35b` ✅ generate (MoE, 3-die split) — both coherent, native engine, no crash. Graph-traced end to end.

Fixes #422
Part of STORY-020.

## Test plan
- [x] CPU unit tests green
- [x] `ornith:9b` + `ornith:35b` run coherently on sm37/K80 (real weights)
- [ ] published image carries it (follow-up CI build)

Generated with [Claude Code](https://claude.com/claude-code)
