### PR TITLE
gptoss: clamp num_batch so gpt-oss:20b loads 100% on GPU at long ctx (#453)

### DIFF
--- a/docs/reports/gptoss-num-batch-context-fit-2026-07-16.md
+++ b/docs/reports/gptoss-num-batch-context-fit-2026-07-16.md
@@ -1,0 +1,47 @@
+# gpt-oss:20b num_batch × context fit map — K80 (2026-07-16)
+
+Measurement backing the `num_batch` clamp for arch `gptoss` (#453).
+
+## Setup
+
+- **Model:** `gpt-oss:20b` — arch `gptoss`, 20.9B MoE (32 experts), **MXFP4 ~13.8 GB**, 24 blocks,
+  heads 64 / KV 8 (GQA), key_length 64, sliding_window 128, **native ctx 131072 (128k)**.
+- **Rig:** `sm37` = 4× Tesla K80 dies, 11441 MiB each (~44.7 GB aggregate). FA off (sm_37 < Volta), f16 KV.
+- **Mechanism:** with FA off, the full-attention (odd) layers materialize a `Q·Kᵀ` score buffer reserved
+  at load — ~16 GiB at 128k/nb=512, which **exceeds a single 11.4 GiB die**, so nothing fits on GPU and
+  the model runs 0% on GPU (CPU, ~0.3 tok/s). `GraphSize` already bounds the SWA (even) layers' KV
+  correctly, so KV is small (~3 GiB); the score buffer, which scales with `num_batch`, is the driver —
+  making it clampable (unlike gemma4, which is KV-bound and FA-ceiling, #451 wontfix).
+
+## Fit map — offload% (direct loads; 100% = fully on GPU)
+
+| ctx | nb=512 | nb=256 | nb=128 |
+|--|--|--|--|
+| 32k | ✅ 100% | ✅ 100% | ✅ 100% |
+| 64k | ⚠️ 86% | ✅ 100% | ✅ 100% |
+| 96k | ❌ 0% | ✅ 100% | ✅ 100% |
+| 128k | ❌ 0% | ⚠️ 85% | ✅ 100% |
+
+## Clamp-selected cells — per-die VRAM + throughput (100% GPU)
+
+The clamp picks the largest `num_batch` that stays 100% on GPU at each context:
+
+| clamp cell | decode tok/s | prefill tok/s | per-die used (MiB) | dies / total |
+|--|--|--|--|--|
+| 32k @nb=512 | 14.93 | 45.1 | 10796, 10970, 7, 7 | 2 / 21.3 G |
+| 64k @nb=256 | 14.62 | 45.0 | 9091, 9211, 8685, 7 | 3 / 26.4 G |
+| 96k @nb=256 | 14.32 | 45.4 | 9892, 9890, 10356, 10531 | 4 / 39.7 G |
+| 128k @nb=128 | 14.68 | 44.9 | 9207, 9671, 9848, 7 | 3 / 28.1 G |
+
+## Solution — clamp (`llm/server.go`)
+
+`case "gptoss", "gpt-oss": clampBatch(32768, 98304)` → **≤32k→512 · ≤96k→256 · >96k→128**.
+
+## Findings
+
+1. **Spills earliest of the K80 families** — 512 fits only ≤32k (the 16 GiB score buffer vs 11.4 GiB dies).
+   But `nb=128` is 100% at every context including native 128k, so the clamp fully rescues it.
+2. **Clamping is free on decode** — decode is flat ~14.3–14.9 tok/s across the clamp; the only alternative
+   at high ctx is a CPU spill at ~0.3 tok/s (≈50× worse). So max-batch-at-100%-GPU costs ~nothing.
+3. **Margin-thinnest tier: 96k@256** — 4 dies near the ceiling (peak 10.5 / 11.4 G). Measured 100% and
+   stable (score buffer fixed at load, KV bounded by ctx), but the tightest cell in the map.

--- a/llm/server.go
+++ b/llm/server.go
@@ -243,9 +243,10 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 
 	// The score buffer scales with the full-attention layer count × heads, which grows with
 	// model size — so each family/size gets its own tiers, all from the measured fit maps
-	// (docs/reports/qwen35*-num-batch-context-fit-*.md). BlockCount splits the dense qwen35:
-	// the 27b (64 blocks, 16 full-attn × 24 heads) spills far earlier than the 9b (32 blocks,
-	// 8 full-attn × 16 heads), which only overflows at 256k.
+	// (docs/reports/*-num-batch-context-fit-*.md). BlockCount splits the dense qwen35: the 27b
+	// (64 blocks, 16 full-attn × 24 heads) spills far earlier than the 9b (32 blocks, 8
+	// full-attn × 16 heads), which only overflows at 256k. gpt-oss's score buffer is huge
+	// relative to the 11.4 GiB K80 dies, so it spills the earliest of all (512 only fits ≤32k).
 	switch {
 	case architecture == "qwen35moe": // 35b (#440)
 		clampBatch(98304, 196608) // ≤96k→512 · ≤192k→256 · >192k→128
@@ -253,6 +254,8 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		clampBatch(65536, 131072) // ≤64k→512 · ≤128k→256 · >128k→128
 	case architecture == "qwen35" && f.KV().BlockCount() < 48: // 9b (#455, runs 29467635730/29468072044)
 		clampBatch(196608, 0) // ≤192k→512 · >192k→256 (256k fits at 256; native max, no 128 tier)
+	case architecture == "gptoss" || architecture == "gpt-oss": // gpt-oss:20b (#453, run 29476267134 + direct loads)
+		clampBatch(32768, 98304) // ≤32k→512 · ≤96k→256 · >96k→128 (native 128k)
 	}
 
 	slog.Debug("using batch size for model",


### PR DESCRIPTION
## Summary
Adds arch `gptoss` to the `num_batch` clamp so gpt-oss:20b runs 100% on GPU at long context on the K80, instead of spilling entirely to CPU.

- `case "gptoss", "gpt-oss": clampBatch(32768, 98304)` → **≤32k:512 · ≤96k:256 · >96k:128** (native max 128k).
- One case in the shared `clampBatch` helper; the qwen35 tiers are untouched.
- Report: `docs/reports/gptoss-num-batch-context-fit-2026-07-16.md`.

Fixes #453

## Why
gpt-oss:20b (arch gptoss, MoE, FA off) has a ~16 GiB score buffer at 128k that **exceeds a single 11.4 GiB K80 die**, so `nb=512` runs 0% on GPU (~0.3 tok/s). It's score-buffer-bound (KV only ~3 GiB) → clampable, the qwen35 pattern — unlike gemma4 (KV-bound + FA ceiling, #451 wontfix).

## Evidence (offload grid + clamp-cell perf)
| ctx | nb=512 | nb=256 | nb=128 |
|--|--|--|--|
| 32k | ✅100% | ✅ | ✅ |
| 64k | ⚠️86% | ✅100% | ✅ |
| 96k | ❌0% | ✅100% | ✅ |
| 128k | ❌0% | ⚠️85% | ✅100% |

Every clamp-selected cell is 100% GPU with **decode flat ~14.7 tok/s** (vs the ~0.3 tok/s CPU spill it replaces). Runs 29476267134 + direct loads.

## Verified on the fresh build (build 29478854984 → apply 29480243106, sm37)
- gpt-oss:20b @128k **default batch** → **0% → 100% GPU** (30.7 GB) — clamp fires server-side.
- qwen3.5:9b @128k → 100% unchanged — no-harm.

## Test plan
- [x] Compiles (build 4/4)
- [x] gpt-oss:20b @128k default-batch → 100% GPU on the fresh build
- [x] qwen35 tiers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)