### PR TITLE
Sync the agent-report contract and the plan-close merge change

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -60,11 +60,10 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │   - Skip silently if no story link or docs/stories/ doesn't exist
         │
         └─► Step 6: Report
-            - Show the PR URL to the user
-            - Stop here — don't auto-advance. The PR now waits for a HUMAN to
-              review and test it. Merge with /dw-merge <PR> only once a human is
-              satisfied. (The change's substance was already gated locally by
-              /dw-review-implement before the PR.)
+            - Report per .claude/rules/agent-report.md; Trace carries the PR URL
+            - Next is the HUMAN review + test — stop here, don't auto-advance. Merge
+              with /dw-merge <PR> only once a human is satisfied. (The change's
+              substance was already gated locally by /dw-review-implement.)
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -111,6 +111,14 @@ history — start, failures, fixes, and resolution.
 
 ---
 
+## OUTPUT
+
+The implementation state, against what the issue asked for. Trace carries the branch,
+the issue, and the commits. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Uses `gh` CLI for issue operations

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -8,7 +8,9 @@ PR number: {{input}}
 ## PURPOSE
 
 Merges an approved PR, deletes the remote branch, cleans up local branches
-and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
+and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body;
+a plan issue never does — no PR targets one — so this command closes the
+story's plans when its last task lands.
 
 ---
 
@@ -40,11 +42,17 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Run: gh issue edit <N> --remove-label "status:needs-review"
         │   - Issue auto-closes via "Fixes #N" — no manual close needed
         │
-        ├─► Step 5: Update Story File (if linked)
+        ├─► Step 5: Close Out the Story (if linked)
         │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
         │     • Check off completed acceptance criteria for this task
         │     • If all story tasks are closed, mark story status as Completed
-        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │   - On that same condition — all story tasks closed — also close its plan
+        │     issues. No PR ever targets a plan, so nothing else will:
+        │       gh issue list --search "[STORY-XXX]" --label plan --state open
+        │       gh issue list --search "[STORY-XXX]" --label test-plan --state open
+        │     Close each, naming the PR that finished the story. Both kinds orphan the
+        │     same way; qa has no terminal gate of its own, so this closes both.
+        │   - Skip silently if no story link, no docs/stories/, or no plan issue is open
         │
         ├─► Step 6: Clean Up Local Branch
         │   - Switch to the repo's default branch and pull — derive it, don't
@@ -53,11 +61,12 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Run: git branch -d <branch-name>
         │
         └─► Step 7: Report
-            - Confirm merge to the user
-            - Show the merged PR URL
-            - If story has remaining open tasks, suggest: /dw-implement <next-issue>
-            - If story is complete, mention it
-            - Mention any follow-up issues if applicable
+            - Report per .claude/rules/agent-report.md; Trace carries the merged PR URL
+              and any plan issues closed
+            - Next: /dw-implement <next-issue> if the story has open tasks left,
+              otherwise say the story is complete
+            - A follow-up the merge deliberately leaves behind is Not done (a choice);
+              Unresolved is for what the merge left genuinely uncertain
 
 ---
 
@@ -71,13 +80,15 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
     $ gh pr checks 30
     $ gh pr merge 30 --merge --delete-branch
     $ gh issue edit 27 --remove-label "status:needs-review"
+    $ gh issue list --search "[STORY-003]" --label plan --state open   # last task → close it
+    $ gh issue close 28 --comment "Delivered — last task merged in PR #30."
     $ git checkout <default-branch> && git pull
     $ git branch -d issue-27-release-notes
 
 **Output:**
 
     PR #30 merged: https://github.com/owner/repo/pull/30
-    Issue #27 auto-closed.
+    Issue #27 auto-closed. Plan #28 closed — that was STORY-003's last task.
     Branch issue-27-release-notes deleted (local + remote).
 
 ---
@@ -88,4 +99,7 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
 - `--merge` preserves full commit history (use `--squash` only if the project convention requires it)
 - `--delete-branch` removes the remote branch; `git branch -d` removes the local one
 - If PR is not approved or CI fails, report the blocker instead of merging
+- A plan closes only on the story's LAST open task — it stays open while any remain
+- The close is hooked to this command, so a story finished another way (tasks closed
+  by hand, a PR merged in the UI) still leaves its plan open
 ```

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -119,8 +119,21 @@ This command produces the plan only. It does NOT create task issues — that is 
 
 **Output:**
 
-    Plan issue #28 created: https://github.com/owner/repo/issues/28
-    A human reviews + approves it; then /dw-tasks STORY-003 breaks it into tasks.
+    PASS — plan #28 written; the approach covers STORY-003.
+
+    Checked     the story's Success Looks Like; repo conventions; no existing plan
+    Not done    task issues — /dw-tasks opens those, after the gate
+    Unresolved  2 open questions, recorded on the issue
+    Trace       https://github.com/owner/repo/issues/28 · docs/stories/STORY-003.md
+    Next        a human reads and approves #28 on GitHub
+
+---
+
+## OUTPUT
+
+The plan issue. Reported per `.claude/rules/agent-report.md` — the verdict first, and a
+section with nothing to report says so. Trace carries the issue URL; Next is the human
+reading it on GitHub, never `/dw-tasks` — that comes after the gate, not from here.
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-implement.md
+++ b/.claude/commands/dev-workflow/dw-review-implement.md
@@ -66,9 +66,10 @@ Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
         │     comment the issue and route back to /dw-implement
         │
         └─► Step 6: Report
-            - Per finding: the exact file:line + the smallest fix
-            - A delivery verdict against the issue's "Done When"
-            - The issue link + suggested next step
+            - Report per .claude/rules/agent-report.md
+            - The verdict is the delivery state against the issue's "Done When";
+              every finding gives the exact file:line and the smallest fix
+            - Trace carries the issue link and the branch
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-story.md
+++ b/.claude/commands/dev-workflow/dw-review-story.md
@@ -54,8 +54,8 @@ hands it back to `/dw-story` if the need itself is unclear.
         │     wording), stop and route to /dw-story to re-capture it with the user
         │
         └─► Step 5: Report
-            - Print the verdict (PASS / REVISED / HAND BACK) and the findings
-            - Print the path to the story and the suggested next step
+            - Report per .claude/rules/agent-report.md
+            - Checked carries both checklists; Trace carries the story path
 
 ---
 
@@ -82,8 +82,12 @@ hands it back to `/dw-story` if the need itself is unclear.
 **Output:**
 
     PASS — STORY-001 is complete and stays a goal.
-    docs/stories/STORY-001.md
-    Next: /dw-tasks STORY-001 to open the issue where the "how" gets decided.
+
+    Checked     both checklists above — completeness, and goal-not-spec
+    Not done    none
+    Unresolved  none
+    Trace       docs/stories/STORY-001.md
+    Next        /dw-tasks STORY-001 — the issue is where the "how" gets decided
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -62,9 +62,10 @@ Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
         │     → back to /dw-tasks to re-decompose
         │
         └─► Step 6: Report
-            - Per issue: verdict + findings
-            - A coverage verdict against the story
-            - The story path + issue links + suggested next step
+            - Report per .claude/rules/agent-report.md
+            - The verdict covers the breakdown as a whole; Checked carries the
+              coverage of the story's "Success Looks Like" and the per-issue passes
+            - Trace carries the story path and the issue links
 
 ---
 
@@ -88,7 +89,12 @@ Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
 **Output:**
 
     PASS — the breakdown covers STORY-007 and each issue stays a goal.
-    Next: /dw-implement 21
+
+    Checked     every Success Looks Like item maps to an issue; each issue one job
+    Not done    none
+    Unresolved  none
+    Trace       docs/stories/STORY-007.md · #21 #22
+    Next        /dw-implement 21
 
 (Illustrative — a hypothetical clean breakdown. Real reviews often return REVISE.)
 

--- a/.claude/commands/dev-workflow/dw-story.md
+++ b/.claude/commands/dev-workflow/dw-story.md
@@ -80,5 +80,7 @@ Show the user the created story and suggest next steps:
 
 ## OUTPUT
 
-The path to the created story file.
+The story captured, and whether it is ready to be gated. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so. Trace carries the story file's path.
 ```

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -81,11 +81,10 @@ Fits in the dev-workflow:
         │     - Issues: #1, #2, #3
         │
         └─► Step 7: Report
-            - Show table of created issues:
-              | Issue | Title | Type | Priority |
-            - Suggest implementation order based on dependencies
-            - Suggest: /dw-review-tasks STORY-XXX to gate the breakdown, then
-              /dw-implement <N> to start on the first task
+            - Report per .claude/rules/agent-report.md; the created issues are a
+              table (| Issue | Title | Type | Priority |) plus the build order
+            - Trace carries the story path, the plan issue, and the issue links
+            - Next: /dw-review-tasks STORY-XXX to gate the breakdown
 
 ---
 
@@ -113,10 +112,18 @@ Fits in the dev-workflow:
 
 **Output:**
 
+    PASS — STORY-003 broken into 2 issues; together they cover the plan.
+
     | Issue | Title                              | Type        | Priority |
     |-------|------------------------------------|-------------|----------|
     | #15   | [STORY-003] Add input validation   | enhancement | high     |
     | #16   | [STORY-003] Add error formatting   | enhancement | medium   |
+
+    Checked     every Acceptance Criterion in plan #28 maps to an issue
+    Not done    none
+    Unresolved  none
+    Trace       docs/stories/STORY-003.md · plan #28 · #15 #16
+    Next        /dw-review-tasks STORY-003 to gate the breakdown
 
     Suggested order: #15 → #16
     Start: /dw-implement 15

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -44,6 +44,15 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The test docs written. Trace carries each doc's path. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
+
+
+---
+
 ## API Notes
 
 - Reuse keeps coverage converging instead of duplicating: skim the existing

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -44,6 +44,15 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The test-plan issue. Trace carries its URL; Next is the paired review. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
+
+
+---
+
 ## API Notes
 
 - A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -40,6 +40,16 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The decision from Step 3, printed — with the findings behind it. Trace carries each doc
+reviewed. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
+
+
+---
+
 ## API Notes
 
 - This reviews the *doc* (intent); `/qw-review-bind` reviews the doc↔script binding.

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -39,6 +39,16 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The decision from Step 3 — recorded as a comment on the test-plan issue, and printed for
+the reader. Trace carries the issue URL. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
+
+
+---
+
 ## API Notes
 
 - Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.

--- a/.claude/rules/agent-report.md
+++ b/.claude/rules/agent-report.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
+---
+
+# agent-report
+
+Every unit in this toolkit ends at a **human gate**. What that human reads to decide is
+the **report**. This states what a report owes its reader.
+
+The report is where the workflow's cost actually lands: producing is cheap, judging is
+not. A report that has to be re-read from the top makes the human the slowest part of a
+pipeline built entirely around their judgment.
+
+This file states the **goal**. The words a report uses — the verdicts, the section
+names, the marker for an empty section, what each medium allows — are **values**: see
+`project-profile.md` → Reports. A unit resolves them from there; it does not name its
+own.
+
+## What a report answers
+
+Seven questions, in this order. The reader should find each without hunting.
+
+```
+   1  What am I being asked to decide?   ──► the verdict, first, alone on a line
+   2  What is wrong, and where?          ──► the findings
+   3  What does this verdict cover?      ──► what was actually examined
+   4  What was left out on purpose?      ──► a CHOICE
+   5  What is still uncertain?           ──► a RISK
+   6  Where are the artifacts?           ──► the trace
+   7  What happens next?                 ──► exactly one step
+```
+
+## The rules that make it work
+
+**Lead with the decision.** Question 1 is answerable without reading the report. A
+verdict that arrives after a paragraph of narration has already cost the reader the
+thing the report exists to save.
+
+**4 and 5 are not the same question.** Something skipped on purpose is a *choice*;
+something unresolved is a *risk*. Collapsing them is the failure this contract exists to
+prevent — it is how a workaround and a concern end up reading alike.
+
+**Silence is not an answer.** A section with nothing to report says so. An absent
+section cannot be told apart from a question never asked, and a reader cannot tell
+whether an area was clean or simply never looked at.
+
+**Say what the verdict covers.** A pass is scoped to what was examined (3). Without it a
+reader assumes the scope, and assumes wrong in the direction of comfort.
+
+**Structure before prose.** A verdict is a line; findings are a table; a flow, a
+pipeline, or a shape is a diagram; options compared are a table with a row each. Prose is
+for an argument that has to be *followed* — and then it is short. Rebuilding structure
+out of paragraphs in your head *is* the review cost.
+
+**Be legible where it lands.** A report read in a chat session must work as plain text.
+One that lands in a document or an issue may use whatever renders there. The formats each
+medium allows are a value — see `project-profile.md` → Reports. Do not bake one medium's
+markup into a unit; a project that reports elsewhere would have to edit it.
+
+## Right-size it
+
+Not every answer is a report. A one-line reply, a confirmation, a single fact a reader
+asked for directly — these are the answer, and wrapping them in seven sections is ritual,
+not rigor. The contract binds a unit's **gate output**: what a command or skill prints
+when it finishes and hands a decision to a human. Below that, use judgment.
+
+## Why this is a rule, not a template
+
+A frozen block of headings is a *procedure* — no profile value can override it, so a
+project that reports differently would be forced to edit a shipped unit and its repo
+would then read as drifted when it was only working around us (see
+`project-profile.md` → what belongs here vs. not). State the questions; let the profile
+name the words.

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -38,6 +38,8 @@ The plan is a **GitHub issue**, one per story, labelled `plan`, titled `[STORY-X
 Its body holds the researched approach, acceptance criteria, and the commands/files it
 expects to touch. It is the **parent** of the task issues (`dw-tasks` links each task back
 with "Part of #<plan>"), and the durable checkpoint that survives a lost session.
+Nothing auto-closes it — no PR targets a plan — so `dw-merge` closes it when the
+story's last task lands.
 
 Its review is a **human gate**: a person reads, comments, and approves the issue on GitHub
 before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirrors the
@@ -69,3 +71,11 @@ review passes plus a plan issue on a typo is ritual, not rigor.
 - **GitHub issues** already hold the work; the plan is one too (the parent), so the
   approach, its review, and its history live where the tasks do — no separate plan store.
 - **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.
+
+## Project-specific values
+
+Story paths, the `STORY-XXX` id scheme, label names + colours, the `[STORY-XXX]` /
+`Part of #<plan>` linking patterns, the `issue-<N>-<slug>` branch name, and the merge
+strategy are **not** owned by the `dw-*` commands — they resolve from
+`.claude/rules/project-profile.md`. The values a command shows are the defaults; change
+them in the profile, not the command.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -86,6 +86,21 @@ project's choice.
   whatever this declares; they do not assume hashing.
 - default status: `green`
 
+## Reports
+
+The words a gate report uses. The contract itself — the questions a report answers and
+why — is `.claude/rules/agent-report.md`; a unit resolves the wording from here.
+
+- verdict vocabulary: `PASS` · `REVISE` · `HAND BACK`
+- extra verdict (artifact review only): `CUT` — the artifact duplicates another or does
+  nothing useful; propose removal
+- section names: `Verdict` · `Findings` · `Checked` · `Not done` · `Unresolved` ·
+  `Trace` · `Next`
+- empty-section marker: `none` (a section with nothing to report says so; it is not dropped)
+- finding columns: `# · severity · location · what's wrong · smallest fix`
+- formats by medium: chat session → plain text, tables, ASCII diagrams · document or
+  issue → whatever renders there.
+
 ## Review semantics
 
 - canonical format (source of truth): `markdown`

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -29,7 +29,9 @@ those docs to a runner and running them is the project's own layer.
 
 `qw-plan`'s scenarios persist as a **GitHub issue**, titled `[STORY-XXX] Test Plan`, labelled
 `test-plan` (distinct from dev's `[STORY-XXX] Plan`). `qw-review-plan` reviews it; `qw-cases`
-reads it and records the issue number in each `TS-*.md` `plan:` field.
+reads it and records the issue number in each `TS-*.md` `plan:` field. Closing it falls to
+`dw-merge`: this pipeline has no terminal gate of its own, and the docs reach the default
+branch through the dev-workflow like any other change.
 
 ## Producer → review pairing
 

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -2,11 +2,11 @@
 name: reviewing-artifacts
 description: |
   Reviews any workflow artifact — the commands, skills, and project docs that are the
-  tooling (READMEs, stories, CLAUDE.md, and the like) — against five goal questions:
+  tooling (READMEs, stories, CLAUDE.md, and the like) — against a few goal questions:
   one clear job, complete, a goal not a frozen spec, fits the project, right for its
-  reader. Also runs a producer→review pairing coverage pass that flags any producer
-  shipped without a paired review. It judges whether an artifact does its job; how a
-  human-read doc (the README, docs/ prose) looks and reads goes to the typography +
+  reader, and (for producers) paired with a review. Its pairing question flags any
+  producer shipped without a paired review. It judges whether an artifact does its job;
+  how a human-read doc (the README, docs/ prose) looks and reads goes to the typography +
   phrasing review. Floor, not ceiling.
 ---
 
@@ -26,7 +26,7 @@ fine-grained **look and words** of a human-read doc — the README, the prose in
 go to `reviewing-typography` (the look) + `reviewing-phrasing` (the words); this skill
 judges whether the artifact does its job (Q5 still asks whether a doc serves its reader).
 
-## The five questions
+## The questions
 
 Ask these of any artifact. The artifact's type shifts which ones bite hardest.
 
@@ -35,68 +35,64 @@ Ask these of any artifact. The artifact's type shifts which ones bite hardest.
    another artifact (could it merge, or go away?).
 2. **Complete.** Does it deliver that job end to end — no missing steps, placeholder
    text, or dead instructions that produce nothing? A reader/agent should be able to act.
+   **Says what it reports?** A unit that ends at a human gate is not complete until it
+   says what it hands that human. Flag one that finishes silently, one that defines a
+   decision it never prints, one that restates the sections of
+   `.claude/rules/agent-report.md` inline instead of resolving to it, and one that
+   invents verdict words outside `project-profile.md` → Reports. A unit deliberately
+   exempt (its output is not a gate) says so — silence is not an exemption.
 3. **Goal, not frozen spec — and no hardcoding.** Does it state intent and leave room
    where room belongs, instead of freezing a "how" that will drift? Flag stale paths or
    filenames, magic values that should be derived, rigid step-by-step where a principle
    would do, and references to tools or layouts that have moved.
-4. **Fits the project.** Does it match the conventions this project actually uses —
-   markdown as the source of truth, plus the tools and layout the repo relies on now —
-   rather than a stack it has moved past? Flag coupling to a tool or layout the project
-   has genuinely retired or relocated; an integration the project still uses, or a
-   deliberate adapter, is not a violation. Cross-references resolve to files that exist.
+   **Bakes in a mechanism?** Hardest bite of this question. A value `project-profile.md`
+   owns may appear inline as a default (see its "Two wiring styles"), but a *procedure* —
+   how drift is detected, how files are laid out — cannot be overridden by any value, so a
+   project that does it differently must edit the shipped unit. Flag every "compute X this
+   way" or "write it at this path" that the profile cannot redirect; the fix is to state
+   the goal and let the profile or the project's layer name the mechanism.
+4. **Fits the project.** Does it match the project's conventions as declared in
+   `project-profile.md` — the **canonical format** (its source of truth) and the **live
+   integrations** listed there — rather than a stack it has moved past? Flag coupling to
+   a tool the profile does not list as live (one genuinely retired or relocated); an
+   integration the profile lists as live, or a deliberate adapter, is not a violation.
+   Cross-references resolve to files that exist. Skills must be flat under
+   `.claude/skills/<name>/` — a foldered skill is undiscoverable; a unit that needs
+   folders to group is a command, not a skill.
 5. **Right for its reader.** Agent-facing (commands, skills): unambiguous instructions
    the agent can follow. Human-facing (README, story): reads like a person wrote it for
    a person — clear, concrete, scannable.
+6. **Paired (producers only).** If this artifact *produces or changes* a **deliverable**
+   (as `project-profile.md` → Review semantics defines one), does a review cover its
+   output? Every producer needs a
+   paired review — a standing rule (the `## Producer → review pairing` tables in
+   `.claude/rules/*.md`). A producer with no
+   review is a gap to flag, not an exception; one that yields no outward deliverable
+   (internal scaffolding, an authoring input) is exempt, not a gap. This skill is the
+   enforcement arm. Bites only on producers.
 
 Where each type leans:
 
 | Artifact | Leans on |
 |----------|----------|
-| Command / skill | Q3 (no hardcoding), Q5 (agent can follow it) |
+| Command / skill | Q3 (no hardcoding), Q5 (agent can follow it), Q6 if it produces |
 | README / user doc | Q5 (reads for a human), Q1 (one clear job) |
 | Story | Q3 (goal, not spec) — this is what `dw-review-story` checks at the story stage |
 | CLAUDE.md | Q2/Q4 (matches the repo as it actually is — no orphaned references) |
-
-## Producer→review pairing (coverage pass)
-
-A standing rule (CLAUDE.md → "Review pairing"): every **producer** has a **paired
-review**. When the scope is the whole workflow — or any change that adds/edits a
-producer — run this coverage pass on top of the five questions.
-
-It is a **method, not a fixed list** — derive the producers and reviews from whatever
-units exist now; don't hardcode an inventory that will drift.
-
-1. **List the producers.** A producer is any unit that *creates, syncs, publishes, or
-   drafts a deliverable* — by name (`create-`, `sync-`, `publish-`, `draft-`, `init-`)
-   or by what it does (a producing gerund skill — a name like `planning-…`, `drafting-…`).
-2. **List the reviews.** Any unit whose job is to *check a result* — `*-review`,
-   `*-verify`, the `reviewing-*` skills, a typography/format audit.
-3. **Match each producer to the review that covers its output.** A pairing is real only
-   if some review actually inspects what that producer makes.
-4. **Flag the gaps.** Name every producer with **no** review covering its output — that
-   is a pairing violation. Note the missing review and where it would live.
-5. **Mark the exempt.** A producer that yields no outward deliverable to review —
-   internal scaffolding, a visual folded into an already-reviewed doc, an authoring
-   input, tooling logs — is **exempt**, not a gap. List it as exempt and say why.
-
-Report pairings as a small table and list the unpaired producers as findings:
-
-```
-Producer → Review
-<producer>           → <review>            ✓
-<producer>           → (none)              ✗  needs: <proposed review + home>
-<producer>           → (exempt)            —  <why it has no outward deliverable>
-```
 
 ## Steps
 
 1. **Scope.** A single file, a folder, or "the files I just changed." Find where the
    artifacts actually live in *this* repo — don't assume a fixed layout.
 2. **Read** the target(s).
-3. **Ask the five questions** of each. Checklists are a floor — note anything else that
+3. **Ask the questions** of each. Checklists are a floor — note anything else that
    weakens the artifact.
-4. **Pairing coverage pass** (when reviewing the workflow or a producer change) — run
-   the section above and report unpaired producers.
+4. **Frontmatter hygiene (commands/skills).** Flag and recommend removing:
+   - `disable-model-invocation: true` — a unit's user-only nature comes from living in
+     `.claude/commands/`, not a flag. On a skill the flag just makes it dormant (Claude
+     can't auto-invoke it); a genuinely user-only entry point belongs in `.claude/commands/`.
+   - a `tools:` / `allowed-tools:` allow-list — legacy baggage that pins the unit to
+     specific tools/servers. Drop it so the unit inherits the session's tools.
 5. **Report** (below).
 6. **Fix (if asked).** Smallest blast radius first: remove leaked hardcoding, fill gaps,
    tighten wording. Structural changes — merging, splitting, or removing an artifact —
@@ -105,16 +101,14 @@ Producer → Review
 
 ## Report
 
-Per artifact, a short verdict and the specific findings — no numeric score.
-
-```
-<artifact path> — PASS | REVISE | CUT
-
-- [Q#] <finding, with line reference> → <smallest fix>
-```
+Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
+and a section with nothing to report saying so. The verdict vocabulary is
+`project-profile.md` → Reports. No numeric score. This review also uses
+**CUT**, declared there as the artifact review's own. In this review they mean:
 
 - **PASS** — does its job, fits the project, nothing leaked.
 - **REVISE** — specific, fixable findings (gaps, hardcoding, drift, readability).
 - **CUT** — duplicates another artifact or does nothing useful; propose removal (with approval).
 
-End with the path(s) reviewed and the suggested next step.
+Each finding names the question it came from (`[Q#]`), the line, and the smallest fix.
+Trace carries the path(s) reviewed.

--- a/.claude/skills/reviewing-phrasing/SKILL.md
+++ b/.claude/skills/reviewing-phrasing/SKILL.md
@@ -33,7 +33,8 @@ These are **lenses, not steps** — they interact, and which bites hardest depen
 doc in hand. Weigh them together, and flag anything that weakens the writing even if it
 isn't named here.
 
-- **Reader.** Who actually reads this, and what do they already know? The phrasing meets
+- **Reader.** Who actually reads this, and what do they already know? Default to the
+  project's audience in `project-profile.md` when the doc doesn't say. The phrasing meets
   them there — no unexplained jargon for a newcomer, no over-explaining to a peer.
 - **Lead with the point.** The reader should hit what matters first, not after a runway of
   setup. Context that arrives before the point reads as not knowing the priority — or as
@@ -57,8 +58,8 @@ redundant, buried, or missing a hook. That spot is the finding.
 
 ## Steps
 
-1. **Scope.** Which doc(s), and who the reader is. If the reader isn't clear from the doc
-   or its context, ask before reviewing.
+1. **Scope.** Which doc(s), and who the reader is — default to the audience in
+   `project-profile.md` when the doc and its context don't say. If still unclear, ask.
 2. **Read it as that reader would** — once, straight through, for whether it lands.
 3. **Weigh the lenses** above by judgment; note anything else that hurts the phrasing.
 4. **Report** (below).
@@ -68,15 +69,12 @@ redundant, buried, or missing a hook. That spot is the finding.
 
 ## Report
 
-Per doc, a short verdict and specific findings — no numeric score.
-
-```
-<doc> — PASS | REVISE
-
-- <what hurts the phrasing, quoted> → <smallest fix>
-```
+Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
+and a section with nothing to report saying so. The verdict vocabulary is
+`project-profile.md` → Reports. No numeric score. In this review they mean:
 
 - **PASS** — fits its reader, leads with the point, says the right thing.
 - **REVISE** — specific, fixable findings (buried point, padding, wrong register, missing fact).
 
-End with what was reviewed and the suggested next step.
+Each finding quotes what hurts the phrasing and gives the smallest fix. Trace carries
+the doc(s) reviewed.

--- a/.claude/skills/reviewing-typography/SKILL.md
+++ b/.claude/skills/reviewing-typography/SKILL.md
@@ -2,7 +2,7 @@
 name: reviewing-typography
 description: |
   Reviews how a human-read document looks — the README, the prose and tables in docs/, or
-  any markdown written for a person — for visual hierarchy, Gestalt proximity, restraint,
+  any human-read document — for visual hierarchy, Gestalt proximity, restraint,
   and walls of text, so a reader can find the point at a glance. The look half of the
   human-read doc review (reviewing-phrasing handles the words). Use when such a doc is
   written or restructured. Judgment over checklist; floor, not ceiling.
@@ -14,15 +14,17 @@ One reviewer for how a human-read document **looks**. Its partner `reviewing-phr
 judges how a doc *reads*; this judges how it *scans*. Together they are the human-read doc
 review.
 
-This skill's job is **human-read** markdown — the README, the prose, tables, and lists in
+This skill's job is **human-read** documents in the project's canonical format
+(`project-profile.md` — markdown by default) — the README, the prose, tables, and lists in
 `docs/`, and any doc aimed at a person. The **agent-read** workflow tooling — commands,
 skills, rules, CLAUDE.md, stories — is **not** this skill's job; whether those do their job
 goes to `reviewing-artifacts`.
 
-A markdown doc has no fonts to set, but it has the same levers UI typography uses, and the
-same principles decide whether it works: **heading levels** are size/weight, **blank lines
-and grouping** are spacing, **bold/italic** are weight, and **paragraph and list length**
-decide whether the page reads as structure or as soup.
+The principles are medium-agnostic; each format expresses them through its own levers. In
+markdown (the default) a doc has no fonts to set, but it has the same levers UI typography
+uses: **heading levels** are size/weight, **blank lines and grouping** are spacing,
+**bold/italic** are weight, and **paragraph and list length** decide whether the page reads
+as structure or as soup.
 
 ## Why this is a judgment skill, not a checklist
 
@@ -79,15 +81,12 @@ and watch where their eye snags or stalls; that spot is the finding.
 
 ## Report
 
-Per doc, a short verdict and specific findings — no numeric score.
-
-```
-<doc> — PASS | REVISE
-
-- <what hurts the look, with the location> → <smallest fix>
-```
+Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
+and a section with nothing to report saying so. The verdict vocabulary is
+`project-profile.md` → Reports. No numeric score. In this review they mean:
 
 - **PASS** — the eye finds the point; hierarchy and grouping hold.
 - **REVISE** — specific, fixable findings (no hierarchy, fused groups, bold inflation, wall of text).
 
-End with what was reviewed and the suggested next step.
+Each finding names the location of what hurts the look and gives the smallest fix. Trace
+carries the doc(s) reviewed.


### PR DESCRIPTION
## Summary

- **Adds `.claude/rules/agent-report.md`** — upstream STORY-007's report contract: what a gate report owes the human reading it.
- **`project-profile.md` gains `## Reports`** — verdict vocabulary, section names, the `none` marker, finding columns, formats by medium. Inserted; every value this repo had set is untouched.
- **Units tracking upstream were copied.** This repo's own `qw-*`/`doc-*` layer was **not** overwritten — each customized unit keeps every line of its local content and gains only the report section the contract requires, written against what *that* command actually produces.
- **`dw-merge` closes the story's plan issues** (upstream STORY-008) — a plan is nobody's `Closes` target, so nothing ever closed one.

Closes #476

## Test plan

- [ ] Units tracking upstream diff clean against it
- [ ] Every customized unit keeps its local content — only an OUTPUT section added
- [ ] `## Reports` declares nothing for a group this repo does not install, and its cross-references resolve

Generated with [Claude Code](https://claude.com/claude-code)