### PR TITLE
STORY-022: record any model's num_batch × context fit map on the K80

### DIFF
--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -35,7 +35,9 @@ suite workflows:
 
 ```
 ├── test-throughput.yml   # cli.ts bench-throughput — per-model tok/s + output check (short prompt)
-└── test-context.yml      # cli.ts bench-context — long-context prefill/decode tok/s + needle + judge
+├── test-context.yml      # cli.ts bench-context — long-context prefill/decode tok/s + needle + judge
+├── test-mcp.yml          # cli.ts test-mcp — MCP tool-call capability (one model list x one ctx/batch)
+└── test-report-sweep.yml # loops model x context (x num_batch, opt-in) — fills the k80-*-by-family tables + the num_batch x context fit map
 ```
 
 `test-context.yml` is the flash-attention path comparison: it primes a realistic long prompt (so
@@ -44,7 +46,15 @@ applies the experiment env (`flash_attention`/`kv_cache_type`) by recreating the
 `always()` reverts to the stable baseline (FA off). `test-throughput.yml` stays the short-prompt K80
 model-regression tool.
 
-(`cli.ts test-mcp` — MCP tool-call capability — is a subcommand with no workflow yet.)
+`test-report-sweep.yml` is a MEASUREMENT sweep, not a gate — kept out of the pipeline because MCP
+T2 legitimately fails for weaker models. It loops every model x context serially, and (opt-in via
+`fit_map_models`) adds a **fit-map** pass: per model it bounds the context ladder to the trained
+window and picks the judge from tool support (`cli.ts model-bounds`, via `/api/show`), then loops
+`num_batch` x bounded-context — one `test-mcp` cell each. `aggregate-sweep.py` derives each cell's
+fit (✅ on GPU / ⚠️ CPU spill / ❌ OOM) from the MCP GPU snapshot (per-die VRAM + offload%, captured
+independent of the correctness verdict), emitting the fit-map table for a human to commit. The
+default sweep (no `fit_map_models`) is unchanged.
+
 `release-docker.yml` builds and publishes the image on a release.
 
 ## Host selection

--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -49,8 +49,9 @@ model-regression tool.
 `test-report-sweep.yml` is a MEASUREMENT sweep, not a gate — kept out of the pipeline because MCP
 T2 legitimately fails for weaker models. It loops every model x context serially, and (opt-in via
 `fit_map_models`) adds a **fit-map** pass: per model it bounds the context ladder to the trained
-window and picks the judge from tool support (`cli.ts model-bounds`, via `/api/show`), then loops
-`num_batch` x bounded-context — one `test-mcp` cell each. `aggregate-sweep.py` derives each cell's
+window and gates on tool support — skipping no-tools models (`cli.ts model-bounds`, via
+`/api/show`) — then loops `num_batch` x bounded-context, one `test-mcp` cell each with the
+structural judge. `aggregate-sweep.py` derives each cell's
 fit (✅ on GPU / ⚠️ CPU spill / ❌ OOM) from the MCP GPU snapshot (per-die VRAM + offload%, captured
 independent of the correctness verdict), emitting the fit-map table for a human to commit. The
 default sweep (no `fit_map_models`) is unchanged.

--- a/.claude/skills/ollama37-ci-perf/SKILL.md
+++ b/.claude/skills/ollama37-ci-perf/SKILL.md
@@ -69,14 +69,16 @@ this as a **fit map** (the basis for the qwen35moe clamp in #440):
 
 ```bash
 gh workflow run test-report-sweep.yml --ref <branch> \
-  -f suite=mcp \
+  -f suite=none \
   -f fit_map_models='qwen3.6:35b' \
   -f fit_map_num_batches='512 256 128' \
   -f fit_map_contexts='8192 65536 98304 131072 196608 262144'
 ```
 
-Per model it bounds the context ladder to the trained window and gates on tool support
-(`cli.ts model-bounds`, via `/api/show`), then loops `num_batch` x bounded-context. The
+`suite=none` skips the default throughput/MCP sweeps so only the fit-map runs (the fit-map is
+gated on `fit_map_models`, independent of `suite`). Per model it bounds the context ladder to the
+trained window and gates on tool support (`cli.ts model-bounds`, via `/api/show`), then loops
+`num_batch` x bounded-context. The
 `report-sweep-results` artifact's `SUMMARY.md` holds the fit-map table: per cell the **fit**
 (✅ on GPU / ⚠️ CPU spill / ❌ OOM), decode tok/s, `total_s`, per-die VRAM, active dies, and
 offload% — captured from the MCP GPU snapshot **independent of the correctness verdict**, so a

--- a/.claude/skills/ollama37-ci-perf/SKILL.md
+++ b/.claude/skills/ollama37-ci-perf/SKILL.md
@@ -59,3 +59,26 @@ So a kernel that panics — e.g. tensor-core MMA on Turing under CUDA 11.4 — i
 dodging the crash; the crash is the finding.
 
 `models` is `sm37`-only for the large models; on `sm75` size to the ~5 GiB it has.
+
+## Size a model's context/batch fit (fit-map sweep)
+
+A different question from "is this FA path faster": *at what context does a model spill to CPU, and
+does a smaller `num_batch` pull it back onto the GPU?* On the K80 (FA off) the `Q·Kᵀ` score buffer is
+sized by `num_batch`, so batch — not just context — sets the VRAM wall. `test-report-sweep.yml` records
+this as a **fit map** (the basis for the qwen35moe clamp in #440):
+
+```bash
+gh workflow run test-report-sweep.yml --ref <branch> \
+  -f suite=mcp \
+  -f fit_map_models='qwen3.6:35b' \
+  -f fit_map_num_batches='512 256 128' \
+  -f fit_map_contexts='8192 65536 98304 131072 196608 262144'
+```
+
+Per model it bounds the context ladder to the trained window and gates on tool support
+(`cli.ts model-bounds`, via `/api/show`), then loops `num_batch` x bounded-context. The
+`report-sweep-results` artifact's `SUMMARY.md` holds the fit-map table: per cell the **fit**
+(✅ on GPU / ⚠️ CPU spill / ❌ OOM), decode tok/s, `total_s`, per-die VRAM, active dies, and
+offload% — captured from the MCP GPU snapshot **independent of the correctness verdict**, so a
+judge hiccup never loses the fit data. Leave `fit_map_models` empty (default) and the sweep runs
+its normal throughput/MCP pass unchanged.

--- a/.github/workflows/test-report-sweep.yml
+++ b/.github/workflows/test-report-sweep.yml
@@ -38,6 +38,18 @@ on:
         description: "Throughput tokens to generate"
         type: string
         default: "16"
+      fit_map_models:
+        description: "Fit-map models (space-separated; empty = skip the fit-map sweep). Records num_batch x context fit per model."
+        type: string
+        default: ""
+      fit_map_num_batches:
+        description: "Fit-map num_batch ladder (space-separated)"
+        type: string
+        default: "512 256 128"
+      fit_map_contexts:
+        description: "Fit-map context ladder (space-separated; each clipped to the model's native context via ollama show)"
+        type: string
+        default: "8192 65536 98304 131072 196608 262144"
       distractor_command:
         description: "MCP distractor server command (raises tool-menu difficulty; empty = none)"
         type: string
@@ -146,10 +158,55 @@ jobs:
             done
           done
 
+      - name: MCP fit-map sweep
+        # Opt-in (fit_map_models set) so the default sweep is byte-for-byte unchanged (K80 no-harm).
+        # Per model: ollama show bounds the ctx ladder to native + gates on tool support (#446);
+        # then loop num_batch x bounded-ctx, one test-mcp cell each. Judge is the structural check
+        # (no --verify-live) so a judge/infra hiccup can't lose the VRAM/tps fit data — the fit
+        # numbers (per-die VRAM + offload, #445) are captured regardless of the correctness verdict.
+        if: ${{ inputs.fit_map_models != '' }}
+        env:
+          MODELS: ${{ inputs.fit_map_models }}
+          TESTLINK_URL: ${{ secrets.TESTLINK_URL }}
+          TESTLINK_API_KEY: ${{ secrets.TESTLINK_API_KEY }}
+        run: |
+          set -o pipefail
+          cd cicd/tests
+          mkdir -p /tmp/sweep-out
+          for M in $MODELS; do
+            read NATIVE_CTX TOOLS ARCH <<< "$(npx tsx src/cli.ts model-bounds "$M" 2>/dev/null)"
+            echo "::group::fit-map $M (native_ctx=$NATIVE_CTX tools=$TOOLS arch=$ARCH)"
+            if [ "$TOOLS" != "1" ]; then
+              echo "  $M reports no tool support — skipping (the fit-map uses the tool-call vehicle)"
+              echo "::endgroup::"; continue
+            fi
+            SAFE=$(echo "$M" | tr ':/' '--')
+            for NB in ${{ inputs.fit_map_num_batches }}; do
+              for CTX in ${{ inputs.fit_map_contexts }}; do
+                if [ "$NATIVE_CTX" != "0" ] && [ "$CTX" -gt "$NATIVE_CTX" ]; then
+                  echo "  skip ctx=$CTX > native $NATIVE_CTX"; continue
+                fi
+                echo "--- $M ctx=$CTX nb=$NB ---"
+                bash ../scripts/gpu-temp-guard.sh -- npx tsx src/cli.ts test-mcp "$M" \
+                  --prompt "List the test suites in the ollama37 project." \
+                  --num-ctx "$CTX" --num-batch "$NB" \
+                  --timeout "3600" \
+                  --mcp-command "docker" \
+                  --mcp-args "run --rm -i -e TESTLINK_URL -e TESTLINK_API_KEY dogkeeper886/testlink-mcp:latest" \
+                  --mcp-env "TESTLINK_URL,TESTLINK_API_KEY" \
+                  --distractor-command "${{ inputs.distractor_command }}" \
+                  --distractor-args "${{ inputs.distractor_args }}" \
+                  --output "/tmp/sweep-out/fitmap_${CTX}_${NB}_${SAFE}.json" \
+                  | tee -a "$GITHUB_STEP_SUMMARY" || echo "fit-map $M ctx=$CTX nb=$NB returned non-zero (partial results kept)"
+              done
+            done
+            echo "::endgroup::"
+          done
+
       - name: Unload models
         if: always()
         env:
-          ALL_MODELS: ${{ inputs.throughput_models }} ${{ inputs.mcp_models }}
+          ALL_MODELS: ${{ inputs.throughput_models }} ${{ inputs.mcp_models }} ${{ inputs.fit_map_models }}
         run: |
           for M in $ALL_MODELS; do
             curl -s "${OLLAMA_HOST}/api/generate" -d "{\"model\":\"${M}\",\"keep_alive\":0}" || true

--- a/.github/workflows/test-report-sweep.yml
+++ b/.github/workflows/test-report-sweep.yml
@@ -12,8 +12,9 @@ on:
       suite:
         description: "What to sweep"
         type: choice
-        options: ["both", "throughput", "mcp"]
+        options: ["both", "throughput", "mcp", "none"]
         default: "both"
+        # "none" skips both default sweeps — use it with fit_map_models to run ONLY the fit-map.
       throughput_models:
         description: "Throughput models (space-separated)"
         type: string

--- a/cicd/scripts/aggregate-sweep.py
+++ b/cicd/scripts/aggregate-sweep.py
@@ -82,10 +82,11 @@ def main():
             model = r.get("model", "?")
             gpu = r.get("gpu") or {}
             offload = gpu.get("offloadPct")
-            # ❌ no GPU snapshot = the model never became resident (OOM / load failure);
-            # ✅ fully on GPU; ⚠️ partial = CPU spill.
+            # ✅ fully on GPU; ⚠️ partial = CPU spill; ❌ no GPU snapshot = the model
+            # never became fully resident — a true OOM, or a load/round error/timeout
+            # (they're indistinguishable here, so the mark claims "not resident", not "OOM").
             if not gpu or offload is None:
-                fit = "OOM"
+                fit = "NOFIT"
             elif offload >= 100:
                 fit = "FIT"
             else:
@@ -138,9 +139,9 @@ def main():
 
     if fitmap:
         lines.append("## Fit map (`num_batch` x context, STORY-022)\n")
-        lines.append("Fit: ✅ fully on GPU · ⚠️ CPU spill · ❌ OOM (never resident). "
+        lines.append("Fit: ✅ fully on GPU · ⚠️ CPU spill · ❌ not resident (OOM or a load/round error). "
                      "Numbers are decode tok/s · total_s · total VRAM · active dies · offload%.\n")
-        mark = {"FIT": "✅", "SPILL": "⚠️", "OOM": "❌"}
+        mark = {"FIT": "✅", "SPILL": "⚠️", "NOFIT": "❌"}
         for model in sorted(fitmap):
             lines.append(f"### `{model}`\n")
             lines.append("| ctx | num_batch | fit | verdict | tok/s | total_s | VRAM (G) | dies | offload% | per-die used (MiB) |")

--- a/cicd/scripts/aggregate-sweep.py
+++ b/cicd/scripts/aggregate-sweep.py
@@ -29,6 +29,7 @@ def main():
     tsv_rows = []          # suite-tagged flat rows for the TSV
     tp = {}                # model -> ctx -> dict
     mcp = {}               # model -> (test,ctx) -> dict
+    fitmap = {}            # model -> (ctx,nb) -> dict  (STORY-022 num_batch x context)
 
     for path in sorted(glob.glob(os.path.join(in_dir, "tp_*.json"))):
         m = re.match(r"tp_(\d+)\.json$", os.path.basename(path))
@@ -70,6 +71,42 @@ def main():
             tsv_rows.append(f"mcp\t{model}\t{test}\t{ctx_label(ctx)}\t{verdict}\t"
                             f"{row['ptok']}\t{row['secs']}\t{row['tps']}\t{calls}")
 
+    # Fit-map cells: one model per file, ctx + num_batch in the name (fitmap_<ctx>_<nb>_<model>.json).
+    # The fit verdict comes from the GPU snapshot (#445), independent of the correctness judge.
+    for path in sorted(glob.glob(os.path.join(in_dir, "fitmap_*.json"))):
+        m = re.match(r"fitmap_(\d+)_(\d+)_.+\.json$", os.path.basename(path))
+        if not m:
+            continue
+        ctx, nb = m.group(1), m.group(2)
+        for r in load(path):
+            model = r.get("model", "?")
+            gpu = r.get("gpu") or {}
+            offload = gpu.get("offloadPct")
+            # ❌ no GPU snapshot = the model never became resident (OOM / load failure);
+            # ✅ fully on GPU; ⚠️ partial = CPU spill.
+            if not gpu or offload is None:
+                fit = "OOM"
+            elif offload >= 100:
+                fit = "FIT"
+            else:
+                fit = "SPILL"
+            per_die = ",".join(str(g.get("usedMib", 0)) for g in (gpu.get("perDie") or [])) or "-"
+            op = (r.get("check") or {}).get("overall_pass")
+            verdict = "PASS" if op else "FAIL"
+            row = {
+                "fit": fit,
+                "verdict": verdict,
+                "tps": r.get("eval_tps", 0),
+                "secs": r.get("total_duration_s", 0),
+                "vram_g": round(gpu.get("totalMib", 0) / 1024, 1) if gpu else 0,
+                "dies": gpu.get("activeDies", 0) if gpu else 0,
+                "offload": offload if offload is not None else 0,
+                "per_die": per_die,
+            }
+            fitmap.setdefault(model, {})[(ctx, nb)] = row
+            tsv_rows.append(f"fitmap\t{model}\t{ctx_label(ctx)}\t{nb}\t{fit}\t{verdict}\t"
+                            f"{row['tps']}\t{row['secs']}\t{row['vram_g']}\t{row['dies']}\t{row['offload']}\t{per_die}")
+
     with open(tsv_out, "w") as f:
         f.write("\n".join(tsv_rows) + "\n")
 
@@ -98,6 +135,21 @@ def main():
                 lines.append(f"| `{model}` | {test} | {ctx_label(ctx)} | {mark} | "
                              f"{r['ptok']} | {r['secs']} | {r['tps']} | {r['calls']} |")
         lines.append("")
+
+    if fitmap:
+        lines.append("## Fit map (`num_batch` x context, STORY-022)\n")
+        lines.append("Fit: ✅ fully on GPU · ⚠️ CPU spill · ❌ OOM (never resident). "
+                     "Numbers are decode tok/s · total_s · total VRAM · active dies · offload%.\n")
+        mark = {"FIT": "✅", "SPILL": "⚠️", "OOM": "❌"}
+        for model in sorted(fitmap):
+            lines.append(f"### `{model}`\n")
+            lines.append("| ctx | num_batch | fit | verdict | tok/s | total_s | VRAM (G) | dies | offload% | per-die used (MiB) |")
+            lines.append("|---|--:|:--:|:--:|--:|--:|--:|:--:|--:|---|")
+            for (ctx, nb) in sorted(fitmap[model], key=lambda k: (int(k[0]), -int(k[1]))):
+                r = fitmap[model][(ctx, nb)]
+                lines.append(f"| {ctx_label(ctx)} | {nb} | {mark.get(r['fit'], r['fit'])} | {r['verdict']} | "
+                             f"{r['tps']} | {r['secs']} | {r['vram_g']} | {r['dies']} | {r['offload']}% | {r['per_die']} |")
+            lines.append("")
 
     with open(md_out, "w") as f:
         f.write("\n".join(lines) + "\n")

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -20,6 +20,7 @@ import { CONFIG, pickEnv } from './config.js';
 import { runThroughput } from './perf/throughput.js';
 import { runContext } from './perf/context.js';
 import { runMcpTest } from './mcp/test-mcp.js';
+import { modelBounds } from './perf/model-bounds.js';
 
 const program = new Command();
 
@@ -346,6 +347,31 @@ program
     });
     await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));
     process.exit(code);
+  });
+
+/**
+ * model-bounds — resolve a model's native context + tool capability for the fit-map sweep.
+ *
+ * Prints ONE line to stdout: `<nativeCtx> <tools 0|1> <arch>` — so the sweep can
+ *   read NATIVE_CTX TOOLS ARCH <<< "$(cli.ts model-bounds "$M")"
+ * to bound its context ladder and pick the judge. All diagnostics go to stderr.
+ */
+program
+  .command('model-bounds')
+  .description("Resolve a model's native context length + tool support from /api/show")
+  .argument('<model>', 'Model name to inspect')
+  .option('-H, --host <url>', 'Ollama host', process.env.OLLAMA_HOST || 'http://localhost:11434')
+  .action(async (model: string, options) => {
+    try {
+      const b = await modelBounds(options.host, model);
+      process.stderr.write(`${model}: native_ctx=${b.nativeCtx} tools=${b.tools} arch=${b.arch}\n`);
+      process.stdout.write(`${b.nativeCtx} ${b.tools ? 1 : 0} ${b.arch}\n`);
+      process.exit(0);
+    } catch (e) {
+      process.stderr.write(`model-bounds ${model}: ${e instanceof Error ? e.message : e}\n`);
+      process.stdout.write('0 0 \n');
+      process.exit(1);
+    }
   });
 
 program.parse();

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -16,6 +16,7 @@ import http from 'node:http';
 import https from 'node:https';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { gpuInfo, gpuOffload, type GpuRow } from '../perf/gpu.js';
 
 /** How to spawn the stdio MCP server. testlink-mcp is just one such config. */
 export interface McpServerConfig {
@@ -83,6 +84,9 @@ export interface McpTrajectory {
   totalDurationS: number;
   evalTps: number;
   error?: string;
+  /** Per-die VRAM + offload %, snapshotted once the model is resident (STORY-022).
+   *  Captured inside the host, before any judge — so it survives a failed verdict. */
+  gpu?: { perDie: GpuRow[]; totalMib: number; activeDies: number; offloadPct: number };
 }
 
 /** MCP tool {name, description?, inputSchema} → Ollama tools[] entry (near 1:1). */
@@ -259,6 +263,19 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
       evalDurNs += raw.eval_duration ?? 0;
       traj.totalDurationS = round2(totalDurNs / 1e9);
       traj.evalTps = tps(traj.outTokens, evalDurNs);
+
+      // Snapshot per-die VRAM + offload once, now that the first round has loaded
+      // the model. Fit is reservation-driven (stable while resident), so one
+      // snapshot suffices; a die holding only the ~93 MiB CUDA ghost is not "active".
+      if (!traj.gpu) {
+        const perDie = await gpuInfo();
+        traj.gpu = {
+          perDie,
+          totalMib: perDie.reduce((s, g) => s + g.usedMib, 0),
+          activeDies: perDie.filter((g) => g.usedMib > 200).length,
+          offloadPct: await gpuOffload(opts.host, opts.model),
+        };
+      }
 
       const msg = raw.message;
       const toolCalls: any[] = msg?.tool_calls ?? [];

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -267,14 +267,21 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
       // Snapshot per-die VRAM + offload once, now that the first round has loaded
       // the model. Fit is reservation-driven (stable while resident), so one
       // snapshot suffices; a die holding only the ~93 MiB CUDA ghost is not "active".
+      // Best-effort telemetry — a GPU-probe failure must NOT fail the tool-call
+      // verdict (the outer catch would turn a passing round into an error), so
+      // swallow it and leave traj.gpu undefined.
       if (!traj.gpu) {
-        const perDie = await gpuInfo();
-        traj.gpu = {
-          perDie,
-          totalMib: perDie.reduce((s, g) => s + g.usedMib, 0),
-          activeDies: perDie.filter((g) => g.usedMib > 200).length,
-          offloadPct: await gpuOffload(opts.host, opts.model),
-        };
+        try {
+          const perDie = await gpuInfo();
+          traj.gpu = {
+            perDie,
+            totalMib: perDie.reduce((s, g) => s + g.usedMib, 0),
+            activeDies: perDie.filter((g) => g.usedMib > 200).length,
+            offloadPct: await gpuOffload(opts.host, opts.model),
+          };
+        } catch (e) {
+          process.stderr.write(`  [warn] GPU snapshot failed (telemetry only): ${e instanceof Error ? e.message : e}\n`);
+        }
       }
 
       const msg = raw.message;

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -65,6 +65,8 @@ interface McpModelResult {
   max_prompt_tokens: number;
   total_duration_s: number;
   eval_tps: number;
+  /** Per-die VRAM + offload % (STORY-022); undefined if the model never loaded. */
+  gpu?: McpTrajectory['gpu'];
   check: { overall_pass: boolean; simple: McpSimpleVerdict; agent: Judgment | null };
 }
 
@@ -136,6 +138,7 @@ export async function runMcpTest(opts: McpTestOptions): Promise<number> {
       max_prompt_tokens: traj.maxPromptTokens,
       total_duration_s: traj.totalDurationS,
       eval_tps: traj.evalTps,
+      gpu: traj.gpu,
       check: { overall_pass: simple.pass, simple, agent: null },
     });
     process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass} · ${traj.outTokens} tok @ ${traj.evalTps} tok/s in ${traj.totalDurationS}s\n`);
@@ -267,8 +270,8 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
   out.push('');
 
   // Scannable table — judge stages + cross-check, no raw JSON in the cells.
-  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Peak in/ctx | Out tok | tok/s |');
-  out.push('|---|---|---|---|---|--:|--:|--:|--:|');
+  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Peak in/ctx | Out tok | tok/s | VRAM/dies@GPU% |');
+  out.push('|---|---|---|---|---|--:|--:|--:|--:|--:|');
   for (const r of results) {
     const verdict = r.check.overall_pass ? '✅ PASS' : r.supported ? '❌ FAIL' : '⚪ NO TOOL SUPPORT';
     const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
@@ -276,7 +279,8 @@ function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
     const stages = s ? `${tick(s.tool)} · ${tick(s.query)} · ${tick(s.content)}` : '—';
     const cc = r.check.agent?.crossCheckUnsupported;
     const cross = cc === undefined ? '—' : cc.length ? `❌ ${cc.join(', ').slice(0, 60)}` : '✅ grounded';
-    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${peakCtx(r.max_prompt_tokens, opts.numCtx)} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} |`);
+    const g = r.gpu ? `${(r.gpu.totalMib / 1024).toFixed(1)}G/${r.gpu.activeDies}d@${r.gpu.offloadPct}%` : '—';
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${peakCtx(r.max_prompt_tokens, opts.numCtx)} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} | ${g} |`);
   }
 
   // Per-model detail (reasoning + raw evidence) tucked behind a toggle — proof without the clutter.

--- a/cicd/tests/src/perf/model-bounds.ts
+++ b/cicd/tests/src/perf/model-bounds.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve a model's native context length + tool capability (STORY-022 #446).
+ *
+ * The fit-map sweep must not exceed a model's trained context (a longer window is
+ * context-shifted, not a real measurement) and must pick a judge the model can satisfy
+ * (a no-tools model can't drive an MCP tool call). Both facts come from `/api/show` —
+ * the JSON `ollama show` reads — so the sweep bounds itself with no per-model setup.
+ */
+export interface ModelBounds {
+  /** Trained context length from `<arch>.context_length`; 0 if the blob doesn't declare it. */
+  nativeCtx: number;
+  /** Model advertises the "tools" capability (can drive an MCP tool call). */
+  tools: boolean;
+  /** general.architecture, for the report. */
+  arch: string;
+}
+
+export async function modelBounds(host: string, model: string): Promise<ModelBounds> {
+  const res = await fetch(`${host}/api/show`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: model }),
+  });
+  if (!res.ok) throw new Error(`/api/show ${model}: HTTP ${res.status}`);
+  const data: any = await res.json();
+  const info = data.model_info ?? {};
+  const arch = String(info['general.architecture'] ?? '');
+  const nativeCtx = Number(info[`${arch}.context_length`] ?? 0) || 0;
+  const tools = Array.isArray(data.capabilities) && data.capabilities.includes('tools');
+  return { nativeCtx, tools, arch };
+}

--- a/docs/stories/STORY-022.md
+++ b/docs/stories/STORY-022.md
@@ -1,0 +1,50 @@
+# STORY-022: Record any model's context × batch fit map on the K80
+
+## User Story
+
+As a K80 maintainer sizing a model,
+I want a repeatable way to record any model's fit map across context length and batch size —
+throughput, correctness, and per-die VRAM together, in one run,
+So that I choose context/batch settings from measured data instead of hand-scraping metrics.
+
+## The Need
+
+Choosing the qwen35moe batch tiers (#440) required a full **context × batch** map for
+`qwen3.6:35b`: for each combination, whether it fits on GPU, how many dies it uses, its VRAM,
+its decode speed, its long-prompt (prefill) cost, and whether the answer is still correct.
+
+Producing that map was manual and awkward. The tool-call test reports throughput and a
+correctness verdict, but **per-die VRAM had to be scraped from an external monitoring dashboard**
+by hand-matching each run's timestamps. That's slow, error-prone, and not reusable — and the same
+map is needed to size other models and to explain why certain models (e.g. `qwen3.6:27b`,
+`qwen3-vl:30b`) spread onto an **extra die** and trip the GPU-count check.
+
+## Success Looks Like
+
+- A maintainer points the tooling at a model (or a few) and gets back a **committed table**: per
+  context × batch — the correctness verdict, decode tok/s, prefill/long-prompt cost, **per-die
+  VRAM, active-die count, and whether it is fully on GPU / spilling / OOM** — all from one run,
+  **no external dashboard**.
+- The measurement **bounds itself to each model's trained context** and picks a sensible
+  correctness check automatically, so running a new model needs **no per-model setup**.
+- A judge or infra hiccup **does not lose the fit data** — the VRAM/throughput numbers are
+  recorded regardless of the correctness verdict.
+- The `qwen3.6:35b` map **reproduces the hand-built one**
+  (`docs/reports/qwen35moe-num-batch-context-fit-2026-07-14.md`), and the `qwen3.6:27b` /
+  `qwen3-vl:30b` maps **reveal when and why** they use the extra die.
+
+## Open Questions
+
+- How per-die VRAM is captured inside the run, and which test vehicle carries it (the long-prompt
+  tool-call test vs the throughput bench) — decided on the issue.
+- Whether this **extends the existing report-sweep workflow or is a new one**.
+- Default correctness-check mode (lightweight structural check vs the live grounded verifier) and
+  how a model's tool-support is detected.
+- Which models make a standing list vs on-demand, and the default context/batch grid.
+- **K80 no-harm:** it must not change the behavior of the existing test suites.
+
+## Status
+
+- Created: 2026-07-15
+- Plan: #444
+- Issues: #445, #446, #447


### PR DESCRIPTION
## Summary
A reusable CI capability to record any model's **num_batch × context fit map** on the K80 — per cell: fit (✅ on GPU / ⚠️ CPU spill / ❌ not resident), decode tok/s, prefill/total_s, **per-die VRAM, active dies, offload %** — from one run, **no external Grafana dashboard**.

- **#445** — `runMcpHost` snapshots per-die VRAM (`gpuInfo`) + offload % (`gpuOffload`) once the model is resident, reusing `perf/gpu.ts`. Captured **before any judge and best-effort** (a GPU-probe failure can't fail the tool-call verdict), so fit data survives a bad verdict *or* a telemetry glitch.
- **#446** — `modelBounds()` + a `model-bounds` CLI resolve native context (`<arch>.context_length`) + tool support from `/api/show`, so the sweep bounds its ctx ladder to the trained window and picks the vehicle with no per-model setup.
- **#447** — an **opt-in** `MCP fit-map sweep` step in `test-report-sweep.yml` loops model × num_batch × bounded-ctx (one `test-mcp` cell each); `aggregate-sweep.py` emits the fit-map table matching `docs/reports/qwen35moe-num-batch-context-fit-2026-07-14.md`. `suite=none` runs it standalone.

Fixes #445
Fixes #446
Fixes #447
Part of STORY-022

## Verified (local)
- Typecheck (`tsc --noEmit`), workflow YAML, and python all clean.
- Aggregator **reproduces the hand-built qwen35moe map** from synthetic cells: `128k@512 ⚠️93%/2.38`, `128k@128 ✅100%/8.45`, `256k@512 ❌`.
- `/code-review medium`: 1 HIGH (unguarded snapshot could flip a passing round to FAIL on the existing test-mcp path) + 1 MEDIUM (honest ❌ label) fixed; 1 LOW (unknown-native disables clip) documented.
- `reviewing-artifacts` on the skill + rule: 2 findings fixed (standalone-run `suite=none`, judge wording).

## Not yet verified — needs a real K80 sweep
The **"reproduces the hand map" / "reveals the 27b/30b extra die"** acceptance criteria are proven in logic against synthetic data but **not on hardware**. The first real sweep is the confirming use:
`gh workflow run test-report-sweep.yml --ref story-022-fit-map -f suite=none -f fit_map_models='qwen3.6:35b'`

## K80 no-harm
The fit-map is gated on `fit_map_models` (default empty); the default sweep is byte-for-byte unchanged. The only change to the existing MCP path is a best-effort, guarded VRAM snapshot.

## Test plan
- [ ] Run the fit-map sweep on `qwen3.6:35b` (sm37); confirm the emitted table matches the hand-built map.
- [ ] Run on `qwen3.6:27b` / `qwen3-vl:30b`; confirm per-die VRAM + active-die count surface the extra-die spread.
- [ ] Confirm a default sweep (no `fit_map_models`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)