### PR TITLE
Re-tune num_batch clamps to fewest-dies (K80 decode throughput)

### DIFF
--- a/docs/reports/num-batch-fewest-dies-retune-2026-07-17.md
+++ b/docs/reports/num-batch-fewest-dies-retune-2026-07-17.md
@@ -58,12 +58,12 @@ tie by measured tok/s (usually the larger batch — faster prefill). Take a larg
 |--|--|--|--|--|
 | 32k | ✅ 1d / 6.45 | ✅ 1d / 6.43 | ✅ 1d / 6.45 | **512** (min dies, largest) |
 | 64k | ✅ **2d** / 5.50 | ✅ **1d** / 6.45 | ✅ 1d / 6.46 | **256** (fewer dies & faster) |
-| 96k | ✅ 2d / 5.34 | ✅ 2d / 5.35 | ✅ 2d / 5.38 | **256** (die tie, monotonic) |
-| 128k | ✅ 2d | ✅ 2d / 5.32 | ✅ 2d / 5.38 | **256** (die tie, monotonic) |
-| 192k | 4d (old) | ✅ **2d** / 5.25 | ✅ 2d / 5.39 | **256** (fewer dies than 512) |
+| 96k | ✅ 2d / 5.34 | ✅ 2d / 5.35 | ✅ 2d / 5.38 | **256** (2d tie → prefill; Δ within noise) |
+| 128k | ✅ 2d | ✅ 2d / 5.32 | ✅ 2d / 5.38 | **256** (2d tie → prefill; Δ within noise) |
+| 192k | 4d (old) | ✅ 2d / 5.23 | ✅ **2d / 5.36** | **128** (faster at equal 2d, avg of 2 runs) |
 | 256k | ❌ | ✅ 3d / 5.10 | ✅ **2d** / 5.35 | **128** (fewer dies & faster) |
 
-→ `clampBatch(32768, 196608)` — ≤32k:512 · ≤192k:256 · >192k:128
+→ `clampBatch(32768, 131072)` — ≤32k:512 · ≤128k:256 · >128k:128
 
 ### gpt-oss:20b (`gptoss`, native 128k)
 | ctx | nb=512 | nb=256 | nb=128 | pick |
@@ -78,8 +78,10 @@ tie by measured tok/s (usually the larger batch — faster prefill). Take a larg
 ## Notes
 
 1. **The 9b VRAM pattern is non-linear** (1 die ≤64k, 2 dies to 192k, 3 at 256k@256), and `nb=512`
-   costs a die at 64k (2d vs 256's 1d) and 192k (4d vs 2d). The clamp uses the monotonic tier that
-   captures both die savings; at 96k/128k (all batches 2d) it holds 256 rather than break monotonicity.
+   costs a die at 64k (2d vs 256's 1d) and 192k (4d vs 2d). From 96k–192k all of 256/128 sit at
+   2 dies, so the pick is a pure decode-tiebreak: 128 measured ≥ 256 throughout and clearly faster
+   at 192k (5.36 vs 5.23, avg of runs 29484930437/29557518952), so the clamp drops to 128 by 192k;
+   96k/128k stay at 256, where the delta is within noise and the larger batch prefills faster.
 2. **The 35b @64k cell was re-measured** (29550110578) after an outlier (256=6.23) in the first pass;
    the clean value (256 = 3d / 7.06 vs 512 = 4d / 6.80) makes 256 the unambiguous pick — fewer dies
    *and* faster.

--- a/docs/reports/num-batch-fewest-dies-retune-2026-07-17.md
+++ b/docs/reports/num-batch-fewest-dies-retune-2026-07-17.md
@@ -1,0 +1,89 @@
+# num_batch clamp re-tune — fewest-dies criterion — K80 (2026-07-17)
+
+Supersedes the "largest-batch" tiers in `qwen35moe-num-batch-context-fit-2026-07-14.md`,
+`qwen35-dense-num-batch-context-fit-2026-07-16.md`, and `gptoss-num-batch-context-fit-2026-07-16.md`.
+Backs the re-tune in #458 (`llm/server.go` `clampBatch`).
+
+## The correction
+
+The earlier clamps capped `num_batch` to the **largest** batch that stays 100% on GPU, on the
+stated assumption that *decode is flat across batch*. Measured on the real MCP workload, that
+assumption is **false**.
+
+With flash attention hard-off on sm_37, each full-attention layer materializes a `Q·Kᵀ` score
+buffer sized `n_ctx × n_batch × n_head`, reserved at load. A **larger batch inflates that buffer**,
+which spreads the model across **more K80 dies**. The four dies talk over **PCIe**, so each extra
+die costs **decode tok/s** — and VRAM, the scarce resource on this rig (a MoE keeps all experts
+resident, so dies are what you run out of).
+
+**New criterion:** cap `num_batch` to the **fewest-die batch that stays 100% on GPU**. Break a die
+tie by measured tok/s (usually the larger batch — faster prefill). Take a larger, more-die batch
+**only where a real number shows it decodes faster**.
+
+## Setup
+
+- **Rig:** `sm37` = 4× Tesla K80 dies, 11441 MiB each (~44.7 GB aggregate). FA off (sm_37 < Volta), f16 KV.
+- **Vehicle:** MCP fit-map (`test-report-sweep.yml`, `suite=none`) — per-die VRAM + `activeDies` +
+  `eval_tps` per (model, ctx, batch) cell (STORY-022).
+- **Runs:** 29482994550 (gpt-oss 64k/96k), 29484930437 (35b/27b/9b `{256,128}`), 29530127306 (512
+  low-tier), 29550110578 (35b @64k re-measure), 29550117574 (9b @256k @128).
+
+## Measured — dies / decode tok-s per batch (✅ = 100% GPU)
+
+### qwen3.6:35b (`qwen35moe`)
+| ctx | nb=512 | nb=256 | nb=128 | pick |
+|--|--|--|--|--|
+| 32k | ✅ 3d / 6.98 | ✅ 3d / 6.83 | ✅ 3d / 5.64 | **512** (min dies, largest) |
+| 64k | ✅ 4d / 6.80 | ✅ **3d / 7.06** | ✅ 3d / 5.64 | **256** (fewer dies & faster) |
+| 96k | ✅ 4d / 6.47 | ✅ **3d / 6.93** | ✅ 3d / 5.67 | **256** (fewer dies & faster) |
+| 128k | ⚠️ | ✅ **4d / 6.33** | ✅ 3d / 5.65 | **256** (more-die, but 6.33 > 5.65 measured) |
+| 192k | ⚠️ | ✅ **4d / 6.62** | ✅ 4d / 5.58 | **256** (die tie → faster) |
+| 256k | ❌ | ✅ 4d / 5.54 | ✅ **4d / 5.65** | **128** (die tie → faster) |
+
+→ `clampBatch(32768, 196608)` — ≤32k:512 · ≤192k:256 · >192k:128
+
+### qwen3.6:27b (`qwen35`, BlockCount ≥ 48)
+| ctx | nb=512 | nb=256 | nb=128 | pick |
+|--|--|--|--|--|
+| 32k | ✅ 3d / 2.25 | ✅ 3d / 2.26 | ✅ 3d / 2.26 | **512** (min dies, largest) |
+| 64k | ✅ 4d / 2.15 | ✅ **3d / 2.24** | ✅ 3d / 2.26 | **256** (fewer dies) |
+| 96k | ⚠️/256 | ✅ 4d / 2.15 | ✅ **3d / 2.27** | **128** (fewer dies & faster) |
+| 128k | ⚠️ | ✅ 4d / 2.15 | ✅ **4d / 2.16** | **128** (die tie → faster) |
+| 192k / 256k | ❌ | ⚠️ spill | ⚠️ spill | out of scope (spills at every batch) |
+
+→ `clampBatch(32768, 65536)` — ≤32k:512 · ≤64k:256 · >64k:128
+
+### qwen3.5:9b (`qwen35`, BlockCount < 48)
+| ctx | nb=512 | nb=256 | nb=128 | pick |
+|--|--|--|--|--|
+| 32k | ✅ 1d / 6.45 | ✅ 1d / 6.43 | ✅ 1d / 6.45 | **512** (min dies, largest) |
+| 64k | ✅ **2d** / 5.50 | ✅ **1d** / 6.45 | ✅ 1d / 6.46 | **256** (fewer dies & faster) |
+| 96k | ✅ 2d / 5.34 | ✅ 2d / 5.35 | ✅ 2d / 5.38 | **256** (die tie, monotonic) |
+| 128k | ✅ 2d | ✅ 2d / 5.32 | ✅ 2d / 5.38 | **256** (die tie, monotonic) |
+| 192k | 4d (old) | ✅ **2d** / 5.25 | ✅ 2d / 5.39 | **256** (fewer dies than 512) |
+| 256k | ❌ | ✅ 3d / 5.10 | ✅ **2d** / 5.35 | **128** (fewer dies & faster) |
+
+→ `clampBatch(32768, 196608)` — ≤32k:512 · ≤192k:256 · >192k:128
+
+### gpt-oss:20b (`gptoss`, native 128k)
+| ctx | nb=512 | nb=256 | nb=128 | pick |
+|--|--|--|--|--|
+| 32k | ✅ 2d / — | ✅ 2d | ✅ 2d | **512** (2-die weight floor, largest) |
+| 64k | ⚠️ 86% | ✅ 3d / 8.14 | ✅ **2d / 8.72** | **128** (fewer dies & +7%) |
+| 96k | ❌ | ✅ 4d / 8.14 | ✅ **2d / 8.86** | **128** (fewer dies & +9%) |
+| 128k | ❌ | ⚠️ 85% | ✅ 3d | **128** (only 100%-GPU batch) |
+
+→ `clampBatch(32768, 32768)` — ≤32k:512 · >32k:128
+
+## Notes
+
+1. **The 9b VRAM pattern is non-linear** (1 die ≤64k, 2 dies to 192k, 3 at 256k@256), and `nb=512`
+   costs a die at 64k (2d vs 256's 1d) and 192k (4d vs 2d). The clamp uses the monotonic tier that
+   captures both die savings; at 96k/128k (all batches 2d) it holds 256 rather than break monotonicity.
+2. **The 35b @64k cell was re-measured** (29550110578) after an outlier (256=6.23) in the first pass;
+   the clean value (256 = 3d / 7.06 vs 512 = 4d / 6.80) makes 256 the unambiguous pick — fewer dies
+   *and* faster.
+3. **The 128k tier on the 35b is the one place a more-die batch wins** (256 = 4d / 6.33 beats
+   128 = 3d / 5.65) — allowed because a real number shows it decodes faster.
+4. **27b ≥192k stays out of scope** — its 2.4× score buffer spills at every batch; needs KV-quant/FA,
+   not num_batch (unchanged from #452).

--- a/llm/server.go
+++ b/llm/server.go
@@ -255,8 +255,8 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		clampBatch(32768, 196608) // ≤32k→512(3d) · ≤192k→256(3–4d) · >192k→128 — 64k/96k: 256 fewer dies & faster than 512
 	case architecture == "qwen35" && f.KV().BlockCount() >= 48: // 27b (#452; #458 re-tune, run 29484930437)
 		clampBatch(32768, 65536) // ≤32k→512(3d) · ≤64k→256(3d) · >64k→128 — 96k: 128=3d beats 256=4d
-	case architecture == "qwen35" && f.KV().BlockCount() < 48: // 9b (#455; #458 re-tune, runs 29484930437/29550117574)
-		clampBatch(32768, 196608) // ≤32k→512(1d) · ≤192k→256(1–2d) · >192k→128(2d) — 256/128 fewer dies than 512
+	case architecture == "qwen35" && f.KV().BlockCount() < 48: // 9b (#455; #458 re-tune, runs 29484930437/29550117574/29557518952)
+		clampBatch(32768, 131072) // ≤32k→512(1d) · ≤128k→256(1–2d) · >128k→128(2d) — 192k: 128 decodes faster at equal 2d (5.36 vs 5.23, 2 runs)
 	case architecture == "gptoss" || architecture == "gpt-oss": // gpt-oss:20b (#453; #458 fewest-dies re-tune, run 29482994550)
 		clampBatch(32768, 32768) // ≤32k→512 · >32k→128 — fewest dies: 128=2d beats 256=3–4d, +7–9% t/s @64k/96k
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -220,14 +220,17 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	// qwen35 / qwen35moe on the K80: with flash attention hard-off (sm_37 < Volta), each
 	// full-attention layer materializes a Q·Kᵀ score buffer sized n_ctx × n_batch × n_head,
 	// reserved at load — it grows with both context and batch and overflows VRAM at long
-	// context (CPU spill, then OOM, at the default nBatch=512). Cap num_batch to the largest
-	// that stays 100% on GPU at this context, per the measured K80 fit maps. This can't live
-	// in modelFamilyBatchDefaults: DefaultOptions() pre-fills NumBatch=512, so its
-	// "NumBatch == 0" family path never runs.
+	// context. A larger batch inflates that buffer, spreading the model across MORE K80 dies;
+	// the dies talk over PCIe, so extra dies cost decode tok/s — and VRAM, the scarce resource
+	// (a MoE keeps all experts resident). So cap num_batch to the FEWEST-die batch that still
+	// stays 100% on GPU at this context, per the measured fit maps (#458). A die tie goes to the
+	// higher measured tok/s (usually the larger batch, for faster prefill); a larger, more-die
+	// batch wins only where a real number shows it decodes faster. This can't live in
+	// modelFamilyBatchDefaults: DefaultOptions() pre-fills NumBatch=512, so its "NumBatch == 0"
+	// family path never runs.
 	//
 	// clampBatch only ever LOWERS the batch: 512 by default, 256 above hi256, 128 above hi128
-	// (hi128 == 0 disables the 128 tier). A smaller explicit num_batch is kept as-is. Lowering
-	// the batch trims prefill (~15% per step) but leaves decode ~flat — a good trade to stay on GPU.
+	// (hi128 == 0 disables the 128 tier). A smaller explicit num_batch is kept as-is.
 	clampBatch := func(hi256, hi128 int) {
 		maxBatch := 512
 		if opts.NumCtx > hi256 {
@@ -248,14 +251,14 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	// full-attn × 16 heads), which only overflows at 256k. gpt-oss's score buffer is huge
 	// relative to the 11.4 GiB K80 dies, so it spills the earliest of all (512 only fits ≤32k).
 	switch {
-	case architecture == "qwen35moe": // 35b (#440)
-		clampBatch(98304, 196608) // ≤96k→512 · ≤192k→256 · >192k→128
-	case architecture == "qwen35" && f.KV().BlockCount() >= 48: // 27b (#452, run 29413759899)
-		clampBatch(65536, 131072) // ≤64k→512 · ≤128k→256 · >128k→128
-	case architecture == "qwen35" && f.KV().BlockCount() < 48: // 9b (#455, runs 29467635730/29468072044)
-		clampBatch(196608, 0) // ≤192k→512 · >192k→256 (256k fits at 256; native max, no 128 tier)
-	case architecture == "gptoss" || architecture == "gpt-oss": // gpt-oss:20b (#453, run 29476267134 + direct loads)
-		clampBatch(32768, 98304) // ≤32k→512 · ≤96k→256 · >96k→128 (native 128k)
+	case architecture == "qwen35moe": // 35b (#440; #458 fewest-dies re-tune, runs 29484930437/29550110578)
+		clampBatch(32768, 196608) // ≤32k→512(3d) · ≤192k→256(3–4d) · >192k→128 — 64k/96k: 256 fewer dies & faster than 512
+	case architecture == "qwen35" && f.KV().BlockCount() >= 48: // 27b (#452; #458 re-tune, run 29484930437)
+		clampBatch(32768, 65536) // ≤32k→512(3d) · ≤64k→256(3d) · >64k→128 — 96k: 128=3d beats 256=4d
+	case architecture == "qwen35" && f.KV().BlockCount() < 48: // 9b (#455; #458 re-tune, runs 29484930437/29550117574)
+		clampBatch(32768, 196608) // ≤32k→512(1d) · ≤192k→256(1–2d) · >192k→128(2d) — 256/128 fewer dies than 512
+	case architecture == "gptoss" || architecture == "gpt-oss": // gpt-oss:20b (#453; #458 fewest-dies re-tune, run 29482994550)
+		clampBatch(32768, 32768) // ≤32k→512 · >32k→128 — fewest dies: 128=2d beats 256=3–4d, +7–9% t/s @64k/96k
 	}
 
 	slog.Debug("using batch size for model",


### PR DESCRIPTION
## Summary
- Re-tune the K80 `num_batch` clamps (#440/#442/#452/#455/#453) from **"largest batch that fits"** to **fewest dies at 100% GPU**. Measured on the real MCP workload: a larger batch inflates the FA-off `Q·Kᵀ` score buffer, spreads the model across more PCIe-connected K80 dies, and costs decode tok/s — and VRAM, the scarce resource (a MoE keeps all experts resident). Criterion: fewest-die batch that stays 100% GPU; break die ties by measured tok/s; take a larger, more-die batch only where a real number shows it decodes faster.
- New tiers (all measured, per model): `35b (32768,196608)` · `27b (32768,65536)` · `9b (32768,131072)` · `gpt-oss (32768,32768)`.
- Adds `docs/reports/num-batch-fewest-dies-retune-2026-07-17.md` — die count + MCP decode tok/s per (model, ctx, batch); supersedes the three "largest-batch" reports.

Fixes #458

## Verification (all on the K80 rig via CI)
- [x] **Clamp fires to the intended batch/die-count** on a fresh build (build 29558544472 → apply 29559622320): 35b→256/3d, 27b→128/3d @96k, 9b→256/1d @64k & 128/2d @192k, gpt-oss→128/2d @96k.
- [x] **Every clamped config 100% GPU** (no spill).
- [x] **35b / 27b / gpt-oss coherent** — verify-live PASS.
- [x] **Headline wins measured live:** gpt-oss @96k 4d→**2d** (+9% t/s); 35b @96k 4d→**3d**; 9b @192k 256→**128** (5.36 vs 5.23, 2 runs).
- [x] **K80 no-harm:** no cell that was 100% GPU became a spill. The 9b's verify-live tool-arg fumble reproduces **identically at the unclamped 512** (control 29560793757) — pre-existing #382 (typed-arg tool calls), **not** a num_batch regression (`num_batch` can't change decode output).
- [x] **code-review (medium):** found + fixed the 9b @192k tier (was 256, decode is faster at 128 at equal 2 dies — confirmed across 2 runs); report justification corrected.

Generated with [Claude Code](https://claude.com/claude-code)