### PR TITLE
qwen35 (9b): auto-clamp num_batch at 256k + fold clamp into one helper (#455)

### DIFF
--- a/docs/reports/qwen35-dense-num-batch-context-fit-2026-07-16.md
+++ b/docs/reports/qwen35-dense-num-batch-context-fit-2026-07-16.md
@@ -1,0 +1,75 @@
+# qwen35 (dense) num_batch × context fit map — K80 (2026-07-16)
+
+Measurement backing the `num_batch` clamp for the **dense** `qwen35` arch — the 27b (#452)
+and 9b (#455) siblings of `qwen35moe` (#440). Establishes, per context length, the largest
+`num_batch` that keeps each model **100% on GPU** on the K80.
+
+## Setup
+
+- **Models:** `qwen3.6:27b` / `qwen3.5:27b` (arch `qwen35`, 27.8B, Q4_K_M ~17.4 GB, 64 blocks)
+  and `qwen3.5:9b` (arch `qwen35`, 9.7B, ~6.6 GB, 32 blocks). GatedDeltaNet hybrid: full
+  attention every 4th layer (`full_attention_interval=4`), the rest recurrent (fixed-state).
+- **Rig:** `sm37` = 4× Tesla K80 dies, 11441 MiB each (~44.7 GB aggregate). FA off (sm_37 < Volta), f16 KV.
+- **Vehicle:** throughput bench (short prompt) + fit-map (MCP) for the num_batch grid — per-die
+  VRAM + offload% via `perf/gpu.ts`, no external dashboard (STORY-022).
+- **Mechanism:** with FA off, each full-attention layer materializes a `Q·Kᵀ` score buffer sized
+  `n_ctx × n_batch × n_head × 4B`, reserved worst-case at load — it grows with both context and
+  batch and drives the spill/OOM. The recurrent layers carry fixed-size state (context-independent).
+
+## Full-attention structure (the spill driver)
+
+`model/models/qwen35/model.go:inferRecurrentLayers` + GGUF `full_attention_interval`:
+
+| Model | blocks | full-attn layers | Q heads | score-buffer weight (layers × heads) |
+|--|--|--|--|--|
+| qwen3.6:35b (`qwen35moe`) | 40 | 10 | 16 | 160 |
+| **qwen3.6:27b** (`qwen35`) | 64 | **16** | **24** | **384** ← 2.4× the 35b |
+| qwen3.5:9b (`qwen35`) | 32 | 8 | 16 | 128 |
+
+The 27b materializes ~2.4× the 35b's score buffer per token **despite being the smaller model** —
+which is why it spills far earlier and why batch-halving can't reach 256k for it.
+
+## Fit maps (fit · per-die VRAM · dies · tok/s)
+
+### qwen3.6:27b — full grid (run 29413759899)
+
+| ctx | nb=512 | nb=256 | nb=128 |
+|--|--|--|--|
+| 8k | ✂️ SAT¹ 25.4G/3d | ✂️ SAT¹ | ✂️ SAT¹ |
+| 64k | ✅ 34.7G/4d | ✅ 29.6G/3d | ✅ 27.1G/3d |
+| 96k | ⚠️ 91% 43.1G/4d | ✅ 36.7G/4d | ✅ 30.3G/3d |
+| 128k | ⚠️ 77% 43.4G/4d | ✅ 42.0G/4d | ✅ 35.7G/4d |
+| 192k | ❌ OOM | ⚠️ 78% 42.6G/4d | ⚠️ 94% 41.8G/4d |
+| 256k | ❌ OOM | ⚠️ 64% 42.3G/4d | ⚠️ 78% 41.6G/4d |
+
+¹ 8k prompt ≈ the 8k window → KV saturation; VRAM valid, tok/s invalid (STORY-022 #449).
+
+### qwen3.5:9b — high context (runs 29416450389, 29467635730, 29468072044)
+
+| ctx | nb=512 | nb=256 | nb=128 |
+|--|--|--|--|
+| 128k | ✅ 20.5G/2d, 8.2 t/s | — | — |
+| 192k | ✅ 41.5G/4d, 8.5 t/s | — | — |
+| 256k | ❌ 0% (CPU fallback), 0.32 t/s | ✅ 30.4G/3d, 4.9 t/s | ✅ 21.0G/2d, 5.4 t/s |
+
+## Solution — context-tiered clamp per size (`llm/server.go`)
+
+`num_batch` capped to the largest that stays 100% on GPU, gated by arch + `BlockCount`:
+
+| Class | Gate | Tiers |
+|--|--|--|
+| 35b | `qwen35moe` | ≤96k→512 · ≤192k→256 · >192k→128 |
+| 27b | `qwen35` & `BlockCount≥48` | ≤64k→512 · ≤128k→256 · >128k→128 |
+| 9b | `qwen35` & `BlockCount<48` | ≤192k→512 · >192k→256 |
+
+## Findings
+
+1. **27b — recovered ≤128k, 256k out of reach by batch.** The clamp pulls 96k/128k from CPU
+   spill to 100% GPU (verified, run 29466751889). 256k spills at every batch (78% even at nb=128) —
+   the 2.4× score buffer needs KV-quant/FA, not batch. Out of scope.
+2. **9b — fits 256k at nb≤256.** Fits at the default 512 through 192k; only 256k@512 overflows to
+   CPU. `nb=256` restores 100% GPU (30.4 G / 3 dies); `nb=128` is roomier still (21.0 G / 2 dies).
+3. **Not a bug.** The `fs/ggml/ggml.go` estimate bounds the recurrent layers to fixed state
+   correctly; the 256k@512 fallback is the real score buffer overflowing, and it is batch-fixable.
+4. **Size-specific thresholds.** The 27b spills at 96k, the 9b only at 256k — same arch, different
+   boundaries — so a single threshold set can't serve both; `BlockCount` splits them.

--- a/llm/server.go
+++ b/llm/server.go
@@ -217,24 +217,23 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	// Cap at context length (can't batch more tokens than context window)
 	opts.NumBatch = min(opts.NumBatch, opts.NumCtx)
 
-	// qwen35moe on the K80: with flash attention hard-off (sm_37 < Volta), each
-	// full-attention layer materializes a Q·Kᵀ score buffer sized
-	// n_ctx × n_batch × n_head, reserved at load — it grows with both context and
-	// batch and overflows VRAM at long context (128k spills to CPU, 256k OOMs at
-	// the default nBatch=512). Cap num_batch to the largest that stays 100% on GPU
-	// at this context, measured on the 4× K80 reference rig
-	// (#440, docs/reports/qwen35moe-num-batch-context-fit-2026-07-14.md):
-	//   ≤96k → 512 · ≤192k → 256 · >192k → 128  (~15% prefill per step; decode ~flat).
-	// This can't live in modelFamilyBatchDefaults: DefaultOptions() pre-fills
-	// NumBatch=512, so getModelBatchParams' "NumBatch == 0" family path never runs.
-	// Only ever lowers the batch: a smaller explicit num_batch is kept as-is; a
-	// larger one (incl. the 512 default) is capped to what fits at this context.
-	if architecture == "qwen35moe" {
+	// qwen35 / qwen35moe on the K80: with flash attention hard-off (sm_37 < Volta), each
+	// full-attention layer materializes a Q·Kᵀ score buffer sized n_ctx × n_batch × n_head,
+	// reserved at load — it grows with both context and batch and overflows VRAM at long
+	// context (CPU spill, then OOM, at the default nBatch=512). Cap num_batch to the largest
+	// that stays 100% on GPU at this context, per the measured K80 fit maps. This can't live
+	// in modelFamilyBatchDefaults: DefaultOptions() pre-fills NumBatch=512, so its
+	// "NumBatch == 0" family path never runs.
+	//
+	// clampBatch only ever LOWERS the batch: 512 by default, 256 above hi256, 128 above hi128
+	// (hi128 == 0 disables the 128 tier). A smaller explicit num_batch is kept as-is. Lowering
+	// the batch trims prefill (~15% per step) but leaves decode ~flat — a good trade to stay on GPU.
+	clampBatch := func(hi256, hi128 int) {
 		maxBatch := 512
-		if opts.NumCtx > 98304 { // >96k: 512 spills
+		if opts.NumCtx > hi256 {
 			maxBatch = 256
 		}
-		if opts.NumCtx > 196608 { // >192k: 256 spills, 128 still fits (256k)
+		if hi128 > 0 && opts.NumCtx > hi128 {
 			maxBatch = 128
 		}
 		if opts.NumBatch > maxBatch {
@@ -242,26 +241,18 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		}
 	}
 
-	// qwen35 (dense GatedDeltaNet — the 27b/9b siblings of qwen35moe) has the same
-	// FA-off score-buffer spill, but this arch spans two sizes: the 27b spills at long
-	// context while the 9b fits at the default batch. The 27b's larger attention (64
-	// blocks / 24 heads vs the 9b's 32 / 16) is what overruns VRAM, so gate the clamp to
-	// the 27b-class by block count — the 9b keeps its default batch (no-harm anchor, #452).
-	// Thresholds measured on the K80 (run 29413759899, qwen3.6:27b fit-map):
-	//   ≤64k → 512 · ≤128k → 256 · >128k → 128. Recovers the 96k/128k CPU spill; 192k+
-	//   still spills at every batch (a separate KV-quant/FA question, out of scope here).
-	// Only ever lowers the batch: a smaller explicit num_batch is kept as-is.
-	if architecture == "qwen35" && f.KV().BlockCount() >= 48 {
-		maxBatch := 512
-		if opts.NumCtx > 65536 { // >64k: 512 spills (96k@512 = 91% GPU)
-			maxBatch = 256
-		}
-		if opts.NumCtx > 131072 { // >128k: 256 spills (192k@256 = 78%); 128 is the least-bad
-			maxBatch = 128
-		}
-		if opts.NumBatch > maxBatch {
-			opts.NumBatch = maxBatch
-		}
+	// The score buffer scales with the full-attention layer count × heads, which grows with
+	// model size — so each family/size gets its own tiers, all from the measured fit maps
+	// (docs/reports/qwen35*-num-batch-context-fit-*.md). BlockCount splits the dense qwen35:
+	// the 27b (64 blocks, 16 full-attn × 24 heads) spills far earlier than the 9b (32 blocks,
+	// 8 full-attn × 16 heads), which only overflows at 256k.
+	switch {
+	case architecture == "qwen35moe": // 35b (#440)
+		clampBatch(98304, 196608) // ≤96k→512 · ≤192k→256 · >192k→128
+	case architecture == "qwen35" && f.KV().BlockCount() >= 48: // 27b (#452, run 29413759899)
+		clampBatch(65536, 131072) // ≤64k→512 · ≤128k→256 · >128k→128
+	case architecture == "qwen35" && f.KV().BlockCount() < 48: // 9b (#455, runs 29467635730/29468072044)
+		clampBatch(196608, 0) // ≤192k→512 · >192k→256 (256k fits at 256; native max, no 128 tier)
 	}
 
 	slog.Debug("using batch size for model",


### PR DESCRIPTION
## Summary
Extends the qwen35 batch clamp (#452) with a **9b tier** and refactors the three clamp blocks into one `clampBatch` helper.

- **9b tier:** `arch=="qwen35" && BlockCount()<48` → `>192k → 256`. The 9b fits at the default 512 through 192k but overflows to CPU at 256k@512; `nb=256` restores 100% GPU.
- **Refactor:** `clampBatch(hi256, hi128)` — the 35b (`98304,196608`) and 27b (`65536,131072`) thresholds pass through **unchanged** (no-harm by construction); addresses the duplication code-review flagged on #452.
- **Report:** `docs/reports/qwen35-dense-num-batch-context-fit-2026-07-16.md` documents the 27b + 9b fit maps.

Fixes #455

## Evidence (every threshold from a measured run)
| qwen3.5:9b @256k | nb=512 | nb=256 | nb=128 |
|--|--|--|--|
| offload | ❌ 0% (CPU) | ✅ 100% | ✅ 100% |
| VRAM/dies | — | 30.4G/3d | 21.0G/2d |
| tok/s | 0.32 | 4.92 | 5.38 |

(runs 29467635730 · 29468072044; 9b @≤192k fits at 512 — run 29467635730)

## Not a bug (traced)
`fs/ggml/ggml.go` estimates the 24 DeltaNet layers as fixed-state (correct); the 256k@512 fallback is the real `Q·Kᵀ` score buffer overflowing, and it's batch-fixable.

## Test plan
- [ ] Fresh build compiles (the refactor touches the shipped 35b/27b clamp).
- [ ] `qwen3.5:9b` @256k → 100% GPU (clamp sets 256); @≤192k unmoved (512).
- [ ] `qwen3.6:27b` (≥48) and `qwen3.6:35b` (`qwen35moe`) clamps unchanged in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)