### PR TITLE
qwen35: context-tiered num_batch clamp for the 27b on K80 (#452)

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -242,6 +242,28 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		}
 	}
 
+	// qwen35 (dense GatedDeltaNet — the 27b/9b siblings of qwen35moe) has the same
+	// FA-off score-buffer spill, but this arch spans two sizes: the 27b spills at long
+	// context while the 9b fits at the default batch. The 27b's larger attention (64
+	// blocks / 24 heads vs the 9b's 32 / 16) is what overruns VRAM, so gate the clamp to
+	// the 27b-class by block count — the 9b keeps its default batch (no-harm anchor, #452).
+	// Thresholds measured on the K80 (run 29413759899, qwen3.6:27b fit-map):
+	//   ≤64k → 512 · ≤128k → 256 · >128k → 128. Recovers the 96k/128k CPU spill; 192k+
+	//   still spills at every batch (a separate KV-quant/FA question, out of scope here).
+	// Only ever lowers the batch: a smaller explicit num_batch is kept as-is.
+	if architecture == "qwen35" && f.KV().BlockCount() >= 48 {
+		maxBatch := 512
+		if opts.NumCtx > 65536 { // >64k: 512 spills (96k@512 = 91% GPU)
+			maxBatch = 256
+		}
+		if opts.NumCtx > 131072 { // >128k: 256 spills (192k@256 = 78%); 128 is the least-bad
+			maxBatch = 128
+		}
+		if opts.NumBatch > maxBatch {
+			opts.NumBatch = maxBatch
+		}
+	}
+
 	slog.Debug("using batch size for model",
 		"architecture", architecture,
 		"n_batch", opts.NumBatch,


### PR DESCRIPTION
## Summary
Extends the qwen35moe long-context batch clamp to arch `qwen35` (the dense GatedDeltaNet 27b), gated to the 27b-class by `BlockCount() >= 48` so the 9b — which fits at the default batch — is untouched. Recovers the 27b's 96k/128k CPU spill to 100% GPU.

- Server-side clamp in `llm/server.go`: `qwen35` + `BlockCount≥48` → `>64k→256`, `>128k→128` (thresholds from the K80 fit-map, run 29413759899). Only ever lowers the batch.
- Mirrors the shipped `qwen35moe` clamp; the 9b (32 blocks) never matches the gate.

Fixes #452

## Verified on hardware
Fresh build of this branch → applied → swept (build 29465520920 · apply 29466676200 · sweep 29466751889, sm37):

| model | ctx | before (nb=512) | after (clamp) |
|--|--|--|--|
| qwen3.6:27b | 96k | ⚠️ 91% spill, 43.1G | ✅ **100% GPU**, 36.7G |
| qwen3.6:27b | 128k | ⚠️ 77% spill, 43.4G | ✅ **100% GPU**, 42.0G |
| qwen3.5:9b | 96k/128k | ✅ 100%, 17.2/20.5G | ✅ **unmoved** (gated out) |

The 27b's post-clamp VRAM matches the `nb=256` fit-map cells exactly → the server clamped 512→256, as designed.

## Why the gate + why 256k is out of scope (traced)
`model/models/qwen35/model.go:inferRecurrentLayers` + GGUF: the 27b has **16 full-attn layers × 24 heads** (score-buffer weight 384) vs the 35b's 10×16 (160) and the 9b's 8×16 (128). The 27b materializes ~2.4× the 35b's `Q·Kᵀ` buffer despite being smaller — so batch-halving recovers ≤128k but **cannot reach 256k** (256k@128 = 78% spill). 256k-on-GPU for 27b needs KV-quant/FA — a separate follow-up.

## Test plan
- [x] 27b @96k/128k → 100% GPU on the fresh build (done, above)
- [x] 9b unmoved (no-harm); 35b `qwen35moe` untouched (separate arch/block)
- [ ] Reviewer confirms the diff is the surgical mirror it claims to be

🤖 Generated with [Claude Code](https://claude.com/claude-code)