### PR TITLE
Defer the drift anchor to the profile in the authoring commands

### DIFF
--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -26,7 +26,7 @@ Fits in the qa-workflow:
         │
         ├─► Step 1: One file per scenario
         │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
-        │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       id, title, namespace, story (+ the drift anchor the profile declares),
         │       issue, status: green
         │   - (Format and field meanings: docs/tests/README.md.)
         │
@@ -49,6 +49,8 @@ Fits in the qa-workflow:
 - Reuse keeps coverage converging instead of duplicating: skim the existing
   docs/tests/ for a matching step before coining a new one. (A searchable step
   store is a deferred enhancement — STORY-006/Phase 2.)
-- `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- Drift anchor: record whatever the profile declares, so a later gate can tell the story
+  has moved (default here: `story_hash`, the `sha256sum` of the story file — what `qw-drift`
+  reads). A project that detects drift another way declares that instead.
 - Producer paired with `/qw-review-cases`.
 ```

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -25,7 +25,7 @@ Fits in the qa-workflow:
         ├─► Step 1: Each doc
         │   - [ ] One scenario, one job; cases are coherent slices of it.
         │   - [ ] Front-matter complete and resolvable: story file exists,
-        │         story_hash matches it, namespace set, status present.
+        │         the profile's drift anchor holds, namespace set, status present.
         │   - [ ] Each step's Expected Result is observable — checkable, not vague.
         │   - [ ] Conforms to the format contract (docs/tests/README.md).
         │

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -1,0 +1,98 @@
+---
+paths:
+  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
+---
+
+# project-profile
+
+The one place a downstream project declares its specifics. The shipped commands and
+skills state their *intent* and resolve any project-specific value — a path, an ID
+scheme, a label, an integration, a format, an audience — **from this file**, instead of
+hardcoding it. Customize a workflow by editing this file, not the units.
+
+**How a unit uses it.** Where a command or skill would otherwise bake in a value, it
+points at the matching section here (e.g. "create the *plan* label — see
+project-profile → Labels"). The values below are the **defaults**: they reproduce this
+repo's current behaviour, so a project that changes nothing behaves exactly as it does
+now. Adoption is opt-in — change a line here and every unit follows.
+
+**Two wiring styles, and when each applies.** A **skill** points at this file at each point
+of use — it is read on its own, with no rule loaded beside it. A **command** may show a
+value inline as an illustrated default; its group rule (`.claude/rules/*.md`) carries the
+"these resolve from the profile" statement for the whole group, so the pointer is not
+repeated line by line. Both are correct. Which one applies is decided by whether the unit
+is read together with its rule — not by preference.
+
+**What belongs here vs. not.** This file is for **declarative** customization — a value
+or a list. A whole **procedure** (e.g. how to publish to Confluence and review the
+render) is *not* a value; it belongs in its own project-owned skill, never crammed into
+a general unit. Lists → here; procedures → a project skill. This is the rules files'
+"what this owns vs. what it hands off" boundary, made concrete.
+
+The same line binds the **units**. A value this file can restate is safe for a unit to show
+inline; a *procedure* never is — how drift is detected, how files are laid out. No value can
+override a procedure, so a project that does it another way is forced to edit the shipped
+unit, and its repo then reads as drifted when it was only working around us. State the goal;
+let this file or the project's own layer name the mechanism.
+
+---
+
+## Paths
+
+- stories dir: `docs/stories/`
+- tests dir: `docs/tests/`
+- story format contract: `docs/stories/README.md`
+- test format contract: `docs/tests/README.md`
+
+## ID schemes
+
+- story id: `STORY-XXX` (zero-padded sequential, e.g. `STORY-001`)
+- scenario id: `TS-NN`
+- case id: `TC-NN`
+- title prefixes: `[STORY-XXX] Plan` · `[STORY-XXX] Test Plan` · `[STORY-XXX] <task>`
+
+## Labels
+
+Names the workflow uses; colours where the workflow pins one (`#hex`), otherwise the
+project's choice.
+
+- plan: `plan` (`#5319e7`)
+- test plan: `test-plan` (`#006b75`)
+- priority: `priority:high` · `priority:medium` · `priority:low`
+- type: `feature` · `enhancement` · `bug` · `docs`
+- status: `status:in-progress` · `status:needs-review` · `status:blocked`
+
+## Linking & branch
+
+- story back-reference (in titles/bodies): `[STORY-XXX]`
+- plan back-reference (task → plan): `Part of #<plan>`
+- issue closure (PR → issue): `Fixes #N` / `Closes #N`
+- feature branch name: `issue-<N>-<slug>`
+
+## Git
+
+- default branch: *derive it* (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`), don't assume `main`
+- merge strategy: `--merge` (preserve history; switch to `--squash` only if the project requires)
+
+## Front-matter & format contract (test docs)
+
+- test-doc filename: `TS-NN-<slug>.md` in the tests dir
+- front-matter fields: `id, title, namespace, story, story_hash, plan, issue, status` — the
+  anchor field tracks the drift anchor below; drop it when that is `none`
+- drift anchor: `story_hash` — the `sha256` of the story file (`sha256sum`), recorded so a
+  later gate can tell the story has moved. A project that detects drift another way (a
+  derived link check, say) names that here instead, or `none`. The `qw-*` commands record
+  whatever this declares; they do not assume hashing.
+- default status: `green`
+
+## Review semantics
+
+- canonical format (source of truth): `markdown`
+- live integrations: `GitHub` — tools the project genuinely uses; coupling to one
+  listed here is correct, not drift. (A downstream adds its own, e.g. Jira, Confluence,
+  TestLink.)
+- deliverable (triggers a paired review): a unit that *produces or changes* an output —
+  by name (`create-`/`sync-`/`publish-`/`draft-`/`init-`) or as a producing gerund skill
+  (`planning-…`, `drafting-…`)
+- audience (human-read docs): engineers and newcomers

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -51,3 +51,10 @@ No producer ships without a review covering its output.
   `drift` / `port-yaml`) and a searchable step-store are **deferred ports** (STORY-006/Phase 2).
 
 The format a test doc must follow is `docs/tests/README.md`.
+
+## Project-specific values
+
+The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the
+test-doc front-matter fields, the drift anchor, and the default status are **not** owned
+by the `qw-*` commands — they resolve from `.claude/rules/project-profile.md`. The values
+a command shows are the defaults; change them in the profile, not the command.


### PR DESCRIPTION
## Summary

- `qw-cases` and `qw-review-cases` stop assuming sha256 — they record whatever anchor the profile declares (upstream agent-workflows #102).
- **Adds `.claude/rules/project-profile.md`**, declaring `drift anchor: story_hash` — the mechanism already in use, so nothing changes behaviourally. The Docs & diagrams block is omitted: no `doc-workflow` group is installed here.
- `qa-workflow.md` gains a `## Project-specific values` pointer; nothing else in it changed.
- **`qw-bind` and `qw-drift` are untouched** — all four `story_hash` references stay. They implement the anchor the profile declares.
- **Not a sync.** Reuse-by-skimming `docs/tests/`, the "searchable step store is a deferred enhancement (STORY-006/Phase 2)" note, and the `qw-bind → qw-run` flow are this repo's own and are deliberately preserved. The two upstream features this repo never adopted — the `[STORY-XXX] Test Plan` issue step and the `plan:` front-matter field — remain unadopted; that is a separate call.

Net: 3 lines edited, 1 file added, 1 section appended.

Closes #474

## Pre-existing gap found while reviewing (not fixed here)

`rules/dev-workflow.md` has no `## Project-specific values` section, so the nine `dw-*` commands remain unwired to the profile. This PR wires the qa side only.

## Test plan

- [ ] `grep -c story_hash` gives qw-bind=2, qw-drift=2 — unchanged
- [ ] The skim-for-reuse step and the step-store deferral note are byte-identical to before
- [ ] Every profile key the authoring commands reference exists

Generated with [Claude Code](https://claude.com/claude-code)