### PR TITLE
CI: retag local build as the compose image (retire Hub push)

### DIFF
--- a/.claude/skills/ollama37-ci-apply/SKILL.md
+++ b/.claude/skills/ollama37-ci-apply/SKILL.md
@@ -37,5 +37,7 @@ is logged and reproducible.
 
 `ollama37-ci-build` builds the image; this skill applies it; then the test suites
 (`test-models.yml`, etc.) exercise it. `test-pipeline.yml` chains `build → runtime → inference →
-models` for one `runner_label` if you want the whole flow in one run. For a CUDA change that must hold
-on both cards, apply the **same published digest** on both hosts before testing — see `ollama37-ci-build`.
+models` for one `runner_label` if you want the whole flow in one run — and because the build suite
+retags the fresh image to the tag compose reads (`TC-BUILD-004`, see `ollama37-ci-build`), that one
+pipeline run builds *and* applies the new bits. Testing is **single-host**; the retired cross-host
+by-digest path no longer applies.

--- a/.claude/skills/ollama37-ci-build/SKILL.md
+++ b/.claude/skills/ollama37-ci-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ollama37-ci-build
-description: Build (and publish) the ollama37 CI image on a self-hosted GPU runner — never with a local make
+description: Build the ollama37 CI image on a self-hosted GPU runner — never with a local make
 user-invocable: true
 ---
 
@@ -39,13 +39,16 @@ gh run watch <run-id> --exit-status        # block until done; GitHub holds the 
   `ensure-builder` rebuilds it, ~90 min). It can run on `sm75` only if `ollama37-builder:latest` is
   already present there.
 
-## The CI image, and moving it between testbeds
+## The CI image lands where compose reads it — same host, no push
 
-`ollama37:latest` is a **local tag** on one runner's Docker daemon — `docker/docker-compose.yml` reads
-exactly this tag. The two runners are **independent hosts with no network between them**, so the tag on
-`sm37` names nothing on `sm75`. To test the *same bits* on both cards, publish to Docker Hub
-**`dogkeeper886/ollama37-ci:ci-<sha>`** and fetch **by digest** (`@sha256:…`, immutable — a tag can be
-overwritten, a digest cannot). `TC-BUILD-004` publishes; a fetch step retags the digest back to
-`ollama37:latest` so compose reads it. That published, digest-addressed artifact is "the CI image."
+The build produces the local tag **`ollama37:latest`**, but `docker/docker-compose.yml` reads
+**`dogkeeper886/ollama37:latest`**. `TC-BUILD-004` (in the build suite) bridges that gap: it retags the
+fresh `ollama37:latest` → `dogkeeper886/ollama37:latest` **locally**, so every later `docker compose up`
+(runtime/inference/models/perf) exercises the build we just made — no compose edit, no Docker Hub push.
+
+This is **single-host**: build and test on the same runner. The old cross-host path — publish to
+`dogkeeper886/ollama37-ci:ci-<sha>` and pull by digest on a second card — was **retired** (#441): the
+push was slow and nothing ever consumed the pushed image. To restore the *published* image on a runner
+(e.g. for a published-image baseline), `docker pull dogkeeper886/ollama37:latest`.
 
 Once built, hand off to `ollama37-ci-apply` to roll it onto the testbed.

--- a/cicd/docs/PLAN.md
+++ b/cicd/docs/PLAN.md
@@ -243,6 +243,13 @@ as a second testbed is what surfaced #385.
 
 ### The decision: build once, test the artifact
 
+> **SUPERSEDED (#441).** The publish → fetch-by-digest cross-host flow below was retired: the
+> Docker Hub push was slow and nothing ever consumed the pushed `ollama37-ci:ci-<sha>` image (the
+> "fetch" half was never implemented). It is replaced by a **local retag** — `TC-BUILD-004` now
+> `docker tag ollama37:latest dogkeeper886/ollama37:latest` on the build runner, so `docker compose
+> up` picks up the fresh build with no push and no compose edit. Testing is **single-host**. The
+> record below is kept for history.
+
 Building on `sm75` would take hours (i3-14100, no builder cache) and would produce a
 *second* artifact — so a disagreement between testbeds could not be attributed. Build on
 `sm37`, publish, pull.

--- a/cicd/tests/testcases/build/TC-BUILD-004.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-004.yml
@@ -1,48 +1,45 @@
 id: TC-BUILD-004
-name: Publish CI image to Docker Hub
+name: Retag local build as the compose image
 suite: build
 priority: 4
-timeout: 600000
+timeout: 60000
 dependencies: []
 intent:
   user_story: |
-    Publish the runtime image already built on this runner to the CI image repo, so a
-    second testbed (e.g. sm75) can pull the exact same artifact by digest.
+    Make the freshly-built ollama37:latest the image docker-compose reads on this runner, so
+    the runtime / inference / models / perf suites exercise the build we just made — without
+    editing docker-compose.yml or a slow Docker Hub push.
   notes: |
-    Runs against the `ollama37:latest` already on this host's Docker daemon — it does NOT
-    rebuild (no dependency on TC-BUILD-002). Publishes to a dedicated public repo so
-    half-tested ci-<sha> tags never touch the tag list users pull `:latest` from. Pushes
-    from the sm37 daemon's existing credential; no docker login step. The digest it prints
-    is what the other testbed pulls (a tag can be overwritten; a digest cannot).
+    docker-compose.yml reads `dogkeeper886/ollama37:latest` and sets no `pull_policy: always`,
+    so `docker compose up` uses a LOCAL image with that tag when one is present. Retagging the
+    fresh `ollama37:latest` (TC-BUILD-002's output, built earlier in this build suite) to that
+    tag makes every subsequent `docker compose up` pick up this build.
+
+    Local-only: the runner's `dogkeeper886/ollama37:latest` now names the last local build;
+    `docker pull dogkeeper886/ollama37:latest` restores the released image (e.g. to run a
+    published-image baseline). This replaces the retired Docker Hub push
+    (`dogkeeper886/ollama37-ci:ci-<sha>`), which had no automated consumer — the "fetch by
+    digest" half was never implemented as a testcase.
 
 steps:
-  - name: Tag and push CI image
+  - name: Retag ollama37:latest as the compose image
     command: |
-      SHA=$(echo "${GITHUB_SHA:-local}" | cut -c1-12)
-      REF="dogkeeper886/ollama37-ci:ci-${SHA}"
-      echo "Publishing ollama37:latest as ${REF}"
-      docker tag ollama37:latest "${REF}"
-      docker push "${REF}"
+      echo "Retagging ollama37:latest -> dogkeeper886/ollama37:latest (local, for compose)"
+      docker tag ollama37:latest dogkeeper886/ollama37:latest
+      docker image inspect dogkeeper886/ollama37:latest --format 'retagged {{.Id}}'
     expectPatterns:
-      - "digest: sha256:"
+      - "retagged sha256:"
     rejectPatterns:
-      - "denied"
-      - "no such image"
-      - "no basic auth credentials"
-
-  - name: Print the fully-qualified digest
-    command: |
-      SHA=$(echo "${GITHUB_SHA:-local}" | cut -c1-12)
-      docker image inspect "dogkeeper886/ollama37-ci:ci-${SHA}" --format '{{index .RepoDigests 0}}'
-    expectPatterns:
-      - "ollama37-ci@sha256:"
+      - "No such image"
 
 criteria: |
-  Publish the local ollama37:latest to dogkeeper886/ollama37-ci:ci-<sha> and report its
-  digest.
+  Retag the freshly-built ollama37:latest to dogkeeper886/ollama37:latest on this runner so
+  docker compose (runtime / inference / models / perf) exercises the new build.
 
   Expected:
-  - docker push succeeds ("digest: sha256:..." in the output)
-  - the fully-qualified digest (dogkeeper886/ollama37-ci@sha256:...) is printed for the
-    fetching testbed to pull by digest
-  - no "denied" (would mean the runner's credential can't push to this repo)
+  - docker tag succeeds and `docker image inspect dogkeeper886/ollama37:latest` prints its id
+    ("retagged sha256:...")
+  - no "No such image" (would mean TC-BUILD-002 did not produce ollama37:latest)
+
+  Local-only: the runner's dogkeeper886/ollama37:latest now names the last local build;
+  `docker pull` restores the published image. No Docker Hub push.

--- a/cicd/tests/testcases/build/TC-BUILD-004.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-004.yml
@@ -3,7 +3,8 @@ name: Retag local build as the compose image
 suite: build
 priority: 4
 timeout: 60000
-dependencies: []
+dependencies:
+  - TC-BUILD-002
 intent:
   user_story: |
     Make the freshly-built ollama37:latest the image docker-compose reads on this runner, so
@@ -12,8 +13,10 @@ intent:
   notes: |
     docker-compose.yml reads `dogkeeper886/ollama37:latest` and sets no `pull_policy: always`,
     so `docker compose up` uses a LOCAL image with that tag when one is present. Retagging the
-    fresh `ollama37:latest` (TC-BUILD-002's output, built earlier in this build suite) to that
-    tag makes every subsequent `docker compose up` pick up this build.
+    fresh `ollama37:latest` (TC-BUILD-002's output — declared as a dependency so it is ordered
+    after the build) to that tag makes every subsequent `docker compose up` pick up this build.
+    If TC-BUILD-002 fails, the build job fails and the pipeline's `needs: build` stops the runtime
+    job before this tag is exercised — so a stale retag is never tested downstream in a pipeline run.
 
     Local-only: the runner's `dogkeeper886/ollama37:latest` now names the last local build;
     `docker pull dogkeeper886/ollama37:latest` restores the released image (e.g. to run a


### PR DESCRIPTION
## Summary
- **TC-BUILD-004** repurposed: `docker tag ollama37:latest dogkeeper886/ollama37:latest` **locally** (was a Docker Hub push). Since compose reads that tag and has no `pull_policy: always`, every subsequent `docker compose up` (runtime/inference/models/perf) exercises the **freshly-built** image — no `docker-compose.yml` edit, model `ollama-data` volume reused.
- **Retires the `ci-<sha>` Hub push** — it was slow and had **no automated consumer** (the fetch-by-digest half was never implemented). Single-host by design; `docker pull dogkeeper886/ollama37:latest` restores the published baseline.
- **Docs:** `ollama37-ci-build` / `ollama37-ci-apply` skills updated; SUPERSEDED note on `cicd/docs/PLAN.md`'s publish/fetch section. `cicd/README.md` unchanged (its only Hub ref is `release-docker`, legit).
- Code-review: `dependencies: [TC-BUILD-002]` so the retag is ordered after the build.

Fixes #441

## Test plan
- [ ] `test-build.yml` on sm37 passes (TC-BUILD-004 retags; "retagged sha256:" printed).
- [ ] After a build, `docker compose up` runs the fresh bits (verify a known change is present).
- [ ] Published baseline still restorable via `docker pull dogkeeper886/ollama37:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)